### PR TITLE
Mildly Reworked Infiltrator.

### DIFF
--- a/lua/sc/loc/loc.lua
+++ b/lua/sc/loc/loc.lua
@@ -887,9 +887,9 @@ Hooks:Add("LocalizationManagerPostInit", "SC_Localization_Perk_Decks", function(
 		--Infiltrator--
 		["menu_deck8_1_desc_sc"] = "When you are within ##18## meters of an enemy, you receive ##10%## less damage from enemies.",
 		["menu_deck8_3_desc_sc"] = "When you are within ##18## meters of an enemy, you receive an additional ##5%## less damage from enemies.",
-		["menu_deck8_5_desc_sc"] = "When you are within ##18## meters of an enemy, you receive an additional ##5%## less damage from enemies.\n\nEach successful melee hit grants and additional ##10%## melee damage boost for ##7## seconds and can stack up to ##4## times.",
-		["menu_deck8_7_desc_sc"] = "When you are surrounded by three enemies or more within ##18 meters##, you receive an additional ##5%## less damage from enemies.\n\nEach successful melee hit grants and additional ##10%## melee damage boost for ##7## seconds and can stack up to ##4## times.",
-		["menu_deck8_9_desc_sc"] = "Striking an enemy with your melee weapon regenerates ##8%## of your health. This cannot occur more than once every ##10## seconds.\n\nDeck Completion Bonus: Your chance of getting a higher quality item during a PAYDAY is increased by ##10%.##",
+		["menu_deck8_5_desc_sc"] = "When you are within ##18## meters of an enemy, you receive an additional ##5%## less damage from enemies.\n\nEach successful melee hit grants an additional ##8%## melee damage boost for ##10## seconds and can stack up to ##5## times.",
+		["menu_deck8_7_desc_sc"] = "When you are surrounded by three enemies or more within ##18 meters##, you receive an additional ##5%## less damage from enemies.\n\nEach successful melee hit grants an additional ##8%## melee damage boost for ##10## seconds and can stack up to ##5## times.",
+		["menu_deck8_9_desc_sc"] = "Each successful melee hit heals ##1## life point every ##1.25## seconds for ##10## seconds, this effect can stack up to ##5## times.\n\nDeck Completion Bonus: Your chance of getting a higher quality item during a PAYDAY is increased by ##10%.##",
 
 		--Sociopath--
 		["menu_deck9_1_sc"] = "No Talk",

--- a/lua/sc/managers/playermanager.lua
+++ b/lua/sc/managers/playermanager.lua
@@ -177,7 +177,11 @@ if SC and SC._data.sc_ai_toggle or restoration and restoration.Options:GetValue(
 			return
 		end
 
+		--Load alternate heal over time tweakdata if player is using Infiltrator.
 		local data = tweak_data.upgrades.damage_to_hot_data
+		if self:has_category_upgrade("melee", "stacking_hit_damage_multiplier") then
+			data = tweak_data.upgrades.melee_to_hot_data
+		end
 
 		if not data then
 			return

--- a/lua/sc/tweak_data/skilltreetweakdata.lua
+++ b/lua/sc/tweak_data/skilltreetweakdata.lua
@@ -2505,7 +2505,7 @@ function SkillTreeTweakData:init(tweak_data)
 			deck8,
 			{
 				upgrades = {
-					"player_melee_life_leech",
+					"player_damage_to_hot_1",
 					"player_passive_loot_drop_multiplier"
 				},
 				cost = 4000,

--- a/lua/sc/tweak_data/upgradestweakdata.lua
+++ b/lua/sc/tweak_data/upgradestweakdata.lua
@@ -902,6 +902,28 @@ function UpgradesTweakData:_init_pd2_values()
 	self.values.temporary.melee_life_leech = {
 		{0.08, 08}
 	}
+	
+	self.melee_to_hot_data = {
+		armors_allowed = {"level_1", "level_2", "level_3", "level_4", "level_5", "level_6", "level_7"},
+		works_with_armor_kit = true,
+		tick_time = 1.25,
+		total_ticks = 8,
+		max_stacks = 5,
+		stacking_cooldown = 0.0,
+		add_stack_sources = {
+			bullet = false,
+			explosion = false,
+			melee = true,
+			taser_tased = false,
+			poison = false,
+			fire = false,
+			projectile = false,
+			swat_van = false,
+			sentry_gun = false,
+			civilian = false
+		}
+	}
+
 	self.values.team.armor.multiplier = {1.05}
 	self.values.team.health.passive_multiplier = {1.05}
 	self.hostage_max_num = {
@@ -936,11 +958,11 @@ function UpgradesTweakData:_init_pd2_values()
 		{0.85, 7},
 		{0.8, 7}
 	}
-	self.max_melee_weapon_dmg_mul_stacks = 4
-	self.values.melee.stacking_hit_expire_t = {7}
+	self.max_melee_weapon_dmg_mul_stacks = 5
+	self.values.melee.stacking_hit_expire_t = {10}
 	self.values.melee.stacking_hit_damage_multiplier = {
-		0.1,
-		0.2
+		0.08,
+		0.16
 	}
 	self.values.dmg_dampener_outnumbered_strong = {
 		{0.95, 7}

--- a/lua/sc/units/player/playerdamage.lua
+++ b/lua/sc/units/player/playerdamage.lua
@@ -34,7 +34,13 @@ if SC and SC._data.sc_ai_toggle or restoration and restoration.Options:GetValue(
 
 		managers.sequence:add_inflict_updator_body("fire", self._unit:key(), self._inflict_damage_body:key(), self._inflict_damage_body:extension().damage)
 
-		self._doh_data = tweak_data.upgrades.damage_to_hot_data or {}
+		--Load alternate heal over time tweakdata if player is using Infiltrator.
+		if player_manager:has_category_upgrade("melee", "stacking_hit_damage_multiplier") then
+			self._doh_data = tweak_data.upgrades.melee_to_hot_data or {}
+		else 
+			self._doh_data = tweak_data.upgrades.damage_to_hot_data or {}
+		end
+
 		self._damage_to_hot_stack = {}
 		self._armor_stored_health = 0
 		self._can_take_dmg_timer = 0


### PR DESCRIPTION
Adjusted melee bonus to last 10 seconds, stack up to 5 times, but only
give an 16% bonus per stack.

Adjusted health regen to be a stacking heal over time to incentivize
maintaining stacks and making heavy usage of melee.