### PR TITLE
DP28 readded, BAR change, and fixes/tweaks

### DIFF
--- a/lua/sc/loc/loc.lua
+++ b/lua/sc/loc/loc.lua
@@ -206,6 +206,7 @@ Hooks:Add("LocalizationManagerPostInit", "SC_Localization_Weapons", function(loc
 		["bm_wp_wpn_fps_ass_galil_m_drum"] = "75 Round Drum Magazine",				
 		["bm_wp_wpn_fps_smg_calico_body_carbine_desc"] = "Custom medium pistol round conversion. Min and Max pickup rate: 0.8x", 
 		["bm_wp_wpn_fps_smg_calico_body_full_desc"] = "Custom heavy pistol round conversion. Min and Max pickup rate: 0.64x",
+		["bm_wp_wpn_fps_lmg_dp28_tripod_top_desc"] = "Tripod with additional ammo mounted to the side.\nThe Tripod is carried on the back while not in use.\nHas a movement speed penalty of 20%",
 		--String override for the stungun--
 		["bm_melee_taser_info"] = "Device that electrocutes and interrupts targets on touch when fully charged.",
 

--- a/lua/sc/tweak_data/weaponfactorytweakdata.lua
+++ b/lua/sc/tweak_data/weaponfactorytweakdata.lua
@@ -46834,6 +46834,11 @@ self.wpn_fps_pis_xs_pm.override = {	--Im not formatting this man....
 			table.list_append(self.wpn_fps_lmg_dp28.uses_parts, {
 				"wpn_fps_upg_i_faster_rof"
 			})
+			self.parts.wpn_fps_lmg_dp28_barrel_dpm36.pcs = nil --whole lot of mods removed till resmod manages to work well with weaponlib
+			self.parts.wpn_fps_lmg_dp28_m_dt.pcs = nil
+			self.parts.wpn_fps_lmg_dp28_m_dpm36.pcs = nil
+			self.parts.wpn_fps_lmg_dp28_bayonet_svt.pcs = nil
+			self.parts.wpn_fps_lmg_dp28_carry_dpm36_1.pcs = nil
 			self.parts.wpn_fps_lmg_dp28_bipod.stats = {
 					value = 2, 
 					zoom = 1, 
@@ -46852,21 +46857,26 @@ self.wpn_fps_pis_xs_pm.override = {	--Im not formatting this man....
 				ammo_pickup_max_mul = 1.2,
 				movement_speed = 0.8
 			}
-			self.parts.wpn_fps_lmg_dp28_tripod_top.forbids = {"wpn_fps_upg_ammo_half_that", "wpn_fps_lmg_dp28_barrel_dpm36"}				
+			self.parts.wpn_fps_lmg_dp28_tripod_top.forbids = {"wpn_fps_upg_ammo_half_that"}				
 			self.parts.wpn_fps_lmg_dp28_barrel_lord.stats = {
 					recoil = 1,
 					spread = -1,										
 					concealment = 1
-				}				
-			self.parts.wpn_fps_lmg_dp28_barrel_dpm36.stats = {
+				}
+			self.parts.wpn_fps_lmg_dp28_barrel_dt.stats = {
+					recoil = -1,
+					spread = 1,					
+					concealment = -2
+				}
+			--[[self.parts.wpn_fps_lmg_dp28_barrel_dpm36.stats = {
 					recoil = -1,
 					spread = 1,										
 					concealment = 2
 				}
-			self.parts.wpn_fps_lmg_dp28_barrel_dpm36.forbids = {"wpn_fps_upg_ammo_half_that", "wpn_fps_lmg_dp28_m_dpm35", "wpn_fps_lmg_dp28_tripod_top"}
+			self.parts.wpn_fps_lmg_dp28_barrel_dpm36.forbids = {"wpn_fps_upg_ammo_half_that", "wpn_fps_lmg_dp28_m_dpm35", "wpn_fps_lmg_dp28_tripod_top"}]]
 			self.parts.wpn_fps_lmg_dp28_g_dt.stats = {
 					value = 1,
-					concealment = 1
+					spread = 1
 				}
 			self.parts.wpn_fps_lmg_dp28_g_dpm.stats = {
 					value = 1,
@@ -46881,21 +46891,12 @@ self.wpn_fps_pis_xs_pm.override = {	--Im not formatting this man....
 					value = 1,
 					spread = 2,																				
 					concealment = -1
-				}					
-			self.parts.wpn_fps_lmg_dp28_g_dpm.stats = {
-					value = 1,
-					spread = 1
-				}												
-			self.parts.wpn_fps_lmg_dp28_barrel_dt.stats = {
-					recoil = -1,
-					spread = 1,					
-					concealment = -2
-				}
+				}																
 			self.parts.wpn_fps_lmg_dp28_m_dpm35.stats = {
 					extra_ammo = 153,
 					concealment = -5
 				}		
-			self.parts.wpn_fps_lmg_dp28_m_dpm36.stats = {
+			--[[self.parts.wpn_fps_lmg_dp28_m_dpm36.stats = {
 					extra_ammo = -17,
 					recoil = -1,
 					concealment = 1,					
@@ -46906,17 +46907,9 @@ self.wpn_fps_pis_xs_pm.override = {	--Im not formatting this man....
 					recoil = -1,
 					spread = -1,					
 					concealment = -3
-				}		
-			self.parts.wpn_fps_lmg_dp28_g_dpm.stats = {
-					value = 1,
-					recoil = 1
-				}	
+				}		]]
 			self.parts.wpn_fps_lmg_dp28_so_lord.stats = nil
-			self.parts.wpn_fps_lmg_dp28_so_pr.stats = nil
-			self.parts.wpn_fps_lmg_dp28_g_dt.stats = {
-					value = 1,
-					spread = 1
-				}											
+			self.parts.wpn_fps_lmg_dp28_so_pr.stats = nil											
 			self.wpn_fps_lmg_dp28.override = {
 				wpn_fps_upg_ammo_half_that = {
 				stats = {
@@ -46924,7 +46917,8 @@ self.wpn_fps_pis_xs_pm.override = {	--Im not formatting this man....
 					total_ammo_mod = 20,
 					concealment = -3
 				},
-				custom_stats = {ammo_pickup_min_mul = 1.2, ammo_pickup_max_mul = 1.2, movement_speed = 0.8},	
+				custom_stats = {ammo_pickup_min_mul = 1.2, ammo_pickup_max_mul = 1.2, movement_speed = 0.8},
+				forbids = {"wpn_fps_lmg_dp28_tripod_top"}
 			}
 		}				
 		end

--- a/lua/sc/tweak_data/weaponfactorytweakdata.lua
+++ b/lua/sc/tweak_data/weaponfactorytweakdata.lua
@@ -45393,44 +45393,43 @@ self.wpn_fps_pis_xs_pm.override = {	--Im not formatting this man....
 				"wpn_fps_upg_i_autofire"
 			})		
 			self.parts.wpn_fps_ass_bar_m_extended.stats = {
-					value = 0,
-					reload = -3,
-					extra_ammo = 20,
-					concealment = -2
-				}				
+				value = 0,
+				reload = -3,
+				extra_ammo = 20,
+				concealment = -2
+			}				
 			self.parts.wpn_fps_ass_bar_b_para.stats = {
-					value = 1,
-					concealment = 2,
-					recoil = -1,
-					spread = -1										
-				}				
+				value = 1,
+				concealment = 2,
+				recoil = -1,
+				spread = -1										
+			}				
 			self.parts.wpn_fps_ass_bar_carryhandle.stats = {
-					value = 1,
-					concealment = -1,
-					recoil = 1
-				}								
+				value = 1,
+				concealment = -1,
+				recoil = 1
+			}
+			self.parts.wpn_fps_ass_bar_bipod.stats = {
+				value = 2,
+				recoil = 2,
+				concealment = -5
+			}	
 			self.parts.wpn_fps_ass_bar_fg_sleeve.stats = {
-					value = 1,
-					concealment = 1,
-					recoil = -1,
-					spread = 1										
-				}	
+				value = 1,
+				concealment = 1,
+				recoil = -1,
+				spread = 1										
+			}	
 			self.parts.wpn_fps_ass_bar_ns_cutts.stats = {
-					value = 1,
-					spread_moving = 1,
-					spread = 1,
-					concealment = -2
-				}								
-			self.parts.wpn_fps_ass_bar_ns_cutts.stats = {
-					value = 1,
-					spread_moving = 1,
-					spread = 1,
-					concealment = -2
-				}																
+				value = 1,
+				spread_moving = 1,
+				spread = 1,
+				concealment = -2
+			}															
 			self.parts.wpn_fps_ass_bar_g_monitor.stats = {
-					value = 1,
-					spread = 1
-				}
+				value = 1,
+				spread = 1
+			}
 			self.wpn_fps_ass_bar.override = {
 				wpn_fps_snp_msr_ns_suppressor = {
 					stats = {
@@ -45449,10 +45448,10 @@ self.wpn_fps_pis_xs_pm.override = {	--Im not formatting this man....
 				wpn_fps_upg_ammo_half_that = {
 					stats = {
 						value = 1,
-						total_ammo_mod = -25,
+						total_ammo_mod = 25,
 						recoil = 0
 					},
-					custom_stats = {ammo_pickup_min_mul = 0.75, ammo_pickup_max_mul = 0.75, movement_speed = 1.25},	
+					custom_stats = {ammo_pickup_min_mul = 1.25, ammo_pickup_max_mul = 1.25, movement_speed = .80},	
 				}
 			}					
 			end	
@@ -46523,6 +46522,13 @@ self.wpn_fps_pis_xs_pm.override = {	--Im not formatting this man....
 				spread = 1,
 				concealment = -2
 			}
+		self.parts.wpn_fps_upg_ultimax_stanag.stats = {
+			spread = 1,
+			recoil = -2,
+			concealment = 4,
+			extra_ammo = -70,
+			reload = 4
+		}
 		table.list_append(self.wpn_fps_lmg_ultimax.uses_parts, {
 			"wpn_fps_upg_o_specter"
 			})
@@ -46578,7 +46584,8 @@ self.wpn_fps_pis_xs_pm.override = {	--Im not formatting this man....
 			wpn_fps_upg_ammo_half_that = {
 				stats = {
 					value = 1,
-					total_ammo_mod = 20
+					total_ammo_mod = 20,
+					concealment = -3
 				},
 				custom_stats = {ammo_pickup_min_mul = 1.2, ammo_pickup_max_mul = 1.2, movement_speed = 0.8},	
 			}
@@ -46815,6 +46822,111 @@ self.wpn_fps_pis_xs_pm.override = {	--Im not formatting this man....
 				recoil = 1,
 				reload = 2
 			}
+		end
+
+		if self.wpn_fps_lmg_dp28 then --Killerwolf's DP-28 
+			table.list_append(self.wpn_fps_lmg_dp28.uses_parts, {
+				"wpn_fps_upg_i_slower_rof"
+			})
+			table.list_append(self.wpn_fps_lmg_dp28.uses_parts, {
+				"wpn_fps_upg_ammo_half_that"
+			})			
+			table.list_append(self.wpn_fps_lmg_dp28.uses_parts, {
+				"wpn_fps_upg_i_faster_rof"
+			})
+			self.parts.wpn_fps_lmg_dp28_bipod.stats = {
+					value = 2, 
+					zoom = 1, 
+					concealment = -5
+				}
+			self.parts.wpn_fps_lmg_dp28_tripod_top.stats = {
+					value = 3, 
+					zoom = 1, 
+					recoil = -1,
+					spread = 2,
+					concealment = -8,
+					total_ammo_mod = 20
+				}
+			self.parts.wpn_fps_lmg_dp28_tripod_top.custom_stats = {
+				ammo_pickup_min_mul = 1.2,
+				ammo_pickup_max_mul = 1.2,
+				movement_speed = 0.8
+			}
+			self.parts.wpn_fps_lmg_dp28_tripod_top.forbids = {"wpn_fps_upg_ammo_half_that", "wpn_fps_lmg_dp28_barrel_dpm36"}				
+			self.parts.wpn_fps_lmg_dp28_barrel_lord.stats = {
+					recoil = 1,
+					spread = -1,										
+					concealment = 1
+				}				
+			self.parts.wpn_fps_lmg_dp28_barrel_dpm36.stats = {
+					recoil = -1,
+					spread = 1,										
+					concealment = 2
+				}
+			self.parts.wpn_fps_lmg_dp28_barrel_dpm36.forbids = {"wpn_fps_upg_ammo_half_that", "wpn_fps_lmg_dp28_m_dpm35", "wpn_fps_lmg_dp28_tripod_top"}
+			self.parts.wpn_fps_lmg_dp28_g_dt.stats = {
+					value = 1,
+					concealment = 1
+				}
+			self.parts.wpn_fps_lmg_dp28_g_dpm.stats = {
+					value = 1,
+					recoil = 1
+				}					
+			self.parts.wpn_fps_lmg_dp28_stock_dt.stats = {
+					value = 1,
+					spread = -1,															
+					concealment = 2
+				}	
+			self.parts.wpn_fps_lmg_dp28_stock_dpm.stats = {
+					value = 1,
+					spread = 2,																				
+					concealment = -1
+				}					
+			self.parts.wpn_fps_lmg_dp28_g_dpm.stats = {
+					value = 1,
+					spread = 1
+				}												
+			self.parts.wpn_fps_lmg_dp28_barrel_dt.stats = {
+					recoil = -1,
+					spread = 1,					
+					concealment = -2
+				}
+			self.parts.wpn_fps_lmg_dp28_m_dpm35.stats = {
+					extra_ammo = 153,
+					concealment = -5
+				}		
+			self.parts.wpn_fps_lmg_dp28_m_dpm36.stats = {
+					extra_ammo = -17,
+					recoil = -1,
+					concealment = 1,					
+					reload = 2
+				}																		
+			self.parts.wpn_fps_lmg_dp28_m_dt.stats = {
+					extra_ammo = 13,
+					recoil = -1,
+					spread = -1,					
+					concealment = -3
+				}		
+			self.parts.wpn_fps_lmg_dp28_g_dpm.stats = {
+					value = 1,
+					recoil = 1
+				}	
+			self.parts.wpn_fps_lmg_dp28_so_lord.stats = nil
+			self.parts.wpn_fps_lmg_dp28_so_pr.stats = nil
+			self.parts.wpn_fps_lmg_dp28_g_dt.stats = {
+					value = 1,
+					spread = 1
+				}											
+			self.wpn_fps_lmg_dp28.override = {
+				wpn_fps_upg_ammo_half_that = {
+				stats = {
+					value = 1,
+					total_ammo_mod = 20,
+					concealment = -3
+				},
+				custom_stats = {ammo_pickup_min_mul = 1.2, ammo_pickup_max_mul = 1.2, movement_speed = 0.8},	
+			}
+		}				
 		end
 
 		--Incendiary Slugs are awesome--

--- a/lua/sc/tweak_data/weapontweakdata.lua
+++ b/lua/sc/tweak_data/weapontweakdata.lua
@@ -9419,7 +9419,7 @@ if SC and SC._data.sc_player_weapon_toggle or restoration and restoration.Option
 			self.scar_m203.kick.crouching = self.new_m4.kick.standing
 			self.scar_m203.kick.steelsight = self.new_m4.kick.standing
 			self.scar_m203.stats = {
-				damage = 35,
+				damage = 40,
 				spread = 15,
 				recoil = 20,
 				spread_moving = 13,
@@ -9871,7 +9871,7 @@ if SC and SC._data.sc_player_weapon_toggle or restoration and restoration.Option
 				recoil = 20,
 				spread_moving = 9,
 				zoom = 1,
-				concealment = 2,
+				concealment = 5,
 				suppression = 7,
 				alert_size = 7,
 				extra_ammo = 101,
@@ -10026,7 +10026,7 @@ if SC and SC._data.sc_player_weapon_toggle or restoration and restoration.Option
 				recoil = 20,
 				spread_moving = 6,
 				zoom = 1,
-				concealment = 2,
+				concealment = 5,
 				suppression = 7,
 				alert_size = 7,
 				extra_ammo = 101,
@@ -10042,8 +10042,8 @@ if SC and SC._data.sc_player_weapon_toggle or restoration and restoration.Option
 			self.yayo.desc_id = "bm_m203_weapon_sc_desc"
 			self.yayo.has_description = true					
 			self.yayo.fire_mode_data.fire_rate = 0.08571428571
-			self.yayo.AMMO_MAX = 120
-			self.yayo.AMMO_PICKUP = self:_pickup_chance(120, 2)
+			self.yayo.AMMO_MAX = 150
+			self.yayo.AMMO_PICKUP = self:_pickup_chance(150, 2)
 			self.yayo.spread.standing = 3
 			self.yayo.spread.crouching = 2
 			self.yayo.spread.steelsight = 1
@@ -10159,14 +10159,14 @@ if SC and SC._data.sc_player_weapon_toggle or restoration and restoration.Option
 				"smg"
 			}
 			self.bar.CLIP_AMMO_MAX = 20
-			self.bar.AMMO_MAX = 80
+			self.bar.AMMO_MAX = 120
 			self.bar.has_description = false
 			self.bar.fire_mode_data.fire_rate = 0.12
 			self.bar.CAN_TOGGLE_FIREMODE = true
 			self.bar.FIRE_MODE = "auto"
 			self.bar.auto = {}
 			self.bar.auto.fire_rate = 0.12			
-			self.bar.AMMO_PICKUP = self:_pickup_chance(80, 2)
+			self.bar.AMMO_PICKUP = self:_pickup_chance(120, 2)
 			self.bar.CAN_TOGGLE_FIREMODE = true
 			self.bar.spread.standing = 3
 			self.bar.spread.crouching = 2
@@ -10178,12 +10178,12 @@ if SC and SC._data.sc_player_weapon_toggle or restoration and restoration.Option
 			self.bar.kick.crouching = self.new_m4.kick.standing
 			self.bar.kick.steelsight = self.new_m4.kick.standing
 			self.bar.stats = {
-				damage = 100,
-				spread = 19,
-				recoil = 16,
+				damage = 50,
+				spread = 18,
+				recoil = 17,
 				spread_moving = 5,
 				zoom = 3,
-				concealment = 5,
+				concealment = 20,
 				suppression = 5,
 				alert_size = 5,
 				extra_ammo = 101,
@@ -12261,7 +12261,7 @@ if SC and SC._data.sc_player_weapon_toggle or restoration and restoration.Option
 			self.scarl.kick.crouching = self.new_m4.kick.standing
 			self.scarl.kick.steelsight = self.new_m4.kick.standing
 			self.scarl.stats = {
-				damage = 35,
+				damage = 40,
 				spread = 15,
 				recoil = 20,
 				spread_moving = 13,
@@ -12595,7 +12595,7 @@ if SC and SC._data.sc_player_weapon_toggle or restoration and restoration.Option
 			recoil = 24,
 			spread_moving = 6,
 			zoom = 2,
-			concealment = 15,
+			concealment = 18,
 			suppression = 8,
 			alert_size = 8,
 			extra_ammo = 101,
@@ -12809,14 +12809,45 @@ if SC and SC._data.sc_player_weapon_toggle or restoration and restoration.Option
 			spread_moving = 15,
 			zoom = 1,
 			concealment = 25,
-			suppression = 10,
-			alert_size = 10,
+			suppression = 9,
+			alert_size = 9,
 			extra_ammo = 101,
 			total_ammo_mod = 100,
 			value = 3,
 			reload = 11
 		}
 		self.calico.panic_suppression_chance = 0.1
+	end
+
+	if self.dp28 then --Killerwolf & Kitsune Jimmy's DP-28 "Its an lmg I swear this time"
+		self.dp28.categories = {
+			"lmg",
+			"smg"
+		}	
+		self.dp28.has_description = false		
+		self.dp28.AMMO_MAX = 150
+		self.dp28.AMMO_PICKUP = self:_pickup_chance(150, 2)
+		self.dp28.spread.standing = 3
+		self.dp28.spread.crouching = 2
+		self.dp28.spread.steelsight = 1
+		self.dp28.spread.moving_standing = 4
+		self.dp28.spread.moving_crouching = 3
+		self.dp28.spread.moving_steelsight = 2
+		self.dp28.stats = {
+		damage = 40,
+		spread = 15,
+		recoil = 17,
+		spread_moving = 9,
+		zoom = 3,
+		concealment = 18,
+		suppression = 5,
+		alert_size = 5,
+		extra_ammo = 101,
+		total_ammo_mod = 100,
+		value = 1,
+		reload = 11
+		}
+		self.dp28.panic_suppression_chance = 0.1
 	end
 
 	end)


### PR DESCRIPTION
DP28 added as heavy LMG; mods that have viewmodel issues are removed for the time being.
BAR is adjusted to 50 damage tier from 100 dmg tier. Still the heaviest LMG, but won't compete with DRMs now. Double ammo kit fixed.
Montana ammo fixed.
M60 and RPD conceal adjusted for double ammo kit.
Ultimax 30rd magazine actually has 30 rounds.
SCAR-L and its M203 variant have their damage buffed to fit their new ammo tiers.