### PR TITLE
Fix for get_spread not including stance modifiers and new movement states to go with the fix

### DIFF
--- a/lua/sc/tweak_data/weapontweakdata.lua
+++ b/lua/sc/tweak_data/weapontweakdata.lua
@@ -3296,11 +3296,11 @@ if SC and SC._data.sc_player_weapon_toggle or restoration and restoration.Option
 		self.new_m4.fire_mode_data.fire_rate = 0.08571428571
 		self.new_m4.auto.fire_rate = 0.08571428571
 		self.new_m4.spread.standing = 3
-		self.new_m4.spread.crouching = 2
-		self.new_m4.spread.steelsight = 1
-		self.new_m4.spread.moving_standing = 4
-		self.new_m4.spread.moving_crouching = 3
-		self.new_m4.spread.moving_steelsight = 2
+		self.new_m4.spread.crouching = self.new_m4.spread.standing / 1.5
+		self.new_m4.spread.steelsight = 1 / 1.5
+		self.new_m4.spread.moving_standing = self.new_m4.spread.standing * 1.5
+		self.new_m4.spread.moving_crouching = self.new_m4.spread.standing
+		self.new_m4.spread.moving_steelsight = 1
 		self.new_m4.kick.standing = {
 			0.6,
 			0.8,

--- a/lua/sc/tweak_data/weapontweakdata.lua
+++ b/lua/sc/tweak_data/weapontweakdata.lua
@@ -3296,11 +3296,11 @@ if SC and SC._data.sc_player_weapon_toggle or restoration and restoration.Option
 		self.new_m4.fire_mode_data.fire_rate = 0.08571428571
 		self.new_m4.auto.fire_rate = 0.08571428571
 		self.new_m4.spread.standing = 3
-		self.new_m4.spread.crouching = self.new_m4.spread.standing / 1.5
-		self.new_m4.spread.steelsight = 1 / 1.5
-		self.new_m4.spread.moving_standing = self.new_m4.spread.standing * 1.5
-		self.new_m4.spread.moving_crouching = self.new_m4.spread.standing
-		self.new_m4.spread.moving_steelsight = 1
+		self.new_m4.spread.crouching = 2
+		self.new_m4.spread.steelsight = 1
+		self.new_m4.spread.moving_standing = 4
+		self.new_m4.spread.moving_crouching = 3
+		self.new_m4.spread.moving_steelsight = 2
 		self.new_m4.kick.standing = {
 			0.6,
 			0.8,

--- a/lua/sc/units/player/playerstandard.lua
+++ b/lua/sc/units/player/playerstandard.lua
@@ -764,5 +764,16 @@ if SC and SC._data.sc_ai_toggle or restoration and restoration.Options:GetValue(
 			end
 			return col_ray
 		end
-
+		
+		function PlayerStandard:get_movement_state()
+			if self._state_data.in_steelsight then
+				return self._moving and "moving_steelsight" or "steelsight"
+			end
+	
+			if self._state_data.ducking then
+				return self._moving and "moving_crouching" or "crouching"
+			else
+				return self._moving and "moving_standing" or "standing"
+			end
+		end
 end

--- a/lua/sc/units/weapons/newraycastweaponbase.lua
+++ b/lua/sc/units/weapons/newraycastweaponbase.lua
@@ -102,10 +102,26 @@ if SC and SC._data.sc_player_weapon_toggle or restoration and restoration.Option
 		self._spread = tweak_data.weapon.stats.spread[new_spread]
 		local spread_x, spread_y
 		if type(current_spread_value) == "number" then
-			spread_x = self._spread --self:_get_spread_from_number(user_unit, current_state, current_spread_value)
+			spread_x = self._spread * current_spread_value --self:_get_spread_from_number(user_unit, current_state, current_spread_value)
 			spread_y = spread_x
 		else
 			spread_x, spread_y = self:_get_spread_from_table(user_unit, current_state, current_spread_value)
+		end
+
+		if current_state:in_steelsight() then
+			local steelsight_tweak = spread_values.steelsight
+			local multi_x, multi_y = nil
+	
+			if type(steelsight_tweak) == "number" then
+				multi_x = steelsight_tweak
+				multi_y = multi_x
+			else
+				multi_x = steelsight_tweak[1]
+				multi_y = steelsight_tweak[2]
+			end
+	
+			spread_x = spread_x * multi_x
+			spread_y = spread_y * multi_y
 		end
 		
 		if self._spread_multiplier then

--- a/lua/sc/units/weapons/newraycastweaponbase.lua
+++ b/lua/sc/units/weapons/newraycastweaponbase.lua
@@ -107,22 +107,6 @@ if SC and SC._data.sc_player_weapon_toggle or restoration and restoration.Option
 		else
 			spread_x, spread_y = self:_get_spread_from_table(user_unit, current_state, current_spread_value)
 		end
-
-		if current_state:in_steelsight() then
-			local steelsight_tweak = spread_values.steelsight
-			local multi_x, multi_y = nil
-	
-			if type(steelsight_tweak) == "number" then
-				multi_x = steelsight_tweak
-				multi_y = multi_x
-			else
-				multi_x = steelsight_tweak[1]
-				multi_y = steelsight_tweak[2]
-			end
-	
-			spread_x = spread_x * multi_x
-			spread_y = spread_y * multi_y
-		end
 		
 		if self._spread_multiplier then
 			spread_x = spread_x * self._spread_multiplier[1]


### PR DESCRIPTION
Specifically the standing, crouching, and moving variants apply. steelsight is applied separately as another modifier and moving_steelsight isn't ever used (and never was).