### PR TITLE
Bugfixes for last bugfixes, Rogue health regen.

### DIFF
--- a/lua/sc/loc/loc.lua
+++ b/lua/sc/loc/loc.lua
@@ -953,7 +953,7 @@ Hooks:Add("LocalizationManagerPostInit", "SC_Localization_Perk_Decks", function(
 		["menu_deck4_3_desc_sc"] = "Your dodge is increased by an additional ##5## points.",
 		["menu_deck4_5_desc_sc"] = "Your dodge is increased by an additional ##5## points.\n\nYour dodge meter is filled when you are revived.",
 		["menu_deck4_7_desc_sc"] = "Your dodge is increased by an additional ##5## points.",
-		["menu_deck4_9_desc_sc"] = "Dodging an attack while your armor is broken regenerates health equal to ##40%## of the damage you would have taken. This effect can only occur once every ##3## seconds.\n\nDeck completion Bonus: Your chance of getting a higher quality item during PAYDAY is increased by ##10%.##",
+		["menu_deck4_9_desc_sc"] = "Dodging an attack causes you to regenerate ##1## life point every ##2## seconds for the next 30 seconds. This effect can stack, but all stacks are lost when a bullet damages your health.\n\nDeck completion Bonus: Your chance of getting a higher quality item during PAYDAY is increased by ##10%.##",
 
 		--Hitman--
 		["menu_deck5_1_desc_sc"] = "Your armor recovery rate is increased by ##10%##.",

--- a/lua/sc/managers/blackmarketgui.lua
+++ b/lua/sc/managers/blackmarketgui.lua
@@ -433,84 +433,83 @@ if SC and SC._data.sc_player_weapon_toggle or restoration and restoration.Option
 		end
 	end
 
-end
+	function BlackMarketGui:_get_armor_stats(name)
+		local base_stats = {}
+		local mods_stats = {}
+		local skill_stats = {}
+		local detection_risk = managers.blackmarket:get_suspicion_offset_from_custom_data({armors = name}, tweak_data.player.SUSPICION_OFFSET_LERP or 0.75)
+		detection_risk = math.round(detection_risk * 100)
+		local bm_armor_tweak = tweak_data.blackmarket.armors[name]
+		local upgrade_level = bm_armor_tweak.upgrade_level
 
-function BlackMarketGui:_get_armor_stats(name)
-	local base_stats = {}
-	local mods_stats = {}
-	local skill_stats = {}
-	local detection_risk = managers.blackmarket:get_suspicion_offset_from_custom_data({armors = name}, tweak_data.player.SUSPICION_OFFSET_LERP or 0.75)
-	detection_risk = math.round(detection_risk * 100)
-	local bm_armor_tweak = tweak_data.blackmarket.armors[name]
-	local upgrade_level = bm_armor_tweak.upgrade_level
+		for i, stat in ipairs(self._armor_stats_shown) do
+			base_stats[stat.name] = {value = 0}
+			mods_stats[stat.name] = {value = 0}
+			skill_stats[stat.name] = {value = 0}
 
-	for i, stat in ipairs(self._armor_stats_shown) do
-		base_stats[stat.name] = {value = 0}
-		mods_stats[stat.name] = {value = 0}
-		skill_stats[stat.name] = {value = 0}
+			if stat.name == "armor" then
+				local base = tweak_data.player.damage.ARMOR_INIT
+				local mod = managers.player:body_armor_value("armor", upgrade_level)
+				base_stats[stat.name] = {value = (base + mod) * tweak_data.gui.stats_present_multiplier}
+				skill_stats[stat.name] = {value = (base_stats[stat.name].value + managers.player:body_armor_skill_addend(name) * tweak_data.gui.stats_present_multiplier) * managers.player:body_armor_skill_multiplier(name) - base_stats[stat.name].value}
+			elseif stat.name == "health" then
+				local base = tweak_data.player.damage.HEALTH_INIT
+				local mod = managers.player:health_skill_addend()
+				base_stats[stat.name] = {value = (base + mod) * tweak_data.gui.stats_present_multiplier}
+				skill_stats[stat.name] = {value = base_stats[stat.name].value * managers.player:health_skill_multiplier() - base_stats[stat.name].value}
+			elseif stat.name == "concealment" then
+				base_stats[stat.name] = {value = managers.player:body_armor_value("concealment", upgrade_level)}
+				skill_stats[stat.name] = {value = managers.blackmarket:concealment_modifier("armors", upgrade_level)}
+			elseif stat.name == "movement" then
+				local base = tweak_data.player.movement_state.standard.movement.speed.STANDARD_MAX / 100 * tweak_data.gui.stats_present_multiplier
+				local movement_penalty = managers.player:body_armor_value("movement", upgrade_level)
+				local base_value = movement_penalty * base
+				base_stats[stat.name] = {value = base_value}
+				local skill_mod = managers.player:movement_speed_multiplier(false, false, upgrade_level, 1)
+				local skill_value = skill_mod * base - base_value
+				skill_stats[stat.name] = {
+					value = skill_value,
+					skill_in_effect = skill_value > 0
+				}
+			elseif stat.name == "dodge" then
+				local base = 0
+				local mod = managers.player:body_armor_value("dodge", upgrade_level)
+				base_stats[stat.name] = {value = (base + mod) * 100}
+				skill_stats[stat.name] = {value = managers.player:skill_dodge_chance(false, false, false, name, detection_risk) * 100}
+			elseif stat.name == "damage_shake" then
+				local base = tweak_data.gui.armor_damage_shake_base
+				local mod = math.max(managers.player:body_armor_value("damage_shake", upgrade_level, nil, 1), 0.01)
+				local skill = math.max(managers.player:upgrade_value("player", "damage_shake_multiplier", 1), 0.01)
+				local base_value = base
+				local mod_value = base / mod - base_value
+				local skill_value = ((base / mod) / skill - base_value) - mod_value + managers.player:upgrade_value("player", "damage_shake_addend", 0)
+				base_stats[stat.name] = {value = (base_value + mod_value) * tweak_data.gui.stats_present_multiplier}
+				skill_stats[stat.name] = {value = skill_value * tweak_data.gui.stats_present_multiplier}
+			elseif stat.name == "stamina" then
+				local stamina_data = tweak_data.player.movement_state.stamina
+				local base = stamina_data.STAMINA_INIT
+				local mod = managers.player:body_armor_value("stamina", upgrade_level)
+				local skill = managers.player:stamina_multiplier()
+				local base_value = base
+				local mod_value = base * mod - base_value
+				local skill_value = (base * mod * skill - base_value) - mod_value
+				base_stats[stat.name] = {value = base_value + mod_value}
+				skill_stats[stat.name] = {value = skill_value}
+			end
 
-		if stat.name == "armor" then
-			local base = tweak_data.player.damage.ARMOR_INIT
-			local mod = managers.player:body_armor_value("armor", upgrade_level)
-			base_stats[stat.name] = {value = (base + mod) * tweak_data.gui.stats_present_multiplier}
-			skill_stats[stat.name] = {value = (base_stats[stat.name].value + managers.player:body_armor_skill_addend(name) * tweak_data.gui.stats_present_multiplier) * managers.player:body_armor_skill_multiplier(name) - base_stats[stat.name].value}
-		elseif stat.name == "health" then
-			local base = tweak_data.player.damage.HEALTH_INIT
-			local mod = managers.player:health_skill_addend()
-			base_stats[stat.name] = {value = (base + mod) * tweak_data.gui.stats_present_multiplier}
-			skill_stats[stat.name] = {value = base_stats[stat.name].value * managers.player:health_skill_multiplier() - base_stats[stat.name].value}
-		elseif stat.name == "concealment" then
-			base_stats[stat.name] = {value = managers.player:body_armor_value("concealment", upgrade_level)}
-			skill_stats[stat.name] = {value = managers.blackmarket:concealment_modifier("armors", upgrade_level)}
-		elseif stat.name == "movement" then
-			local base = tweak_data.player.movement_state.standard.movement.speed.STANDARD_MAX / 100 * tweak_data.gui.stats_present_multiplier
-			local movement_penalty = managers.player:body_armor_value("movement", upgrade_level)
-			local base_value = movement_penalty * base
-			base_stats[stat.name] = {value = base_value}
-			local skill_mod = managers.player:movement_speed_multiplier(false, false, upgrade_level, 1)
-			local skill_value = skill_mod * base - base_value
-			skill_stats[stat.name] = {
-				value = skill_value,
-				skill_in_effect = skill_value > 0
-			}
-		elseif stat.name == "dodge" then
-			local base = 0
-			local mod = managers.player:body_armor_value("dodge", upgrade_level)
-			base_stats[stat.name] = {value = (base + mod) * 100}
-			skill_stats[stat.name] = {value = managers.player:skill_dodge_chance(false, false, false, name, detection_risk) * 100}
-		elseif stat.name == "damage_shake" then
-			local base = tweak_data.gui.armor_damage_shake_base
-			local mod = math.max(managers.player:body_armor_value("damage_shake", upgrade_level, nil, 1), 0.01)
-			local skill = math.max(managers.player:upgrade_value("player", "damage_shake_multiplier", 1), 0.01)
-			local base_value = base
-			local mod_value = base / mod - base_value
-			local skill_value = ((base / mod) / skill - base_value) - mod_value + managers.player:upgrade_value("player", "damage_shake_addend", 0)
-			base_stats[stat.name] = {value = (base_value + mod_value) * tweak_data.gui.stats_present_multiplier}
-			skill_stats[stat.name] = {value = skill_value * tweak_data.gui.stats_present_multiplier}
-		elseif stat.name == "stamina" then
-			local stamina_data = tweak_data.player.movement_state.stamina
-			local base = stamina_data.STAMINA_INIT
-			local mod = managers.player:body_armor_value("stamina", upgrade_level)
-			local skill = managers.player:stamina_multiplier()
-			local base_value = base
-			local mod_value = base * mod - base_value
-			local skill_value = (base * mod * skill - base_value) - mod_value
-			base_stats[stat.name] = {value = base_value + mod_value}
-			skill_stats[stat.name] = {value = skill_value}
+			skill_stats[stat.name].skill_in_effect = skill_stats[stat.name].skill_in_effect or skill_stats[stat.name].value ~= 0
 		end
 
-		skill_stats[stat.name].skill_in_effect = skill_stats[stat.name].skill_in_effect or skill_stats[stat.name].value ~= 0
-	end
+		if managers.player:has_category_upgrade("player", "armor_to_health_conversion") then
+			local conversion_ratio = managers.player:upgrade_value("player", "armor_to_health_conversion") * 0.01
+			local converted_armor = (base_stats.armor.value + skill_stats.armor.value) * conversion_ratio
+			local skill_in_effect = converted_armor ~= 0
+			skill_stats.armor.value = (base_stats.armor.value + skill_stats.armor.value) * -1
+			skill_stats.health.value = skill_stats.health.value + converted_armor
+			skill_stats.armor.skill_in_effect = skill_in_effect
+			skill_stats.health.skill_in_effect = skill_in_effect
+		end
 
-	if managers.player:has_category_upgrade("player", "armor_to_health_conversion") then
-		local conversion_ratio = managers.player:upgrade_value("player", "armor_to_health_conversion") * 0.01
-		local converted_armor = (base_stats.armor.value + skill_stats.armor.value) * conversion_ratio
-		local skill_in_effect = converted_armor ~= 0
-		skill_stats.armor.value = (base_stats.armor.value + skill_stats.armor.value) * -1
-		skill_stats.health.value = skill_stats.health.value + converted_armor
-		skill_stats.armor.skill_in_effect = skill_in_effect
-		skill_stats.health.skill_in_effect = skill_in_effect
+		return base_stats, mods_stats, skill_stats
 	end
-
-	return base_stats, mods_stats, skill_stats
 end

--- a/lua/sc/managers/playermanager.lua
+++ b/lua/sc/managers/playermanager.lua
@@ -179,8 +179,10 @@ if SC and SC._data.sc_ai_toggle or restoration and restoration.Options:GetValue(
 
 		--Load alternate heal over time tweakdata if player is using Infiltrator.
 		local data = tweak_data.upgrades.damage_to_hot_data
-		if self:has_category_upgrade("melee", "stacking_hit_damage_multiplier") then
+		if self:has_category_upgrade("melee", "stacking_hit_damage_multiplier") then --Load alternate heal over time tweakdata if player is using Infiltrator.
 			data = tweak_data.upgrades.melee_to_hot_data
+		elseif self:has_category_upgrade("player", "dodge_to_heal") then --Or Rogue
+			data = tweak_data.upgrades.dodge_to_hot_data
 		end
 
 		if not data then

--- a/lua/sc/tweak_data/skilltreetweakdata.lua
+++ b/lua/sc/tweak_data/skilltreetweakdata.lua
@@ -2263,7 +2263,8 @@ function SkillTreeTweakData:init(tweak_data)
 			{
 				upgrades = {
 					"player_passive_loot_drop_multiplier",
-					"player_dodge_to_heal"
+					"player_dodge_to_heal",
+					"player_damage_to_hot_1"
 				},
 				cost = 4000,
 				icon_xy = {1, 0},

--- a/lua/sc/tweak_data/upgradestweakdata.lua
+++ b/lua/sc/tweak_data/upgradestweakdata.lua
@@ -1021,9 +1021,25 @@ function UpgradesTweakData:_init_pd2_values()
 	}
 
 	--Rogue
-	self.dodge_to_heal = {
-		0.4, --% healed
-		3.0 --cooldown
+	self.dodge_to_hot_data = {
+		armors_allowed = {"level_1", "level_2", "level_3", "level_4", "level_5", "level_6", "level_7"},
+		works_with_armor_kit = true,
+		tick_time = 2.0,
+		total_ticks = 15.0,
+		max_stacks = 100,
+		stacking_cooldown = 0.0,
+		add_stack_sources = {
+			bullet = false,
+			explosion = false,
+			melee = false,
+			taser_tased = false,
+			poison = false,
+			fire = false,
+			projectile = false,
+			swat_van = false,
+			sentry_gun = false,
+			civilian = false
+		}
 	}
 
 	--Gambler

--- a/lua/sc/units/player/playermaskoff.lua
+++ b/lua/sc/units/player/playermaskoff.lua
@@ -1,6 +1,0 @@
-if SC and SC._data.sc_ai_toggle or restoration and restoration.Options:GetValue("SC/SC") then
-    Hooks:PostHook(PlayerMaskOff, "exit", "ResDodgeInitMessage", function(self, state_data, new_state_name)
-		self._ext_damage:set_dodge_points()
-	end)
-end
-

--- a/lua/sc/units/player/playerstandard.lua
+++ b/lua/sc/units/player/playerstandard.lua
@@ -776,4 +776,8 @@ if SC and SC._data.sc_ai_toggle or restoration and restoration.Options:GetValue(
 				return self._moving and "moving_standing" or "standing"
 			end
 		end
+
+		Hooks:PostHook(PlayerStandard, "_enter", "ResDodgeInit", function(self, enter_data)
+			self._ext_damage:set_dodge_points()
+		end)
 end

--- a/main.xml
+++ b/main.xml
@@ -104,7 +104,6 @@
 		<hook file="sc/units/weapons/weaponunderbarrellauncher.lua" source_file="lib/units/weapons/weaponunderbarrellauncher"/>
 		<hook file="sc/units/weapons/arrowbase.lua" source_file="lib/units/weapons/projectiles/arrowbase"/>
 		<hook file="sc/units/player/playerdamage.lua" source_file="lib/units/beings/player/playerdamage"/>
-		<hook file="sc/units/player/playermaskoff.lua" source_file="lib/units/beings/player/states/playermaskoff"/>
 		<hook file="sc/units/player/playercarry.lua" source_file="lib/units/beings/player/states/playercarry"/>
 		<hook file="sc/units/player/playerbleedout.lua" source_file="lib/units/beings/player/states/playerbleedout"/>
 		<hook file="sc/units/player/playertased.lua" source_file="lib/units/beings/player/states/playertased"/>

--- a/mod.txt
+++ b/mod.txt
@@ -38,10 +38,6 @@
 		{
 			"hook_id" : "lib/units/beings/player/playerdamage",
 			"script_path" : "lua/sc/units/player/playerdamage.lua"
-		},
-		{
-			"hook_id" : "lib/units/beings/player/states/playermaskoff",
-			"script_path" : "lua/sc/units/player/playermaskoff.lua"
 		}
 	]
 }


### PR DESCRIPTION
Rogue health regen reworked. Now each dodge causes you to slowly
regenerate health. Effect stacks but all stacks are lost when you take
health damage from a bullet.

Dodge init moved to playerstandard init, I forgot about heists that
instantly start you masked up when they begin.

Also fixed issue related to stoic and armor on the GUI for people with overhaul disabled.