### PR TITLE
Grinder text bugfix.

### DIFF
--- a/lua/sc/loc/loc.lua
+++ b/lua/sc/loc/loc.lua
@@ -953,7 +953,7 @@ Hooks:Add("LocalizationManagerPostInit", "SC_Localization_Perk_Decks", function(
 		["menu_deck4_3_desc_sc"] = "Your dodge is increased by an additional ##5## points.",
 		["menu_deck4_5_desc_sc"] = "Your dodge is increased by an additional ##5## points.\n\nYour dodge meter is filled when you are revived.",
 		["menu_deck4_7_desc_sc"] = "Your dodge is increased by an additional ##5## points.",
-		["menu_deck4_9_desc_sc"] = "Dodging an attack causes you to regenerate ##1## life point every ##2## seconds for the next 30 seconds. This effect can stack, but all stacks are lost when a bullet damages your health.\n\nDeck completion Bonus: Your chance of getting a higher quality item during PAYDAY is increased by ##10%.##",
+		["menu_deck4_9_desc_sc"] = "Dodging an attack causes you to regenerate ##1## life point every ##2## seconds for the next ##30## seconds. This effect can stack, but all stacks are lost when a bullet damages your health.\n\nDeck completion Bonus: Your chance of getting a higher quality item during PAYDAY is increased by ##10%.##",
 
 		--Hitman--
 		["menu_deck5_1_desc_sc"] = "Your armor recovery rate is increased by ##10%##.",

--- a/lua/sc/managers/playermanager.lua
+++ b/lua/sc/managers/playermanager.lua
@@ -157,7 +157,7 @@ if SC and SC._data.sc_ai_toggle or restoration and restoration.Options:GetValue(
 	function PlayerManager:_check_damage_to_hot(t, unit, damage_info)
 		local player_unit = self:player_unit()
 
-		if not self:has_category_upgrade("player", "damage_to_hot") then
+		if not self:has_category_upgrade("player", "damage_to_hot") and not self:has_category_upgrade("player", "heal_over_time") then
 			return
 		end
 		

--- a/lua/sc/managers/playermanager.lua
+++ b/lua/sc/managers/playermanager.lua
@@ -179,7 +179,7 @@ if SC and SC._data.sc_ai_toggle or restoration and restoration.Options:GetValue(
 
 		--Load alternate heal over time tweakdata if player is using Infiltrator.
 		local data = tweak_data.upgrades.damage_to_hot_data
-		if self:has_category_upgrade("melee", "stacking_hit_damage_multiplier") then --Load alternate heal over time tweakdata if player is using Infiltrator.
+		if self:has_category_upgrade("player", "melee_to_heal") then --Load alternate heal over time tweakdata if player is using Infiltrator.
 			data = tweak_data.upgrades.melee_to_hot_data
 		elseif self:has_category_upgrade("player", "dodge_to_heal") then --Or Rogue
 			data = tweak_data.upgrades.dodge_to_hot_data

--- a/lua/sc/tweak_data/skilltreetweakdata.lua
+++ b/lua/sc/tweak_data/skilltreetweakdata.lua
@@ -2264,7 +2264,7 @@ function SkillTreeTweakData:init(tweak_data)
 				upgrades = {
 					"player_passive_loot_drop_multiplier",
 					"player_dodge_to_heal",
-					"player_damage_to_hot_1"
+					"player_heal_over_time"
 				},
 				cost = 4000,
 				icon_xy = {1, 0},
@@ -2514,7 +2514,8 @@ function SkillTreeTweakData:init(tweak_data)
 			deck8,
 			{
 				upgrades = {
-					"player_damage_to_hot_1",
+					"player_heal_over_time",
+					"player_melee_to_heal",
 					"player_passive_loot_drop_multiplier"
 				},
 				cost = 4000,

--- a/lua/sc/tweak_data/upgradestweakdata.lua
+++ b/lua/sc/tweak_data/upgradestweakdata.lua
@@ -169,6 +169,7 @@ function UpgradesTweakData:_init_pd2_values()
     	self.values.player.yakuza_berserker = {true}
 		self.values.player.electrocution_resistance_multiplier = {1}
 		self.values.player.dodge_to_heal = {true}
+		self.values.player.melee_to_heal = {true}
 		self.values.player.dodge_on_revive = {true}
 	--Bot boost stuff stuff--
 	self.values.team.crew_add_health = {3}
@@ -934,6 +935,10 @@ function UpgradesTweakData:_init_pd2_values()
 		}
 	}
 
+	self.values.player.heal_over_time = {
+		0.1
+	}	
+
 	self.values.team.armor.multiplier = {1.05}
 	self.values.team.health.passive_multiplier = {1.05}
 	self.hostage_max_num = {
@@ -1620,6 +1625,15 @@ function UpgradesTweakData:_player_definitions()
 			value = 1
 		}
 	}
+	self.definitions.player_melee_to_heal = {
+		category = "feature",
+		name_id = "menu_player_melee_to_heal",
+		upgrade = {
+			category = "player",
+			upgrade = "melee_to_heal",
+			value = 1
+		}
+	}
 	self.definitions.player_dodge_on_revive = {
 		category = "feature",
 		name_id = "menu_player_dodge_on_revive",
@@ -2285,6 +2299,15 @@ function UpgradesTweakData:_saw_definitions()
 			category = "shotgun",
 			upgrade = "swap_speed_multiplier",
 			value = 1
+		}
+	}
+	self.definitions.player_heal_over_time = {
+		name_id = "menu_player_heal_over_time",
+		category = "feature",
+		upgrade = {
+			value = 1,
+			upgrade = "heal_over_time",
+			category = "player"
 		}
 	}
 end


### PR DESCRIPTION
The warning that "Grinder only works with Flak Jacket" now only displays for Grinder. Stacking heals over time are now not as coupled to Grinder as before.

Also fixed a minor issue with the description of Rogue's final perk.