### PR TITLE
Fixed Interaction with Anarchist and More Blood to Bleed (and other health multipliers)

### DIFF
--- a/lua/sc/loc/loc.lua
+++ b/lua/sc/loc/loc.lua
@@ -1039,9 +1039,9 @@ Hooks:Add("LocalizationManagerPostInit", "SC_Localization_Perk_Decks", function(
 
 		--Anarchist--
 		["menu_deck15_1_desc_sc"] = "Instead of fully regenerating armor when out of combat, The Anarchist will periodically regenerate armor at a rate equivalent to ##10## armor per second. Heavier armor regenerates more armor per tick, but has a longer delay between ticks.\n\nNote: Skills and perks that increases the armor recovery rate are disabled when using this perk deck.",
-		["menu_deck15_3_desc_sc"] = "##50%## of your health is converted into ##45%## armor.",
-		["menu_deck15_5_desc_sc"] = "##50%## of your health is converted into ##60%## armor.",
-		["menu_deck15_7_desc_sc"] = "##50%## of your health is converted into ##75%## armor.",
+		["menu_deck15_3_desc_sc"] = "##50%## of your health is converted into ##50%## armor.",
+		["menu_deck15_5_desc_sc"] = "##50%## of your health is converted into ##70%## armor.",
+		["menu_deck15_7_desc_sc"] = "##50%## of your health is converted into ##90%## armor.",
 		["menu_deck15_9_desc_sc"] = "Dealing damage will grant you armor - This can only occur once every ##3## seconds. Heavier armors are granted more armor.\n\nDeck Completion Bonus: Your chance of getting a higher quality item during a PAYDAY is increased by ##10%.##",
 
 		--Scarface--

--- a/lua/sc/managers/playermanager.lua
+++ b/lua/sc/managers/playermanager.lua
@@ -397,5 +397,20 @@ if SC and SC._data.sc_ai_toggle or restoration and restoration.Options:GetValue(
 	--function PlayerManager:speak(message, arg1, arg2)
 	--	self:player_unit():sound():say(message, arg1, arg2)
 	--end
-		
+	
+	function PlayerManager:health_skill_multiplier()
+		local multiplier = 1
+		multiplier = multiplier + self:upgrade_value("player", "health_multiplier", 1) - 1
+		multiplier = multiplier + self:upgrade_value("player", "passive_health_multiplier", 1) - 1
+		multiplier = multiplier + self:team_upgrade_value("health", "passive_multiplier", 1) - 1
+		multiplier = multiplier + self:get_hostage_bonus_multiplier("health") - 1
+		multiplier = multiplier * self:upgrade_value("player", "health_decrease", 0)
+
+		if self:num_local_minions() > 0 then
+			multiplier = multiplier + self:upgrade_value("player", "minion_master_health_multiplier", 1) - 1
+		end
+
+		return multiplier
+	end
+
 end

--- a/lua/sc/managers/playermanager.lua
+++ b/lua/sc/managers/playermanager.lua
@@ -404,12 +404,13 @@ if SC and SC._data.sc_ai_toggle or restoration and restoration.Options:GetValue(
 		multiplier = multiplier + self:upgrade_value("player", "passive_health_multiplier", 1) - 1
 		multiplier = multiplier + self:team_upgrade_value("health", "passive_multiplier", 1) - 1
 		multiplier = multiplier + self:get_hostage_bonus_multiplier("health") - 1
-		multiplier = multiplier * self:upgrade_value("player", "health_decrease", 1.0)
 
 		if self:num_local_minions() > 0 then
 			multiplier = multiplier + self:upgrade_value("player", "minion_master_health_multiplier", 1) - 1
 		end
 
+		multiplier = multiplier * self:upgrade_value("player", "health_decrease", 1.0)
+		
 		return multiplier
 	end
 

--- a/lua/sc/managers/playermanager.lua
+++ b/lua/sc/managers/playermanager.lua
@@ -404,7 +404,7 @@ if SC and SC._data.sc_ai_toggle or restoration and restoration.Options:GetValue(
 		multiplier = multiplier + self:upgrade_value("player", "passive_health_multiplier", 1) - 1
 		multiplier = multiplier + self:team_upgrade_value("health", "passive_multiplier", 1) - 1
 		multiplier = multiplier + self:get_hostage_bonus_multiplier("health") - 1
-		multiplier = multiplier * self:upgrade_value("player", "health_decrease", 0)
+		multiplier = multiplier * self:upgrade_value("player", "health_decrease", 1.0)
 
 		if self:num_local_minions() > 0 then
 			multiplier = multiplier + self:upgrade_value("player", "minion_master_health_multiplier", 1) - 1

--- a/lua/sc/tweak_data/upgradestweakdata.lua
+++ b/lua/sc/tweak_data/upgradestweakdata.lua
@@ -1102,9 +1102,9 @@ function UpgradesTweakData:_init_pd2_values()
 	self.values.player.health_decrease = {0.5}
 	
 	self.values.player.armor_increase = {
-		0.45,
-		0.6,
-		0.75
+		0.50,
+		0.70,
+		0.90
 	}
 
 	self.values.player.damage_to_armor = {

--- a/lua/sc/units/player/playerdamage.lua
+++ b/lua/sc/units/player/playerdamage.lua
@@ -34,7 +34,7 @@ if SC and SC._data.sc_ai_toggle or restoration and restoration.Options:GetValue(
 
 		managers.sequence:add_inflict_updator_body("fire", self._unit:key(), self._inflict_damage_body:key(), self._inflict_damage_body:extension().damage)
 
-		--Load alternate heal over time tweakdata if player is using Infiltrator.
+		--Load alternate heal over time tweakdata if player is using Infiltrator or Rogue.
 		if player_manager:has_category_upgrade("player", "melee_to_heal") then
 			self._doh_data = tweak_data.upgrades.melee_to_hot_data or {}
 			self._hot_amount = managers.player:upgrade_value("player", "heal_over_time", 0)


### PR DESCRIPTION
Bonus health from More Blood to Bleed (or other health increases) is now properly reduced by Anarchist. Since this effected the amount of armor Anarchist gained, Anarchist's armor/health conversion rate has been slightly increased. It works out to be a nerf for min/maxed builds (-40 health, -some variable amount of armor), but a mild buff to non-optimal builds (~+15 armor).