### PR TITLE
Rack-Em-Up-Esque Trigger Happy and Desperado, skill bugfixes.

### DIFF
--- a/lua/sc/loc/loc.lua
+++ b/lua/sc/loc/loc.lua
@@ -906,7 +906,7 @@ Hooks:Add("LocalizationManagerPostInit", "SC_Localization_Skills", function(loc)
 
 		--Desperado--
 		["menu_expert_handling_sc"] = "Desperado",
-		["menu_expert_handling_desc_sc"] = "BASIC: ##$basic##\nEach successful pistol headshot grants a ##15%## accuracy boost for ##4## seconds. This effect can stack ##5## times, and the duration of each stack is refreshed on successful pistol headshots.\n\nACE: ##$pro##\nIncreases the accuracy boost duration to ##6## seconds, and all pistol hits refresh the duration.",																																																																																																																																																																																																																																		
+		["menu_expert_handling_desc_sc"] = "BASIC: ##$basic##\nEach successful pistol headshot grants a ##10%## accuracy boost for ##4## seconds. This effect can stack ##5## times, and the duration of each stack is refreshed on successful pistol headshots.\n\nACE: ##$pro##\nIncreases the accuracy boost duration to ##6## seconds, and all pistol hits refresh the duration.",																																																																																																																																																																																																																																		
 
 		--Trigger Happy--
 		["menu_trigger_happy_beta_sc"] = "Trigger Happy",

--- a/lua/sc/loc/loc.lua
+++ b/lua/sc/loc/loc.lua
@@ -906,11 +906,11 @@ Hooks:Add("LocalizationManagerPostInit", "SC_Localization_Skills", function(loc)
 
 		--Desperado--
 		["menu_expert_handling_sc"] = "Desperado",
-		["menu_expert_handling_desc_sc"] = "BASIC: ##$basic##\nEach successful pistol hit gives you a ##10%## increased accuracy bonus for ##10## seconds and can stack ##5## times.\n\nACE: ##$pro##\nIncreases the accuracy boost duration to ##20## seconds.",																																																																																																																																																																																																																																		
+		["menu_expert_handling_desc_sc"] = "BASIC: ##$basic##\nEach successful pistol headshot grants a ##15%## accuracy boost for ##6## seconds. This effect can stack ##5## times, and the duration of each stack is refreshed on successful pistol headshots.\n\nACE: ##$pro##\nIncreases the accuracy boost duration to ##9## seconds, and all pistol hits refresh the duration.",																																																																																																																																																																																																																																		
 
 		--Trigger Happy--
 		["menu_trigger_happy_beta_sc"] = "Trigger Happy",
-		["menu_trigger_happy_beta_desc_sc"] = "BASIC: ##$basic##\nEach successful pistol hit grants a ##10%## damage boost for ##10## seconds and can stack ##5## times.\n\nACE: ##$pro##\nIncreases the damage boost duration to ##20## seconds.",																								
+		["menu_trigger_happy_beta_desc_sc"] = "BASIC: ##$basic##\nEach successful pistol headshot grants a ##10%## damage boost for ##6## seconds. This effect can stack ##5## times, and the duration of each stack is refreshed on successful pistol headshots.\n\nACE: ##$pro##\nIncreases the damage boost duration to ##9## seconds, and all pistol hits refresh the duration.",																								
 				
 		--Running From Death--
 		["menu_nine_lives_beta_sc"] = "Running from Death",

--- a/lua/sc/loc/loc.lua
+++ b/lua/sc/loc/loc.lua
@@ -906,11 +906,11 @@ Hooks:Add("LocalizationManagerPostInit", "SC_Localization_Skills", function(loc)
 
 		--Desperado--
 		["menu_expert_handling_sc"] = "Desperado",
-		["menu_expert_handling_desc_sc"] = "BASIC: ##$basic##\nEach successful pistol headshot grants a ##15%## accuracy boost for ##6## seconds. This effect can stack ##5## times, and the duration of each stack is refreshed on successful pistol headshots.\n\nACE: ##$pro##\nIncreases the accuracy boost duration to ##9## seconds, and all pistol hits refresh the duration.",																																																																																																																																																																																																																																		
+		["menu_expert_handling_desc_sc"] = "BASIC: ##$basic##\nEach successful pistol headshot grants a ##15%## accuracy boost for ##4## seconds. This effect can stack ##5## times, and the duration of each stack is refreshed on successful pistol headshots.\n\nACE: ##$pro##\nIncreases the accuracy boost duration to ##6## seconds, and all pistol hits refresh the duration.",																																																																																																																																																																																																																																		
 
 		--Trigger Happy--
 		["menu_trigger_happy_beta_sc"] = "Trigger Happy",
-		["menu_trigger_happy_beta_desc_sc"] = "BASIC: ##$basic##\nEach successful pistol headshot grants a ##10%## damage boost for ##6## seconds. This effect can stack ##5## times, and the duration of each stack is refreshed on successful pistol headshots.\n\nACE: ##$pro##\nIncreases the damage boost duration to ##9## seconds, and all pistol hits refresh the duration.",																								
+		["menu_trigger_happy_beta_desc_sc"] = "BASIC: ##$basic##\nEach successful pistol headshot grants a ##10%## damage boost for ##4## seconds. This effect can stack ##5## times, and the duration of each stack is refreshed on successful pistol headshots.\n\nACE: ##$pro##\nIncreases the damage boost duration to ##6## seconds, and all pistol hits refresh the duration.",																								
 				
 		--Running From Death--
 		["menu_nine_lives_beta_sc"] = "Running from Death",

--- a/lua/sc/managers/playermanager.lua
+++ b/lua/sc/managers/playermanager.lua
@@ -605,14 +605,13 @@ if SC and SC._data.sc_ai_toggle or restoration and restoration.Options:GetValue(
 		end
 	end
 
-
 	function PlayerManager:_on_enter_ammo_efficiency_event(unit, attack_data)
 		if not self._coroutine_mgr:is_running("ammo_efficiency") then
 			local weapon_unit = self:equipped_weapon_unit()
 			local attacker_unit = attack_data.attacker_unit
 			local variant = attack_data.variant
 
-			if attacker_unit == self:player_unit() and variant ~= "melee" and weapon_unit and weapon_unit:base():fire_mode() == "single" and weapon_unit:base():is_category("smg", "assault_rifle", "snp") then
+			if attacker_unit == self:player_unit() and variant == "bullet" and weapon_unit and weapon_unit:base():fire_mode() == "single" and weapon_unit:base():is_category("smg", "assault_rifle", "snp") then
 				self._coroutine_mgr:add_coroutine("ammo_efficiency", PlayerAction.AmmoEfficiency, self, self._ammo_efficiency.headshots, self._ammo_efficiency.ammo, Application:time() + self._ammo_efficiency.time)
 			end
 		end

--- a/lua/sc/managers/playermanager.lua
+++ b/lua/sc/managers/playermanager.lua
@@ -613,7 +613,6 @@ if SC and SC._data.sc_ai_toggle or restoration and restoration.Options:GetValue(
 			local variant = attack_data.variant
 
 			if attacker_unit == self:player_unit() and variant ~= "melee" and weapon_unit and weapon_unit:base():fire_mode() == "single" and weapon_unit:base():is_category("smg", "assault_rifle", "snp") then
-				log("First Headshot!")
 				self._coroutine_mgr:add_coroutine("ammo_efficiency", PlayerAction.AmmoEfficiency, self, self._ammo_efficiency.headshots, self._ammo_efficiency.ammo, Application:time() + self._ammo_efficiency.time)
 			end
 		end
@@ -627,7 +626,6 @@ if SC and SC._data.sc_ai_toggle or restoration and restoration.Options:GetValue(
 			local data = self:upgrade_value("pistol", "stacked_accuracy_bonus", nil)
 
 			if data and type(data) ~= "number" then
-				log("BEES!")
 				self._coroutine_mgr:add_coroutine(PlayerAction.ExpertHandling, PlayerAction.ExpertHandling, self, data.accuracy_bonus, data.max_stacks, Application:time() + data.max_time, data.max_time)
 			end
 		end

--- a/lua/sc/player_actions/skills/playeractionammoefficiency.lua
+++ b/lua/sc/player_actions/skills/playeractionammoefficiency.lua
@@ -1,37 +1,39 @@
-PlayerAction.AmmoEfficiency = {
-	Priority = 1,
-	Function = function (player_manager, target_headshots, bullet_refund, target_time)
-		local co = coroutine.running()
-		local time = Application:time()
-		local headshots = 1
+if SC and SC._data.sc_ai_toggle or restoration and restoration.Options:GetValue("SC/SC") then
+	PlayerAction.AmmoEfficiency = {
+		Priority = 1,
+		Function = function (player_manager, target_headshots, bullet_refund, target_time)
+			local co = coroutine.running()
+			local time = Application:time()
+			local headshots = 1
 
-		local function on_headshot(unit, attack_data)
-			local attacker_unit = attack_data.attacker_unit
-			local variant = attack_data.variant
+			local function on_headshot(unit, attack_data)
+				local attacker_unit = attack_data.attacker_unit
+				local variant = attack_data.variant
 
-			if attacker_unit == player_manager:player_unit() and variant == "bullet" then
-				headshots = headshots + 1
+				if attacker_unit == player_manager:player_unit() and variant == "bullet" then
+					headshots = headshots + 1
 
-				if headshots == target_headshots then
-					player_manager:on_ammo_increase(bullet_refund)
-					time = target_time
+					if headshots == target_headshots then
+						player_manager:on_ammo_increase(bullet_refund)
+						time = target_time
+					end
 				end
 			end
-		end
 
-		player_manager:register_message(Message.OnHeadShot, co, on_headshot)
+			player_manager:register_message(Message.OnHeadShot, co, on_headshot)
 
-		while time < target_time do
-			time = Application:time()
-			local weapon_unit = player_manager:equipped_weapon_unit()
+			while time < target_time do
+				time = Application:time()
+				local weapon_unit = player_manager:equipped_weapon_unit()
 
-			if weapon_unit and (weapon_unit:base():fire_mode() ~= "single" or not weapon_unit:base():is_category("smg", "assault_rifle", "snp")) then
-				break
+				if weapon_unit and (weapon_unit:base():fire_mode() ~= "single" or not weapon_unit:base():is_category("smg", "assault_rifle", "snp")) then
+					break
+				end
+
+				coroutine.yield(co)
 			end
 
-			coroutine.yield(co)
+			player_manager:unregister_message(Message.OnHeadShot, co)
 		end
-
-		player_manager:unregister_message(Message.OnHeadShot, co)
-	end
-}
+	}
+end

--- a/lua/sc/player_actions/skills/playeractionammoefficiency.lua
+++ b/lua/sc/player_actions/skills/playeractionammoefficiency.lua
@@ -1,0 +1,37 @@
+PlayerAction.AmmoEfficiency = {
+	Priority = 1,
+	Function = function (player_manager, target_headshots, bullet_refund, target_time)
+		local co = coroutine.running()
+		local time = Application:time()
+		local headshots = 1
+
+		local function on_headshot(unit, attack_data)
+			local attacker_unit = attack_data.attacker_unit
+			local variant = attack_data.variant
+
+			if attacker_unit == player_manager:player_unit() and variant == "bullet" then
+				headshots = headshots + 1
+
+				if headshots == target_headshots then
+					player_manager:on_ammo_increase(bullet_refund)
+					time = target_time
+				end
+			end
+		end
+
+		player_manager:register_message(Message.OnHeadShot, co, on_headshot)
+
+		while time < target_time do
+			time = Application:time()
+			local weapon_unit = player_manager:equipped_weapon_unit()
+
+			if weapon_unit and (weapon_unit:base():fire_mode() ~= "single" or not weapon_unit:base():is_category("smg", "assault_rifle", "snp")) then
+				break
+			end
+
+			coroutine.yield(co)
+		end
+
+		player_manager:unregister_message(Message.OnHeadShot, co)
+	end
+}

--- a/lua/sc/player_actions/skills/playeractiondamagecontrol.lua
+++ b/lua/sc/player_actions/skills/playeractiondamagecontrol.lua
@@ -1,114 +1,116 @@
-PlayerAction.DamageControl = {
-	Priority = 1,
-	Function = function ()
-		local timer = TimerManager:game()
-		local auto_shrug_time = nil
-		local cooldown_drain = managers.player:has_category_upgrade("player", "damage_control_cooldown_drain") and managers.player:upgrade_value("player", "damage_control_cooldown_drain")
-		local damage_delay_values = managers.player:has_category_upgrade("player", "damage_control_passive") and managers.player:upgrade_value("player", "damage_control_passive")
-		local auto_shrug_delay = managers.player:has_category_upgrade("player", "damage_control_auto_shrug") and managers.player:upgrade_value("player", "damage_control_auto_shrug")
-		local shrug_healing = managers.player:has_category_upgrade("player", "damage_control_healing") and managers.player:upgrade_value("player", "damage_control_healing") * 0.01
+if SC and SC._data.sc_ai_toggle or restoration and restoration.Options:GetValue("SC/SC") then
+	PlayerAction.DamageControl = {
+		Priority = 1,
+		Function = function ()
+			local timer = TimerManager:game()
+			local auto_shrug_time = nil
+			local cooldown_drain = managers.player:has_category_upgrade("player", "damage_control_cooldown_drain") and managers.player:upgrade_value("player", "damage_control_cooldown_drain")
+			local damage_delay_values = managers.player:has_category_upgrade("player", "damage_control_passive") and managers.player:upgrade_value("player", "damage_control_passive")
+			local auto_shrug_delay = managers.player:has_category_upgrade("player", "damage_control_auto_shrug") and managers.player:upgrade_value("player", "damage_control_auto_shrug")
+			local shrug_healing = managers.player:has_category_upgrade("player", "damage_control_healing") and managers.player:upgrade_value("player", "damage_control_healing") * 0.01
 
-		if not damage_delay_values then
-			return
-		end
-
-		damage_delay_values = {
-			delay_ratio = damage_delay_values[1] * 0.01,
-			tick_ratio = damage_delay_values[2] * 0.01
-		}
-		if cooldown_drain then
-			cooldown_drain = {
-				health_ratio = cooldown_drain[1] * 0.01,
-				seconds_below = cooldown_drain[2],
-				seconds_above = managers.player:upgrade_value_by_level("player", "damage_control_cooldown_drain", 1)[2]
-			}
-		end
-
-		local function shrug_off_damage()
-			local player_unit = managers.player:player_unit()
-
-			if player_unit then
-				local player_damage = player_unit:character_damage()
-				local remaining_damage = player_damage:clear_delayed_damage()
-				local is_downed = game_state_machine:verify_game_state(GameStateFilters.downed)
-				local swan_song_active = managers.player:has_activate_temporary_upgrade("temporary", "berserker_damage_multiplier")
-
-				if is_downed or swan_song_active then
-					return
-				end
-
-				if shrug_healing then
-					player_damage:restore_health(remaining_damage * shrug_healing, true)
-				end
-			end
-
-			auto_shrug_time = nil
-		end
-
-		local function modify_damage_taken(amount, attack_data)
-			local is_downed = game_state_machine:verify_game_state(GameStateFilters.downed)
-
-			if attack_data.variant == "delayed_tick" or is_downed then
+			if not damage_delay_values then
 				return
 			end
 
-			local player_damage = managers.player:player_unit():character_damage()
-			local removed = amount * damage_delay_values.delay_ratio
-			local duration = 1 / damage_delay_values.tick_ratio
-
-			player_damage:delay_damage(removed, duration)
-
-			if auto_shrug_delay then
-				auto_shrug_time = timer:time() + auto_shrug_delay
-			end
-
-			return -removed
-		end
-
-		local function on_ability_activated(ability_name)
-			if ability_name == "damage_control" then
-				shrug_off_damage()
-			end
-		end
-
-		local function on_enemy_killed(weapon_unit, variant, enemy_unit)
+			damage_delay_values = {
+				delay_ratio = damage_delay_values[1] * 0.01,
+				tick_ratio = damage_delay_values[2] * 0.01
+			}
 			if cooldown_drain then
-				local player = managers.player:player_unit()
-				local low_health = player:character_damage():health_ratio() <= cooldown_drain.health_ratio
-				local seconds = low_health and cooldown_drain.seconds_below or cooldown_drain.seconds_above
+				cooldown_drain = {
+					health_ratio = cooldown_drain[1] * 0.01,
+					seconds_below = cooldown_drain[2],
+					seconds_above = managers.player:upgrade_value_by_level("player", "damage_control_cooldown_drain", 1)[2]
+				}
+			end
 
-				if player then
-					managers.player:speed_up_grenade_cooldown(seconds)
+			local function shrug_off_damage()
+				local player_unit = managers.player:player_unit()
+
+				if player_unit then
+					local player_damage = player_unit:character_damage()
+					local remaining_damage = player_damage:clear_delayed_damage()
+					local is_downed = game_state_machine:verify_game_state(GameStateFilters.downed)
+					local swan_song_active = managers.player:has_activate_temporary_upgrade("temporary", "berserker_damage_multiplier")
+
+					if is_downed or swan_song_active then
+						return
+					end
+
+					if shrug_healing then
+						player_damage:restore_health(remaining_damage * shrug_healing, true)
+					end
+				end
+
+				auto_shrug_time = nil
+			end
+
+			local function modify_damage_taken(amount, attack_data)
+				local is_downed = game_state_machine:verify_game_state(GameStateFilters.downed)
+
+				if attack_data.variant == "delayed_tick" or is_downed then
+					return
+				end
+
+				local player_damage = managers.player:player_unit():character_damage()
+				local removed = amount * damage_delay_values.delay_ratio
+				local duration = 1 / damage_delay_values.tick_ratio
+
+				player_damage:delay_damage(removed, duration)
+
+				if auto_shrug_delay then
+					auto_shrug_time = timer:time() + auto_shrug_delay
+				end
+
+				return -removed
+			end
+
+			local function on_ability_activated(ability_name)
+				if ability_name == "damage_control" then
+					shrug_off_damage()
+				end
+			end
+
+			local function on_enemy_killed(weapon_unit, variant, enemy_unit)
+				if cooldown_drain then
+					local player = managers.player:player_unit()
+					local low_health = player:character_damage():health_ratio() <= cooldown_drain.health_ratio
+					local seconds = low_health and cooldown_drain.seconds_below or cooldown_drain.seconds_above
+
+					if player then
+						managers.player:speed_up_grenade_cooldown(seconds)
+					end
+				end
+			end
+
+			local on_check_skills_key = {}
+			local on_enemy_killed_key = {}
+			local on_ability_activated_key = {}
+
+			managers.player:register_message(Message.OnEnemyKilled, on_enemy_killed_key, on_enemy_killed)
+			managers.player:register_message("ability_activated", on_ability_activated_key, on_ability_activated)
+
+			local damage_taken_key = managers.player:add_modifier("damage_taken", modify_damage_taken)
+
+			local function remove_listeners()
+				managers.player:unregister_message("check_skills", on_check_skills_key)
+				managers.player:unregister_message(Message.OnEnemyKilled, on_enemy_killed_key)
+				managers.player:unregister_message("ability_activated", on_ability_activated_key)
+				managers.player:remove_modifier("damage_taken", damage_taken_key)
+			end
+
+			managers.player:register_message("check_skills", on_check_skills_key, remove_listeners)
+
+			while true do
+				coroutine.yield()
+
+				local now = timer:time()
+
+				if auto_shrug_time and auto_shrug_time <= now then
+					shrug_off_damage()
 				end
 			end
 		end
-
-		local on_check_skills_key = {}
-		local on_enemy_killed_key = {}
-		local on_ability_activated_key = {}
-
-		managers.player:register_message(Message.OnEnemyKilled, on_enemy_killed_key, on_enemy_killed)
-		managers.player:register_message("ability_activated", on_ability_activated_key, on_ability_activated)
-
-		local damage_taken_key = managers.player:add_modifier("damage_taken", modify_damage_taken)
-
-		local function remove_listeners()
-			managers.player:unregister_message("check_skills", on_check_skills_key)
-			managers.player:unregister_message(Message.OnEnemyKilled, on_enemy_killed_key)
-			managers.player:unregister_message("ability_activated", on_ability_activated_key)
-			managers.player:remove_modifier("damage_taken", damage_taken_key)
-		end
-
-		managers.player:register_message("check_skills", on_check_skills_key, remove_listeners)
-
-		while true do
-			coroutine.yield()
-
-			local now = timer:time()
-
-			if auto_shrug_time and auto_shrug_time <= now then
-				shrug_off_damage()
-			end
-		end
-	end
-}
+	}
+end

--- a/lua/sc/player_actions/skills/playeractionexperthandling.lua
+++ b/lua/sc/player_actions/skills/playeractionexperthandling.lua
@@ -3,7 +3,7 @@ PlayerAction.ExpertHandling = {
 	Function = function (player_manager, accuracy_bonus, max_stacks, max_time, add_time)
 		local co = coroutine.running()
 		local current_time = Application:time()
-		local current_stacks = 0
+		local current_stacks = 1
 
 		local function on_headshot(unit, attack_data)
 			local attacker_unit = attack_data.attacker_unit

--- a/lua/sc/player_actions/skills/playeractionexperthandling.lua
+++ b/lua/sc/player_actions/skills/playeractionexperthandling.lua
@@ -11,7 +11,7 @@ PlayerAction.ExpertHandling = {
 
 			if attacker_unit == player_manager:player_unit() and variant == "bullet" then
 				current_stacks = current_stacks + 1
-				log("WowWow!")
+
 				if current_stacks <= max_stacks then
 					player_manager:mul_to_property("desperado", accuracy_bonus)
 				end
@@ -23,7 +23,7 @@ PlayerAction.ExpertHandling = {
 		local function on_hit(unit, attack_data)
 			local attacker_unit = attack_data.attacker_unit
 			local variant = attack_data.variant
-			log("Rough Rider!")
+
 			if attacker_unit == player_manager:player_unit() and variant == "bullet" then
 				max_time = current_time + add_time
 			end

--- a/lua/sc/player_actions/skills/playeractionexperthandling.lua
+++ b/lua/sc/player_actions/skills/playeractionexperthandling.lua
@@ -1,54 +1,56 @@
-PlayerAction.ExpertHandling = {
-	Priority = 1,
-	Function = function (player_manager, accuracy_bonus, max_stacks, max_time, add_time)
-		local co = coroutine.running()
-		local current_time = Application:time()
-		local current_stacks = 1
+if SC and SC._data.sc_ai_toggle or restoration and restoration.Options:GetValue("SC/SC") then
+	PlayerAction.ExpertHandling = {
+		Priority = 1,
+		Function = function (player_manager, accuracy_bonus, max_stacks, max_time, add_time)
+			local co = coroutine.running()
+			local current_time = Application:time()
+			local current_stacks = 1
 
-		local function on_headshot(unit, attack_data)
-			local attacker_unit = attack_data.attacker_unit
-			local variant = attack_data.variant
+			local function on_headshot(unit, attack_data)
+				local attacker_unit = attack_data.attacker_unit
+				local variant = attack_data.variant
 
-			if attacker_unit == player_manager:player_unit() and variant == "bullet" then
-				current_stacks = current_stacks + 1
+				if attacker_unit == player_manager:player_unit() and variant == "bullet" then
+					current_stacks = current_stacks + 1
 
-				if current_stacks <= max_stacks then
-					player_manager:mul_to_property("desperado", accuracy_bonus)
+					if current_stacks <= max_stacks then
+						player_manager:mul_to_property("desperado", accuracy_bonus)
+					end
+				end
+
+				max_time = current_time + add_time
+			end
+
+			local function on_hit(unit, attack_data)
+				local attacker_unit = attack_data.attacker_unit
+				local variant = attack_data.variant
+
+				if attacker_unit == player_manager:player_unit() and variant == "bullet" then
+					max_time = current_time + add_time
 				end
 			end
 
-			max_time = current_time + add_time
-		end
-
-		local function on_hit(unit, attack_data)
-			local attacker_unit = attack_data.attacker_unit
-			local variant = attack_data.variant
-
-			if attacker_unit == player_manager:player_unit() and variant == "bullet" then
-				max_time = current_time + add_time
-			end
-		end
-
-		player_manager:mul_to_property("desperado", accuracy_bonus)
-		player_manager:register_message(Message.OnHeadShot, co, on_headshot)
-		if player_manager:has_category_upgrade("player", "desperado_bodyshot_refresh") then
-			player_manager:register_message(Message.OnEnemyShot, co, on_hit)
-		end
-
-		while current_time < max_time do
-			current_time = Application:time()
-
-			if not player_manager:is_current_weapon_of_category("pistol") then
-				break
+			player_manager:mul_to_property("desperado", accuracy_bonus)
+			player_manager:register_message(Message.OnHeadShot, co, on_headshot)
+			if player_manager:has_category_upgrade("player", "desperado_bodyshot_refresh") then
+				player_manager:register_message(Message.OnEnemyShot, co, on_hit)
 			end
 
-			coroutine.yield(co)
-		end
+			while current_time < max_time do
+				current_time = Application:time()
 
-		player_manager:remove_property("desperado")
-		player_manager:unregister_message(Message.OnHeadShot, co)
-		if player_manager:has_category_upgrade("player", "desperado_bodyshot_refresh") then
-			player_manager:unregister_message(Message.OnEnemyShot, co)
+				if not player_manager:is_current_weapon_of_category("pistol") then
+					break
+				end
+
+				coroutine.yield(co)
+			end
+
+			player_manager:remove_property("desperado")
+			player_manager:unregister_message(Message.OnHeadShot, co)
+			if player_manager:has_category_upgrade("player", "desperado_bodyshot_refresh") then
+				player_manager:unregister_message(Message.OnEnemyShot, co)
+			end
 		end
-	end
-}
+	}
+end

--- a/lua/sc/player_actions/skills/playeractionexperthandling.lua
+++ b/lua/sc/player_actions/skills/playeractionexperthandling.lua
@@ -1,0 +1,54 @@
+PlayerAction.ExpertHandling = {
+	Priority = 1,
+	Function = function (player_manager, accuracy_bonus, max_stacks, max_time, add_time)
+		local co = coroutine.running()
+		local current_time = Application:time()
+		local current_stacks = 0
+
+		local function on_headshot(unit, attack_data)
+			local attacker_unit = attack_data.attacker_unit
+			local variant = attack_data.variant
+
+			if attacker_unit == player_manager:player_unit() and variant == "bullet" then
+				current_stacks = current_stacks + 1
+				log("WowWow!")
+				if current_stacks <= max_stacks then
+					player_manager:mul_to_property("desperado", accuracy_bonus)
+				end
+			end
+
+			max_time = current_time + add_time
+		end
+
+		local function on_hit(unit, attack_data)
+			local attacker_unit = attack_data.attacker_unit
+			local variant = attack_data.variant
+			log("Rough Rider!")
+			if attacker_unit == player_manager:player_unit() and variant == "bullet" then
+				max_time = current_time + add_time
+			end
+		end
+
+		player_manager:mul_to_property("desperado", accuracy_bonus)
+		player_manager:register_message(Message.OnHeadShot, co, on_headshot)
+		if player_manager:has_category_upgrade("player", "desperado_bodyshot_refresh") then
+			player_manager:register_message(Message.OnEnemyShot, co, on_hit)
+		end
+
+		while current_time < max_time do
+			current_time = Application:time()
+
+			if not player_manager:is_current_weapon_of_category("pistol") then
+				break
+			end
+
+			coroutine.yield(co)
+		end
+
+		player_manager:remove_property("desperado")
+		player_manager:unregister_message(Message.OnHeadShot, co)
+		if player_manager:has_category_upgrade("player", "desperado_bodyshot_refresh") then
+			player_manager:unregister_message(Message.OnEnemyShot, co)
+		end
+	end
+}

--- a/lua/sc/player_actions/skills/playeractiontriggerhappy.lua
+++ b/lua/sc/player_actions/skills/playeractiontriggerhappy.lua
@@ -1,54 +1,56 @@
-PlayerAction.TriggerHappy = {
-	Priority = 1,
-	Function = function (player_manager, damage_bonus, max_stacks, max_time, add_time)
-		local co = coroutine.running()
-		local current_time = Application:time()
-		local current_stacks = 1
+if SC and SC._data.sc_ai_toggle or restoration and restoration.Options:GetValue("SC/SC") then
+	PlayerAction.TriggerHappy = {
+		Priority = 1,
+		Function = function (player_manager, damage_bonus, max_stacks, max_time, add_time)
+			local co = coroutine.running()
+			local current_time = Application:time()
+			local current_stacks = 1
 
-		local function on_headshot(unit, attack_data)
-			local attacker_unit = attack_data.attacker_unit
-			local variant = attack_data.variant
+			local function on_headshot(unit, attack_data)
+				local attacker_unit = attack_data.attacker_unit
+				local variant = attack_data.variant
 
-			if attacker_unit == player_manager:player_unit() and variant == "bullet" then
-				current_stacks = current_stacks + 1
+				if attacker_unit == player_manager:player_unit() and variant == "bullet" then
+					current_stacks = current_stacks + 1
 
-				if current_stacks <= max_stacks then
-					player_manager:mul_to_property("trigger_happy", damage_bonus)
+					if current_stacks <= max_stacks then
+						player_manager:mul_to_property("trigger_happy", damage_bonus)
+					end
+				end
+
+				max_time = current_time + add_time
+			end
+
+			local function on_hit(unit, attack_data)
+				local attacker_unit = attack_data.attacker_unit
+				local variant = attack_data.variant
+
+				if attacker_unit == player_manager:player_unit() and variant == "bullet" then
+					max_time = current_time + add_time
 				end
 			end
 
-			max_time = current_time + add_time
-		end
-
-		local function on_hit(unit, attack_data)
-			local attacker_unit = attack_data.attacker_unit
-			local variant = attack_data.variant
-
-			if attacker_unit == player_manager:player_unit() and variant == "bullet" then
-				max_time = current_time + add_time
-			end
-		end
-
-		player_manager:mul_to_property("trigger_happy", damage_bonus)
-		player_manager:register_message(Message.OnHeadShot, co, on_headshot)
-		if player_manager:has_category_upgrade("player", "trigger_happy_bodyshot_refresh") then
-			player_manager:register_message(Message.OnEnemyShot, co, on_hit)
-		end
-
-		while current_time < max_time do
-			current_time = Application:time()
-
-			if not player_manager:is_current_weapon_of_category("pistol") then
-				break
+			player_manager:mul_to_property("trigger_happy", damage_bonus)
+			player_manager:register_message(Message.OnHeadShot, co, on_headshot)
+			if player_manager:has_category_upgrade("player", "trigger_happy_bodyshot_refresh") then
+				player_manager:register_message(Message.OnEnemyShot, co, on_hit)
 			end
 
-			coroutine.yield(co)
-		end
+			while current_time < max_time do
+				current_time = Application:time()
 
-		player_manager:remove_property("trigger_happy")
-		player_manager:unregister_message(Message.OnHeadShot, co)
-		if player_manager:has_category_upgrade("player", "trigger_happy_bodyshot_refresh") then
-			player_manager:unregister_message(Message.OnEnemyShot, co)
+				if not player_manager:is_current_weapon_of_category("pistol") then
+					break
+				end
+
+				coroutine.yield(co)
+			end
+
+			player_manager:remove_property("trigger_happy")
+			player_manager:unregister_message(Message.OnHeadShot, co)
+			if player_manager:has_category_upgrade("player", "trigger_happy_bodyshot_refresh") then
+				player_manager:unregister_message(Message.OnEnemyShot, co)
+			end
 		end
-	end
-}
+	}
+end

--- a/lua/sc/player_actions/skills/playeractiontriggerhappy.lua
+++ b/lua/sc/player_actions/skills/playeractiontriggerhappy.lua
@@ -1,0 +1,54 @@
+PlayerAction.TriggerHappy = {
+	Priority = 1,
+	Function = function (player_manager, damage_bonus, max_stacks, max_time, add_time)
+		local co = coroutine.running()
+		local current_time = Application:time()
+		local current_stacks = 1
+
+		local function on_headshot(unit, attack_data)
+			local attacker_unit = attack_data.attacker_unit
+			local variant = attack_data.variant
+
+			if attacker_unit == player_manager:player_unit() and variant == "bullet" then
+				current_stacks = current_stacks + 1
+
+				if current_stacks <= max_stacks then
+					player_manager:mul_to_property("trigger_happy", damage_bonus)
+				end
+			end
+
+			max_time = current_time + add_time
+		end
+
+		local function on_hit(unit, attack_data)
+			local attacker_unit = attack_data.attacker_unit
+			local variant = attack_data.variant
+
+			if attacker_unit == player_manager:player_unit() and variant == "bullet" then
+				max_time = current_time + add_time
+			end
+		end
+
+		player_manager:mul_to_property("trigger_happy", damage_bonus)
+		player_manager:register_message(Message.OnHeadShot, co, on_headshot)
+		if player_manager:has_category_upgrade("player", "trigger_happy_bodyshot_refresh") then
+			player_manager:register_message(Message.OnEnemyShot, co, on_hit)
+		end
+
+		while current_time < max_time do
+			current_time = Application:time()
+
+			if not player_manager:is_current_weapon_of_category("pistol") then
+				break
+			end
+
+			coroutine.yield(co)
+		end
+
+		player_manager:remove_property("trigger_happy")
+		player_manager:unregister_message(Message.OnHeadShot, co)
+		if player_manager:has_category_upgrade("player", "trigger_happy_bodyshot_refresh") then
+			player_manager:unregister_message(Message.OnEnemyShot, co)
+		end
+	end
+}

--- a/lua/sc/tweak_data/skilltreetweakdata.lua
+++ b/lua/sc/tweak_data/skilltreetweakdata.lua
@@ -1705,7 +1705,8 @@ function SkillTreeTweakData:init(tweak_data)
 				},
 				[2] = {
 					upgrades = {
-						"pistol_stacked_accuracy_bonus_2"
+						"pistol_stacked_accuracy_bonus_2",
+						"player_desperado_bodyshot_refresh"
 					},
 					cost = self.costs.hightierpro
 				}
@@ -1724,7 +1725,8 @@ function SkillTreeTweakData:init(tweak_data)
 				},
 				[2] = {
 					upgrades = {
-						"pistol_stacking_hit_damage_multiplier_2"
+						"pistol_stacking_hit_damage_multiplier_2",
+						"player_trigger_happy_bodyshot_refresh"
 					},
 					cost = self.costs.hightierpro
 				}

--- a/lua/sc/tweak_data/upgradestweakdata.lua
+++ b/lua/sc/tweak_data/upgradestweakdata.lua
@@ -772,23 +772,25 @@ function UpgradesTweakData:_init_pd2_values()
 
 				--Desperado
 				self.values.pistol.stacked_accuracy_bonus = {
-					{accuracy_bonus = 1.1, max_stacks = 5, max_time = 10},
-					{accuracy_bonus = 1.1, max_stacks = 5, max_time = 20}
+					{accuracy_bonus = 0.85, max_stacks = 5, max_time = 6},
+					{accuracy_bonus = 0.85, max_stacks = 5, max_time = 9}
 				}
+				self.values.player.desperado_bodyshot_refresh = {true}
 				
 				--Trigger Happy
 				self.values.pistol.stacking_hit_damage_multiplier = {
 					{
 						damage_bonus = 1.1,
 						max_stacks = 5,
-						max_time = 10
+						max_time = 6
 					},
 					{	
 						damage_bonus = 1.1,
 						max_stacks = 5,
-						max_time = 20
+						max_time = 9
 					}
 				}
+				self.values.player.trigger_happy_bodyshot_refresh = {true}
 
 			--}
 			
@@ -2409,6 +2411,24 @@ function UpgradesTweakData:_saw_definitions()
 		upgrade = {
 			value = 1,
 			upgrade = "spooc_damage_resist",
+			category = "player"
+		}
+	}
+	self.definitions.player_trigger_happy_bodyshot_refresh = {
+		name_id = "menu_player_trigger_happy_bodyshot_refresh",
+		category = "feature",
+		upgrade = {
+			value = 1,
+			upgrade = "trigger_happy_bodyshot_refresh",
+			category = "player"
+		}
+	}
+	self.definitions.player_desperado_bodyshot_refresh = {
+		name_id = "menu_player_desperado_bodyshot_refresh",
+		category = "feature",
+		upgrade = {
+			value = 1,
+			upgrade = "desperado_bodyshot_refresh",
 			category = "player"
 		}
 	}

--- a/lua/sc/tweak_data/upgradestweakdata.lua
+++ b/lua/sc/tweak_data/upgradestweakdata.lua
@@ -794,8 +794,8 @@ function UpgradesTweakData:_init_pd2_values()
 
 				--Desperado
 				self.values.pistol.stacked_accuracy_bonus = {
-					{accuracy_bonus = 0.85, max_stacks = 5, max_time = 6},
-					{accuracy_bonus = 0.85, max_stacks = 5, max_time = 9}
+					{accuracy_bonus = 0.85, max_stacks = 5, max_time = 4},
+					{accuracy_bonus = 0.85, max_stacks = 5, max_time = 6}
 				}
 				self.values.player.desperado_bodyshot_refresh = {true}
 				
@@ -804,12 +804,12 @@ function UpgradesTweakData:_init_pd2_values()
 					{
 						damage_bonus = 1.1,
 						max_stacks = 5,
-						max_time = 6
+						max_time = 4
 					},
 					{	
 						damage_bonus = 1.1,
 						max_stacks = 5,
-						max_time = 9
+						max_time = 6
 					}
 				}
 				self.values.player.trigger_happy_bodyshot_refresh = {true}

--- a/lua/sc/tweak_data/upgradestweakdata.lua
+++ b/lua/sc/tweak_data/upgradestweakdata.lua
@@ -794,8 +794,8 @@ function UpgradesTweakData:_init_pd2_values()
 
 				--Desperado
 				self.values.pistol.stacked_accuracy_bonus = {
-					{accuracy_bonus = 0.85, max_stacks = 5, max_time = 4},
-					{accuracy_bonus = 0.85, max_stacks = 5, max_time = 6}
+					{accuracy_bonus = 0.9, max_stacks = 5, max_time = 4},
+					{accuracy_bonus = 0.9, max_stacks = 5, max_time = 6}
 				}
 				self.values.player.desperado_bodyshot_refresh = {true}
 				

--- a/lua/sc/units/enemies/copdamage.lua
+++ b/lua/sc/units/enemies/copdamage.lua
@@ -32,7 +32,7 @@ if SC and SC._data.sc_player_weapon_toggle or restoration and restoration.Option
 			end
 
 			if head then
-				managers.player:on_headshot_dealt()
+				managers.player:on_headshot_dealt(self._unit, attack_data)
 			end
 		end
 
@@ -344,7 +344,7 @@ if SC and SC._data.sc_player_weapon_toggle or restoration and restoration.Option
 				damage = damage * managers.player:upgrade_value("weapon", "special_damage_taken_multiplier", 1)
 			end
 			if head then
-				managers.player:on_headshot_dealt()
+				managers.player:on_headshot_dealt(self._unit, attack_data)
 				headshot = true
 			end
 		end
@@ -600,7 +600,7 @@ if SC and SC._data.sc_player_weapon_toggle or restoration and restoration.Option
 				damage = damage * managers.player:upgrade_value("weapon", "special_damage_taken_multiplier", 1)
 			end
 			if head then
-				managers.player:on_headshot_dealt()
+				managers.player:on_headshot_dealt(self._unit, attack_data)
 			end
 		end
 		if self._damage_reduction_multiplier then

--- a/main.xml
+++ b/main.xml
@@ -143,6 +143,9 @@
 		<hook file="sc/units/pickups/ammoclip.lua" source_file="lib/units/pickups/ammoclip"/>
 		<hook file="sc/player_actions/skills/playeractionstockholmsyndrometrade.lua" source_file="lib/player_actions/skills/playeractionstockholmsyndrometrade"/>
 		<hook file="sc/player_actions/skills/playeractiondamagecontrol.lua" source_file="lib/player_actions/skills/playeractiondamagecontrol"/>
+		<hook file="sc/player_actions/skills/playeractiontriggerhappy.lua" source_file="lib/player_actions/skills/playeractiontriggerhappy"/>
+		<hook file="sc/player_actions/skills/playeractionexperthandling.lua" source_file="lib/player_actions/skills/playeractionexperthandling"/>
+		<hook file="sc/player_actions/skills/playeractionammoefficiency.lua" source_file="lib/player_actions/skills/playeractionammoefficiency"/>
 		<hook file="sc/units/equipment/sentrygundamage.lua" source_file="lib/units/equipment/sentry_gun/sentrygundamage"/>
 		<hook file="sc/units/enemies/securitycamera.lua" source_file="lib/units/props/securitycamera"/>
 		<hook file="sc/states/ingamewaitingforplayers.lua" source_file="lib/states/ingamewaitingforplayers"/>


### PR DESCRIPTION
Trigger Happy and Desperado now stack off of and have their durations refreshed by headshots. Durations can also be refreshed by body shots if aced. To compensate for the fact that their durations can be refreshed, their durations have been decreased.

Ammo Efficiency no longer procs off of melee headshots while a valid weapon is equipped.

Desperado now increases accuracy, previously it actually decreased it. The conditional_accuracy_multiplier() function in newraycastweaponbase looks for values below 1 as bonuses (hence why skills like Rifleman give multipliers like "0.9"), but Desperado had a stacking value of "1.1". Desperado now has a stacking value of "0.9".