### PR TITLE
Minor duration increase (+2s) to trigger happy/desperado.

### DIFF
--- a/lua/sc/loc/loc.lua
+++ b/lua/sc/loc/loc.lua
@@ -906,11 +906,11 @@ Hooks:Add("LocalizationManagerPostInit", "SC_Localization_Skills", function(loc)
 
 		--Desperado--
 		["menu_expert_handling_sc"] = "Desperado",
-		["menu_expert_handling_desc_sc"] = "BASIC: ##$basic##\nEach successful pistol headshot grants a ##10%## accuracy boost for ##4## seconds. This effect can stack ##5## times, and the duration of each stack is refreshed on successful pistol headshots.\n\nACE: ##$pro##\nIncreases the accuracy boost duration to ##6## seconds, and all pistol hits refresh the duration.",																																																																																																																																																																																																																																		
+		["menu_expert_handling_desc_sc"] = "BASIC: ##$basic##\nEach successful pistol headshot grants a ##10%## accuracy boost for ##6## seconds. This effect can stack ##5## times, and the duration of each stack is refreshed on successful pistol headshots.\n\nACE: ##$pro##\nIncreases the accuracy boost duration to ##8## seconds, and all pistol hits refresh the duration.",																																																																																																																																																																																																																																		
 
 		--Trigger Happy--
 		["menu_trigger_happy_beta_sc"] = "Trigger Happy",
-		["menu_trigger_happy_beta_desc_sc"] = "BASIC: ##$basic##\nEach successful pistol headshot grants a ##10%## damage boost for ##4## seconds. This effect can stack ##5## times, and the duration of each stack is refreshed on successful pistol headshots.\n\nACE: ##$pro##\nIncreases the damage boost duration to ##6## seconds, and all pistol hits refresh the duration.",																								
+		["menu_trigger_happy_beta_desc_sc"] = "BASIC: ##$basic##\nEach successful pistol headshot grants a ##10%## damage boost for ##6## seconds. This effect can stack ##5## times, and the duration of each stack is refreshed on successful pistol headshots.\n\nACE: ##$pro##\nIncreases the damage boost duration to ##8## seconds, and all pistol hits refresh the duration.",																								
 				
 		--Running From Death--
 		["menu_nine_lives_beta_sc"] = "Running from Death",

--- a/lua/sc/tweak_data/upgradestweakdata.lua
+++ b/lua/sc/tweak_data/upgradestweakdata.lua
@@ -794,8 +794,8 @@ function UpgradesTweakData:_init_pd2_values()
 
 				--Desperado
 				self.values.pistol.stacked_accuracy_bonus = {
-					{accuracy_bonus = 0.9, max_stacks = 5, max_time = 4},
-					{accuracy_bonus = 0.9, max_stacks = 5, max_time = 6}
+					{accuracy_bonus = 0.9, max_stacks = 5, max_time = 6},
+					{accuracy_bonus = 0.9, max_stacks = 5, max_time = 8}
 				}
 				self.values.player.desperado_bodyshot_refresh = {true}
 				
@@ -804,12 +804,12 @@ function UpgradesTweakData:_init_pd2_values()
 					{
 						damage_bonus = 1.1,
 						max_stacks = 5,
-						max_time = 4
+						max_time = 6
 					},
 					{	
 						damage_bonus = 1.1,
 						max_stacks = 5,
-						max_time = 6
+						max_time = 8
 					}
 				}
 				self.values.player.trigger_happy_bodyshot_refresh = {true}


### PR DESCRIPTION
Effects offered very little margin for error in maintaining them before, especially when not aced. Should make it a little more reasonable.