### PR TITLE
Fixed Trigger Happy crashes with Pocohud by moving table lookups to coroutine from function header.

### DIFF
--- a/lua/sc/managers/playermanager.lua
+++ b/lua/sc/managers/playermanager.lua
@@ -592,19 +592,6 @@ if SC and SC._data.sc_ai_toggle or restoration and restoration.Options:GetValue(
 		end
 	end
 
-	function PlayerManager:_on_enter_trigger_happy_event(unit, attack_data)
-		local attacker_unit = attack_data.attacker_unit
-		local variant = attack_data.variant
-
-		if attacker_unit == self:player_unit() and variant == "bullet" and not self._coroutine_mgr:is_running("trigger_happy") and self:is_current_weapon_of_category("pistol") then
-			local data = self:upgrade_value("pistol", "stacking_hit_damage_multiplier", 0)
-
-			if data ~= 0 then
-				self._coroutine_mgr:add_coroutine("trigger_happy", PlayerAction.TriggerHappy, self, data.damage_bonus, data.max_stacks, Application:time() + data.max_time, data.max_time)
-			end
-		end
-	end
-
 	function PlayerManager:_on_enter_ammo_efficiency_event(unit, attack_data)
 		if not self._coroutine_mgr:is_running("ammo_efficiency") then
 			local weapon_unit = self:equipped_weapon_unit()
@@ -613,19 +600,6 @@ if SC and SC._data.sc_ai_toggle or restoration and restoration.Options:GetValue(
 
 			if attacker_unit == self:player_unit() and variant == "bullet" and weapon_unit and weapon_unit:base():fire_mode() == "single" and weapon_unit:base():is_category("smg", "assault_rifle", "snp") then
 				self._coroutine_mgr:add_coroutine("ammo_efficiency", PlayerAction.AmmoEfficiency, self, self._ammo_efficiency.headshots, self._ammo_efficiency.ammo, Application:time() + self._ammo_efficiency.time)
-			end
-		end
-	end
-
-	function PlayerManager:_on_expert_handling_event(unit, attack_data)
-		local attacker_unit = attack_data.attacker_unit
-		local variant = attack_data.variant
-
-		if attacker_unit == self:player_unit() and self:is_current_weapon_of_category("pistol") and variant == "bullet" and not self._coroutine_mgr:is_running(PlayerAction.ExpertHandling) then
-			local data = self:upgrade_value("pistol", "stacked_accuracy_bonus", nil)
-
-			if data and type(data) ~= "number" then
-				self._coroutine_mgr:add_coroutine(PlayerAction.ExpertHandling, PlayerAction.ExpertHandling, self, data.accuracy_bonus, data.max_stacks, Application:time() + data.max_time, data.max_time)
 			end
 		end
 	end

--- a/lua/sc/player_actions/skills/playeractionexperthandling.lua
+++ b/lua/sc/player_actions/skills/playeractionexperthandling.lua
@@ -1,10 +1,11 @@
 if SC and SC._data.sc_ai_toggle or restoration and restoration.Options:GetValue("SC/SC") then
 	PlayerAction.ExpertHandling = {
 		Priority = 1,
-		Function = function (player_manager, accuracy_bonus, max_stacks, max_time, add_time)
+		Function = function (player_manager, accuracy_bonus, max_stacks, max_time)
 			local co = coroutine.running()
 			local current_time = Application:time()
 			local current_stacks = 1
+			local add_time = player_manager:upgrade_value("pistol", "stacked_accuracy_bonus", nil).max_time
 
 			local function on_headshot(unit, attack_data)
 				local attacker_unit = attack_data.attacker_unit

--- a/lua/sc/player_actions/skills/playeractiontriggerhappy.lua
+++ b/lua/sc/player_actions/skills/playeractiontriggerhappy.lua
@@ -1,11 +1,12 @@
 if SC and SC._data.sc_ai_toggle or restoration and restoration.Options:GetValue("SC/SC") then
 	PlayerAction.TriggerHappy = {
 		Priority = 1,
-		Function = function (player_manager, damage_bonus, max_stacks, max_time, add_time)
+		Function = function (player_manager, damage_bonus, max_stacks, max_time)
 			local co = coroutine.running()
 			local current_time = Application:time()
 			local current_stacks = 1
-
+			local add_time = player_manager:upgrade_value("pistol", "stacked_accuracy_bonus", nil).max_time
+			
 			local function on_headshot(unit, attack_data)
 				local attacker_unit = attack_data.attacker_unit
 				local variant = attack_data.variant


### PR DESCRIPTION
Pocohud buff trackers will be inaccurate since they cannot take into account duration refresh. The extended duration also stops the tracker from appearing after the first time.