### PR TITLE
Dodge Optimization???

### DIFF
--- a/lua/managers/HUDManager.lua
+++ b/lua/managers/HUDManager.lua
@@ -5,9 +5,12 @@ if SC and SC._data.sc_ai_toggle or restoration and restoration.Options:GetValue(
 		_setup_player_info_hud_pd2_original(self)
 		self._dodge_meter = HUDDodgeMeter:new((managers.hud:script(PlayerBase.PLAYER_INFO_HUD_PD2)))
 	end
-	function HUDManager:set_dodge_value(value, total_dodge)
+	function HUDManager:set_dodge_value(value)
 		--Sends current dodge meter level and players dodge stat to the dodge panel in HUDtemp.lua
-		self._dodge_meter:set_dodge_value(value, total_dodge)
+		self._dodge_meter:set_dodge_value(value)
+	end
+	function HUDManager:unhide_dodge_panel(dodge_points)
+		self._dodge_meter:unhide_dodge_panel(dodge_points)
 	end
 end
 

--- a/lua/managers/hud/HUDTemp.lua
+++ b/lua/managers/hud/HUDTemp.lua
@@ -29,7 +29,8 @@ if SC and SC._data.sc_ai_toggle or restoration and restoration.Options:GetValue(
 		local dodge_bar = self._dodge_panel:rect({
 			name = "dodge_bar",
 			color = Color(0.5, 0.5, 0.8),
-			layer = 1
+			layer = 1,
+			h = 0
 		})
 		local dodge_threshold = self._dodge_panel:rect({
 			name = "dodge_threshold",

--- a/lua/managers/hud/HUDTemp.lua
+++ b/lua/managers/hud/HUDTemp.lua
@@ -65,14 +65,19 @@ if SC and SC._data.sc_ai_toggle or restoration and restoration.Options:GetValue(
 		self._dodge_panel:set_right(1263)
 		self._dodge_panel:set_center_y(360)
 		self._dodge_panel:set_alpha(0) --Hide dodge panel until players actually get dodge.
+		self._dodge_points = 0
 	end
 
-	function HUDDodgeMeter:set_dodge_value(value, total_dodge)
-		self._dodge_panel:set_alpha(1) --Display dodge panel when needed.
-		self._dodge_panel:child("dodge_bar"):set_h((value / (1.5-total_dodge)) * self._dodge_panel:h())
+	function HUDDodgeMeter:unhide_dodge_panel(dodge_points)
+		self._dodge_panel:set_alpha(1)
+		self._dodge_points = dodge_points
+		self._dodge_panel:child("dodge_threshold"):set_center_y((1.0 - ((1.0 - dodge_points) / (1.5 - dodge_points))) * self._dodge_panel:h())
+	end
+
+	function HUDDodgeMeter:set_dodge_value(value)
+		self._dodge_panel:child("dodge_bar"):set_h(self._dodge_panel:h() * value / (1.5 - self._dodge_points))
 		self._dodge_panel:child("dodge_bar"):set_bottom(self._dodge_panel:h())
-		self._dodge_panel:child("dodge_threshold"):set_center_y((1.0 - ((1.0-total_dodge) / (1.5-total_dodge))) * self._dodge_panel:h())
-		if value >= 1.0 - total_dodge then
+		if value >= 1.0 - self._dodge_points then
 			self._dodge_panel:animate(callback(self, self, "_animate_high_dodge"))
 		else
 			self._dodge_panel:stop()

--- a/lua/sc/units/player/playerdamage.lua
+++ b/lua/sc/units/player/playerdamage.lua
@@ -59,6 +59,7 @@ if SC and SC._data.sc_ai_toggle or restoration and restoration.Options:GetValue(
 
 		self._dodge_points = 0.0
 		self._dodge_meter = 0.0 --Amount of dodge built up as meter. Caps at '150' dodge.
+		self._dodge_meter_prev = 0.0 --dodge in meter from previous frame.
 		self._in_smoke_bomb = 0.0 --0 = not in smoke, 1 = inside smoke, 2 = inside own smoke.
 		self._can_survive_one_hit = player_manager:has_category_upgrade("player", "survive_one_hit")
 		self._keep_health_on_revive = false
@@ -647,6 +648,9 @@ if SC and SC._data.sc_ai_toggle or restoration and restoration.Options:GetValue(
 			+managers.player:body_armor_value("dodge")
 			+managers.player:skill_dodge_chance(false, false, false))
 			or 0.0
+		if self._dodge_points > 0 then
+			managers.hud:unhide_dodge_panel(self._dodge_points)
+		end
 	end
 
 	--Adds to/Subtracts from dodge meter and updates hud element.
@@ -657,7 +661,6 @@ if SC and SC._data.sc_ai_toggle or restoration and restoration.Options:GetValue(
 			elseif self._dodge_meter < 1.5 then
 				self._dodge_meter = math.max(math.min(self._dodge_meter + dodge_added, 1.5), 0.0)
 			end
-			managers.hud:set_dodge_value(math.min(self._dodge_meter, 1.5), self._dodge_points) --Goes through Hudmanager.lua then HUDtemp.lua.
 		end
 	end
 
@@ -712,6 +715,11 @@ if SC and SC._data.sc_ai_toggle or restoration and restoration.Options:GetValue(
 		end
 
 		self:fill_dodge_meter(self._dodge_points * dt * passive_dodge)
+
+		if self._dodge_meter ~= self._dodge_meter_prev then
+			managers.hud:set_dodge_value(math.min(self._dodge_meter, 1.5)) --Update UI element once per frame.
+			self._dodge_meter_prev = self._dodge_meter
+		end
 	end)
 
 	Hooks:PostHook(PlayerDamage, "on_downed" , "ResDodgeMeterOnDown" , function(self)


### PR DESCRIPTION
Dodge meter threshold and visibility now calculated on startup.
UI element is now only ever touched once per frame if you gained/lost dodge.

In controlled testing (Enemy Spawner staring at skybox with nothing around comparing standing still, walking, and sprinting with duck and cover aced over 10 second periods away from any collidable objects outside of the ground) no notable framerate difference between moving and sprinting was found. For reference standing still averaged ~210 fps while both sprinting and moving normally resulted in framerates averaging 150. Framedrops from movement are vanilla and are likely the result of the physics system and other related update functions, but it's impossible to know without proper profiling tools. At this point all dodge meter related operations are O(1) using mostly cached variables or table lookups the game already constantly does per frame so any frame drops from it are likely placebo. The only exception is the Sicario Smoke Grenade check which is O(N) for the relevant table- but this is typically an incredibly small list that's only checked while a smoke grenade is out.