### PR TITLE
Putting the Ass in Gas: Grenadier Tear Gas Damage Buffed, Stamina Drain on DS

### DIFF
--- a/lua/sc/units/weapons/quickcsgrenade.lua
+++ b/lua/sc/units/weapons/quickcsgrenade.lua
@@ -7,22 +7,24 @@ if SC and SC._data.sc_ai_toggle or restoration and restoration.Options:GetValue(
 		self._tweak_data = tweak_data.projectiles[grenade_entry]
 		self._radius = self._tweak_data.radius or 300
 		self._radius_blurzone_multiplier = self._tweak_data.radius_blurzone_multiplier or 1.3
-		self._damage_per_tick = 0.4
+		self._damage_per_tick = 0.6
+		self._stamina_per_tick = 0.0
 		if difficulty_index <= 2 then
-			self._damage_tick_period = 0.55
+			self._damage_tick_period = 0.6
 		elseif difficulty_index == 3 then
-			self._damage_tick_period = 0.5
+			self._damage_tick_period = 0.55
 		elseif difficulty_index == 4 then
-			self._damage_tick_period = 0.45
+			self._damage_tick_period = 0.5
 		elseif difficulty_index == 5 then
-			self._damage_tick_period = 0.4
+			self._damage_tick_period = 0.45
 		elseif difficulty_index == 6 then
-			self._damage_tick_period = 0.35
+			self._damage_tick_period = 0.4
 		elseif difficulty_index == 7 then
 			self._damage_tick_period = 0.35
 		else
 			self._damage_tick_period = 0.3
-			self._damage_per_tick = 0.6
+			self._stamina_per_tick = 3
+			self._damage_per_tick = 0.9
 		end
 	end
 	
@@ -70,4 +72,26 @@ if SC and SC._data.sc_ai_toggle or restoration and restoration.Options:GetValue(
 		end
 	end	
 
+	function QuickCsGrenade:_do_damage()
+		local player_unit = managers.player:player_unit()
+
+		if player_unit and mvector3.distance_sq(self._unit:position(), player_unit:position()) < self._tweak_data.radius * self._tweak_data.radius then
+			local attack_data = {
+				damage = self._damage_per_tick,
+				col_ray = {
+					ray = math.UP
+				}
+			}
+
+			player_unit:character_damage():damage_killzone(attack_data)
+			player_unit:movement():subtract_stamina(self._stamina_per_tick)
+			player_unit:movement():_restart_stamina_regen_timer()
+
+			if not self._has_played_VO then
+				PlayerStandard.say_line(player_unit:sound(), "g42x_any")
+
+				self._has_played_VO = true
+			end
+		end
+	end
 end

--- a/lua/sc/units/weapons/quickcsgrenade.lua
+++ b/lua/sc/units/weapons/quickcsgrenade.lua
@@ -84,8 +84,11 @@ if SC and SC._data.sc_ai_toggle or restoration and restoration.Options:GetValue(
 			}
 
 			player_unit:character_damage():damage_killzone(attack_data)
-			player_unit:movement():subtract_stamina(self._stamina_per_tick)
-			player_unit:movement():_restart_stamina_regen_timer()
+
+			if self._stamina_per_tick > 0.0 then
+				player_unit:movement():subtract_stamina(self._stamina_per_tick)
+				player_unit:movement():_restart_stamina_regen_timer()
+			end
 
 			if not self._has_played_VO then
 				PlayerStandard.say_line(player_unit:sound(), "g42x_any")


### PR DESCRIPTION
Tear Gas Grenade per tick damage increased to 6/9 (from 4/6). Tick delay increased by .5s for difficulties below DW.

This works out to the following DPS values:
- Normal: 10
- Hard: 11
- Very Hard: 12
- Overkill: 13
- Mayhem: 15
- Death Wish: 17
- Death Sentence: 30

On DS Tear Gas grenades now drain 3 stamina per tick (10 stamina per second).

Given how avoidable tear gas damage is when compared to almost all other forms of damage, it seems odd that it's such a small amount (especially since many enemies can chunk you for like 50hp without a big neon visual warning). On lower difficulties it can usually be safely ignored, even on higher difficulties it can often be ignored (though tear gas in the open over a downed player is really painful). Upping its damage should allow for it to better fulfill its role of area denial. Breakpoints work out such that even 20 armor suit dodge users can safely sprint through them on DS without suffering from health damage (assuming other enemies aren't shooting them of course, but that would eat their armor anyway). On lower difficulties, this is of course an even longer period of time.