### PR TITLE
Ai stop icon

### DIFF
--- a/loc/english.txt
+++ b/loc/english.txt
@@ -432,6 +432,8 @@
 	"RestorationModProfileDescID" : "Enable or disable alpha Profile Box.",
 	"RestorationModNewsfeedTitleID" : "Alpha Newsfeed",
 	"RestorationModNewsfeedDescID" : "Enable or disable alpha Newsfeed.",
+	"RestorationModUppercaseNamesTitleID" : "Uppercase names",
+	"RestorationModUppercaseNamesDescID" : "Enable or disable uppercase names.",	
 	"RestorationModPeerColorsTitleID" : "Alpha Peer Colors",
 	"RestorationModPeerColorsDescID" : "Enable or disable the alpha peer colors.",
 	"alpha_assault" : "Early Alpha Corner",

--- a/lua/managers/hud/HUDTeammate.lua
+++ b/lua/managers/hud/HUDTeammate.lua
@@ -753,7 +753,12 @@ function HUDTeammate:set_name(teammate_name)
 	local name = teammate_panel:child("name")
 	local name_bg = teammate_panel:child("name_bg")
 	local callsign = teammate_panel:child("callsign")
-	name:set_text( utf8.to_upper( " "..teammate_name ) )
+	if restoration.Options:GetValue("HUD/UppercaseNames") then
+	    name_text = utf8.to_upper( " "..teammate_name ) 
+	else
+	    name_text = " "..teammate_name
+	end
+	name:set_text( name_text )
 	local h = name:h()
 	managers.hud:make_fine_text(name)
 	name:set_h(h)

--- a/main.xml
+++ b/main.xml
@@ -351,6 +351,7 @@
 				<option type="bool" default_value="true" name="MaskOn"/>
 				<option type="bool" default_value="false" name="Hostage"/>
 				<option type="bool" default_value="false" name="Custody"/>
+				<option type="bool" default_value="true" name="UppercaseNames"/>				
 			</option_group>
 			<option_group name="SC">
 				<option type="bool" default_value="false" name="SC" value_changed="RestorationCoreCallbacks:Restart"/>


### PR DESCRIPTION
I noticed that the labels above ai teammates were missing the ai stop icon which I use a lot.

I tried a few different fixes but the only thing that seemed to work for me was to take out the uppercase names on the teammate hud. So I made an option that lets you enable/disable the uppercase names.