### PR TITLE
KS23 fix

### DIFF
--- a/lua/sc/loc/loc.lua
+++ b/lua/sc/loc/loc.lua
@@ -57,6 +57,7 @@ Hooks:Add("LocalizationManagerPostInit", "SC_Localization", function(loc)
 		--Shotgun Generic Mods--
 		["bm_wp_upg_a_slug_sc"] = "AP Slug",
 		["bm_wp_upg_a_slug_sc_desc"] = "Fires a single accurate shotgun slug. Does not pierce.", --Auto/Semi-Auto shotguns--
+		["bm_wp_upg_a_slug_heavy_desc_sc"] = "Fires a single accurate lead slug that penetrates body armor, enemies, shields, titan shields, and walls.", --For shotguns that can hit Heavy Sniper damage tier--
 		["bm_wp_upg_a_explosive_desc_sc"] = "High-explosive slugs. Fires one explosive charge that kills or stuns targets. Cannot headshot.",
 		["bm_wp_ns_duck_desc_sc"] = "Causes pellets to spread horizontally instead of clustering.",
 		["bm_wp_upg_a_custom_desc"] = "Fewer, bigger pellets that increase damage at the cost of some consistency and ammo.",

--- a/lua/sc/tweak_data/weaponfactorytweakdata.lua
+++ b/lua/sc/tweak_data/weaponfactorytweakdata.lua
@@ -25630,7 +25630,11 @@ if self.wpn_fps_shot_ks23 then 	-- Pawcio's KS-23
 				damage_near_mul = 999,
 				damage_far_mul = 999,
 				rays = 1,
-				heavy_AP = true
+				armor_piercing_add = 1,
+				can_shoot_through_enemy = true,
+				can_shoot_through_shield = true,
+				can_shoot_through_wall = true,
+				can_shoot_through_titan_shield = true
 			}
 		self.parts.wpn_fps_upg_ks23_barrel_short.supported = true
 		self.parts.wpn_fps_upg_ks23_barrel_short.stats = {

--- a/lua/sc/tweak_data/weaponfactorytweakdata.lua
+++ b/lua/sc/tweak_data/weaponfactorytweakdata.lua
@@ -25615,6 +25615,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 		
 if self.wpn_fps_shot_ks23 then 	-- Pawcio's KS-23	
 		self.parts.wpn_fps_upg_ks23_ammo_slug.supported = true	
+		self.parts.wpn_fps_upg_ks23_ammo_slug.desc_id = "bm_wp_upg_a_slug_heavy_desc_sc"
 		self.parts.wpn_fps_upg_ks23_ammo_slug.stats = {
 				value = 10,
 				concealment = -5,
@@ -25656,6 +25657,7 @@ if self.wpn_fps_shot_ks23 then 	-- Pawcio's KS-23
 			}
 		self.parts.wpn_fps_upg_ks23_ammo_buckshot_20pellet.pcs = nil
 		self.parts.wpn_fps_upg_ks23_ammo_buckshot_8pellet.supported = true
+		self.parts.wpn_fps_upg_ks23_ammo_buckshot_8pellet.desc_id = "bm_wp_upg_a_custom_desc"
 		self.parts.wpn_fps_upg_ks23_ammo_buckshot_8pellet.stats = {
 				value = 9,
 				damage = 60,	


### PR DESCRIPTION
Giving its Thanatos damage tier slug back its proper piercing since it lost all piercing at some point.
(I know the idea is to replace it with Hammer23, but that hasn't happened yet)