### PR TITLE
Some big changes

### DIFF
--- a/lua/sc/managers/mission/elementspawnenemydummy.lua
+++ b/lua/sc/managers/mission/elementspawnenemydummy.lua
@@ -990,7 +990,7 @@ local federales_zeal = {
 		["units/pd2_dlc_bex/characters/ene_swat_cloaker_policia_federale/ene_swat_cloaker_policia_federale"] = "units/pd2_dlc_bex/characters/ene_swat_cloaker_policia_federale_sc/ene_swat_cloaker_policia_federale_sc",
 		["units/pd2_dlc_bex/characters/ene_swat_shield_policia_federale_mp9/ene_swat_shield_policia_federale_mp9"] = "units/pd2_dlc_bex/characters/ene_swat_shield_policia_federale_mp9_zeal/ene_swat_shield_policia_federale_mp9_zeal",
 		["units/pd2_dlc_bex/characters/ene_swat_shield_policia_federale_c45/ene_swat_shield_policia_federale_c45"] = "units/pd2_dlc_bex/characters/ene_swat_shield_policia_federale_mp9_zeal/ene_swat_shield_policia_federale_mp9_zeal",
-		["units/pd2_dlc_bex/characters/ene_swat_policia_sniper/ene_swat_policia_sniper"] = "units/pd2_dlc_bex/characters/ene_swat_policia_federale_zeal/ene_swat_policia_federale_zeal",	
+		["units/pd2_dlc_bex/characters/ene_swat_policia_sniper/ene_swat_policia_sniper"] = "units/pd2_dlc_bex/characters/ene_swat_policia_sniper_zeal/ene_swat_policia_sniper_zeal",	
 		
 		--fbi swat
 		["units/pd2_dlc_bex/characters/ene_swat_policia_federale_fbi/ene_swat_policia_federale_fbi"] = "units/pd2_dlc_bex/characters/ene_swat_policia_federale_zeal/ene_swat_policia_federale_zeal",

--- a/lua/sc/managers/modifiersmanager.lua
+++ b/lua/sc/managers/modifiersmanager.lua
@@ -16,6 +16,8 @@ if ai_type == b then
 		["units/pd2_dlc_bex/characters/ene_swat_heavy_policia_federale/ene_swat_heavy_policia_federale"] = "units/pd2_dlc_bex/characters/ene_swat_heavy_policia_federale_fbi_g36/ene_swat_heavy_policia_federale_fbi_g36",
 		--Federales FBI Heavy Shotgun
 		["units/pd2_dlc_bex/characters/ene_swat_heavy_policia_federale/ene_swat_heavy_policia_federale_r870"] = "units/pd2_dlc_bex/characters/ene_swat_heavy_policia_federale_fbi_r870/ene_swat_heavy_policia_federale_fbi_r870",
+		--Federales FBI Shield
+		["units/pd2_dlc_bex/characters/ene_swat_shield_policia_federale_c45/ene_swat_shield_policia_federale_c45"] = "units/pd2_dlc_bex/characters/ene_swat_shield_policia_federale_mp9_fbi/ene_swat_shield_policia_federale_mp9_fbi",
 		
 		--Mex Bravo Rifle
 		["units/pd2_dlc_bex/characters/ene_swat_policia_federale_fbi/ene_swat_policia_federale_fbi"] = "units/pd2_mod_bravo/characters/ene_bravo_rifle_mex/ene_bravo_rifle_mex",
@@ -77,6 +79,8 @@ elseif ai_type == m then
 		["units/pd2_mod_sharks/characters/ene_swat_heavy_1/ene_swat_heavy_1"] = "units/pd2_mod_sharks/characters/ene_fbi_heavy_1/ene_fbi_heavy_1",
 		--Murky FBI Heavy Shotgun
 		["units/pd2_mod_sharks/characters/ene_swat_heavy_r870/ene_swat_heavy_r870"] = "units/pd2_mod_sharks/characters/ene_fbi_heavy_r870/ene_fbi_heavy_r870",
+		--Murky FBI Shield
+		["units/pd2_mod_sharks/characters/ene_murky_shield_yellow/ene_murky_shield_yellow"] = "units/pd2_mod_sharks/characters/ene_murky_shield_fbi/ene_murky_shield_fbi",
 		
 		--Murky Bravo Rifle
 		["units/pd2_mod_sharks/characters/ene_fbi_swat_1/ene_fbi_swat_1"] = "units/pd2_mod_bravo/characters/ene_bravo_rifle_murky/ene_bravo_rifle_murky",
@@ -96,19 +100,23 @@ else
 		--FBI Rifle
 		["units/payday2/characters/ene_swat_1_sc/ene_swat_1_sc"] = "units/payday2/characters/ene_fbi_swat_1_sc/ene_fbi_swat_1_sc",
 		["units/pd2_mod_nypd/characters/ene_nypd_swat_1/ene_nypd_swat_1"] = "units/pd2_mod_nypd/characters/ene_fbi_swat_1/ene_fbi_swat_1",
-		["units/pd2_mod_lapd/characters/ene_lapd_light_1/ene_lapd_light_1"] = "units/pd2_mod_lapd/characters/ene_fbi_swat_1/ene_fbi_swat_1",
+		["units/pd2_mod_lapd/characters/ene_swat_1/ene_swat_1"] = "units/pd2_mod_lapd/characters/ene_fbi_swat_1/ene_fbi_swat_1",
 		--FBI Shotgun
 		["units/payday2/characters/ene_swat_2_sc/ene_swat_2_sc"] = "units/payday2/characters/ene_fbi_swat_2_sc/ene_fbi_swat_2_sc",
 		["units/pd2_mod_nypd/characters/ene_nypd_swat_2/ene_nypd_swat_2"] = "units/pd2_mod_nypd/characters/ene_fbi_swat_2/ene_fbi_swat_2",
-		["units/pd2_mod_lapd/characters/ene_lapd_light_2/ene_lapd_light_2"] = "units/pd2_mod_lapd/characters/ene_fbi_swat_2/ene_fbi_swat_2",
+		["units/pd2_mod_lapd/characters/ene_swat_2/ene_swat_2"] = "units/pd2_mod_lapd/characters/ene_fbi_swat_2/ene_fbi_swat_2",
 		--FBI Heavy Rifle
 		["units/payday2/characters/ene_swat_heavy_1_sc/ene_swat_heavy_1_sc"] = "units/payday2/characters/ene_fbi_heavy_1/ene_fbi_heavy_1",
 		["units/pd2_mod_nypd/characters/ene_nypd_heavy_m4/ene_nypd_heavy_m4"] = "units/pd2_mod_nypd/characters/ene_fbi_heavy_1/ene_fbi_heavy_1",
-		["units/pd2_mod_lapd/characters/ene_lapd_heavy_1/ene_lapd_heavy_1"] = "units/pd2_mod_lapd/characters/ene_fbi_heavy_1/ene_fbi_heavy_1",
+		["units/pd2_mod_lapd/characters/ene_swat_heavy_1/ene_swat_heavy_1"] = "units/pd2_mod_lapd/characters/ene_fbi_heavy_1/ene_fbi_heavy_1",
 		--FBI Heavy Shotgun
 		["units/payday2/characters/ene_swat_heavy_r870_sc/ene_swat_heavy_r870_sc"] = "units/payday2/characters/ene_fbi_heavy_r870_sc/ene_fbi_heavy_r870_sc",
 		["units/pd2_mod_nypd/characters/ene_nypd_heavy_r870/ene_nypd_heavy_r870"] = "units/pd2_mod_nypd/characters/ene_fbi_heavy_r870_sc/ene_fbi_heavy_r870_sc",
-		["units/pd2_mod_lapd/characters/ene_lapd_heavy_2/ene_lapd_heavy_2"] = "units/pd2_mod_lapd/characters/ene_fbi_heavy_r870_sc/ene_fbi_heavy_r870_sc",
+		["units/pd2_mod_lapd/characters/ene_swat_heavy_r870/ene_swat_heavy_r870"] = "units/pd2_mod_lapd/characters/ene_fbi_heavy_r870_sc/ene_fbi_heavy_r870_sc",
+		--FBI Shield
+		["units/payday2/characters/ene_shield_2_sc/ene_shield_2_sc"] = "units/payday2/characters/ene_shield_1_sc/ene_shield_1_sc",
+		["units/pd2_mod_nypd/characters/ene_nypd_shield/ene_nypd_shield"] = "units/pd2_mod_nypd/characters/ene_shield_1/ene_shield_1",
+		["units/pd2_mod_lapd/characters/ene_shield_2/ene_shield_2"] = "units/pd2_mod_lapd/characters/ene_shield_1/ene_shield_1",
 		
 		--Bravo Rifle
 		["units/pd2_mod_lapd/characters/ene_fbi_swat_1/ene_fbi_swat_1"] = "units/pd2_mod_bravo/characters/ene_bravo_rifle/ene_bravo_rifle",

--- a/packages/america_diff/hard_sc_america.xml
+++ b/packages/america_diff/hard_sc_america.xml
@@ -162,6 +162,13 @@
     <object				path="units/payday2/characters/ene_fbi_heavy_r870_sc/ene_fbi_heavy_r870_sc"/>
 	<cooked_physics		path="units/payday2/characters/ene_fbi_heavy_r870_sc/ene_fbi_heavy_r870_sc"/>
 	<model				path="units/payday2/characters/ene_fbi_heavy_r870_sc/ene_fbi_heavy_r870_sc"/>
+	
+	<!-- shield -->
+	<unit				path="units/payday2/characters/ene_shield_1_sc/ene_shield_1_sc" load="true"/>
+	<unit				path="units/payday2/characters/ene_shield_1_sc/ene_shield_1_sc_husk" load="true"/>
+	<object				path="units/payday2/characters/ene_shield_1_sc/ene_shield_1_sc" />	
+	<model				path="units/payday2/characters/ene_shield_1_sc/ene_shield_1_sc" />	
+	<cooked_physics		path="units/payday2/characters/ene_shield_1_sc/ene_shield_1_sc" />
 
 	<texture			path="units/payday2/characters/shared_textures/helmet_shotgun_df" />
 	<texture			path="units/payday2/characters/shared_textures/helmet_shotgun_nm" />				

--- a/packages/america_diff/normal_sc_america.xml
+++ b/packages/america_diff/normal_sc_america.xml
@@ -164,6 +164,13 @@
 	<cooked_physics		path="units/payday2/characters/ene_fbi_heavy_r870_sc/ene_fbi_heavy_r870_sc"/>
 	<model				path="units/payday2/characters/ene_fbi_heavy_r870_sc/ene_fbi_heavy_r870_sc"/>
 	
+	<!-- shield -->
+	<unit				path="units/payday2/characters/ene_shield_1_sc/ene_shield_1_sc" load="true"/>
+	<unit				path="units/payday2/characters/ene_shield_1_sc/ene_shield_1_sc_husk" load="true"/>
+	<object				path="units/payday2/characters/ene_shield_1_sc/ene_shield_1_sc" />	
+	<model				path="units/payday2/characters/ene_shield_1_sc/ene_shield_1_sc" />	
+	<cooked_physics		path="units/payday2/characters/ene_shield_1_sc/ene_shield_1_sc" />
+	
 	<texture			path="units/payday2/characters/shared_textures/helmet_shotgun_df" />
 	<texture			path="units/payday2/characters/shared_textures/helmet_shotgun_nm" />				
 	<!-- fbi tier end -->

--- a/packages/federales_diff/hard_sc_federales.xml
+++ b/packages/federales_diff/hard_sc_federales.xml
@@ -191,7 +191,27 @@
 	<unit				path="units/pd2_dlc_bex/characters/ene_swat_heavy_policia_federale_fbi_r870/ene_swat_heavy_policia_federale_fbi_r870"  load="true"/>
 	<material_config	path="units/pd2_dlc_bex/characters/ene_swat_heavy_policia_federale_fbi_r870/ene_swat_heavy_policia_federale_fbi_r870" />
 	<material_config	path="units/pd2_dlc_bex/characters/ene_swat_heavy_policia_federale_fbi_r870/ene_swat_heavy_policia_federale_fbi_r870_contour" />
-	<unit				path="units/pd2_dlc_bex/characters/ene_swat_heavy_policia_federale_fbi_r870/ene_swat_heavy_policia_federale_fbi_r870_husk"  load="true"/>		
+	<unit				path="units/pd2_dlc_bex/characters/ene_swat_heavy_policia_federale_fbi_r870/ene_swat_heavy_policia_federale_fbi_r870_husk"  load="true"/>	
+	
+	<!--shield no idea why i made a unique model for him but he's the homie-->
+	<material_config	path="units/pd2_dlc_bex/characters/ene_swat_shield_policia_federale_mp9_fbi/ene_swat_shield_policia_federale_mp9_fbi_contour" />	
+	<material_config	path="units/pd2_dlc_bex/characters/ene_swat_shield_policia_federale_mp9_fbi/ene_swat_shield_policia_federale_mp9_fbi" />
+	<object				path="units/pd2_dlc_bex/characters/ene_swat_shield_policia_federale_mp9_fbi/ene_swat_shield_policia_federale_mp9_fbi" />
+	<model				path="units/pd2_dlc_bex/characters/ene_swat_shield_policia_federale_mp9_fbi/ene_swat_shield_policia_federale_mp9_fbi" />	
+	<unit				path="units/pd2_dlc_bex/characters/ene_swat_shield_policia_federale_mp9_fbi/ene_swat_shield_policia_federale_mp9_fbi_husk" load="true"/>	
+	<unit				path="units/pd2_dlc_bex/characters/ene_swat_shield_policia_federale_mp9_fbi/ene_swat_shield_policia_federale_mp9_fbi" load="true"/>	
+	<cooked_physics		path="units/pd2_dlc_bex/characters/ene_swat_shield_policia_federale_mp9_fbi/ene_swat_shield_policia_federale_mp9_fbi"/>	
+	
+	<!--big shield acc-->
+	<sequence_manager	path="units/pd2_dlc_bex/characters/ene_acc_shield_lights_sc/ene_acc_shield_lights_sc" />
+	<cooked_physics		path="units/pd2_dlc_bex/characters/ene_acc_shield_lights_sc/ene_acc_shield_lights_sc" />
+	<object				path="units/pd2_dlc_bex/characters/ene_acc_shield_lights_sc/ene_acc_shield_lights_sc" />
+	<model				path="units/pd2_dlc_bex/characters/ene_acc_shield_lights_sc/ene_acc_shield_lights_sc" />
+	<unit				path="units/pd2_dlc_bex/characters/ene_acc_shield_lights_sc/ene_acc_shield_lights_sc" load="true"/>
+	<texture			path="units/pd2_dlc_bex/characters/shared_textures/ene_acc_shield_lights_df" />
+	<material_config	path="units/pd2_dlc_bex/characters/ene_acc_shield_lights_sc/ene_acc_shield_lights_sc"/>
+
+	
 	<!-- fbi tier end -->
 	
 	<!-- specials-->

--- a/packages/federales_diff/normal_sc_federales.xml
+++ b/packages/federales_diff/normal_sc_federales.xml
@@ -186,7 +186,26 @@
 	<unit				path="units/pd2_dlc_bex/characters/ene_swat_heavy_policia_federale_fbi_r870/ene_swat_heavy_policia_federale_fbi_r870"  load="true"/>
 	<material_config	path="units/pd2_dlc_bex/characters/ene_swat_heavy_policia_federale_fbi_r870/ene_swat_heavy_policia_federale_fbi_r870" />
 	<material_config	path="units/pd2_dlc_bex/characters/ene_swat_heavy_policia_federale_fbi_r870/ene_swat_heavy_policia_federale_fbi_r870_contour" />
-	<unit				path="units/pd2_dlc_bex/characters/ene_swat_heavy_policia_federale_fbi_r870/ene_swat_heavy_policia_federale_fbi_r870_husk"  load="true"/>		
+	<unit				path="units/pd2_dlc_bex/characters/ene_swat_heavy_policia_federale_fbi_r870/ene_swat_heavy_policia_federale_fbi_r870_husk"  load="true"/>
+	
+	<!--shield no idea why i made a unique model for him but he's the homie-->
+	<material_config	path="units/pd2_dlc_bex/characters/ene_swat_shield_policia_federale_mp9_fbi/ene_swat_shield_policia_federale_mp9_fbi_contour" />	
+	<material_config	path="units/pd2_dlc_bex/characters/ene_swat_shield_policia_federale_mp9_fbi/ene_swat_shield_policia_federale_mp9_fbi" />
+	<object				path="units/pd2_dlc_bex/characters/ene_swat_shield_policia_federale_mp9_fbi/ene_swat_shield_policia_federale_mp9_fbi" />
+	<model				path="units/pd2_dlc_bex/characters/ene_swat_shield_policia_federale_mp9_fbi/ene_swat_shield_policia_federale_mp9_fbi" />	
+	<unit				path="units/pd2_dlc_bex/characters/ene_swat_shield_policia_federale_mp9_fbi/ene_swat_shield_policia_federale_mp9_fbi_husk" load="true"/>	
+	<unit				path="units/pd2_dlc_bex/characters/ene_swat_shield_policia_federale_mp9_fbi/ene_swat_shield_policia_federale_mp9_fbi" load="true"/>	
+	<cooked_physics		path="units/pd2_dlc_bex/characters/ene_swat_shield_policia_federale_mp9_fbi/ene_swat_shield_policia_federale_mp9_fbi"/>	
+	
+	<!--big shield acc-->
+	<sequence_manager	path="units/pd2_dlc_bex/characters/ene_acc_shield_lights_sc/ene_acc_shield_lights_sc" />
+	<cooked_physics		path="units/pd2_dlc_bex/characters/ene_acc_shield_lights_sc/ene_acc_shield_lights_sc" />
+	<object				path="units/pd2_dlc_bex/characters/ene_acc_shield_lights_sc/ene_acc_shield_lights_sc" />
+	<model				path="units/pd2_dlc_bex/characters/ene_acc_shield_lights_sc/ene_acc_shield_lights_sc" />
+	<unit				path="units/pd2_dlc_bex/characters/ene_acc_shield_lights_sc/ene_acc_shield_lights_sc" load="true"/>
+	<texture			path="units/pd2_dlc_bex/characters/shared_textures/ene_acc_shield_lights_df" />
+	<material_config	path="units/pd2_dlc_bex/characters/ene_acc_shield_lights_sc/ene_acc_shield_lights_sc"/>
+	
 	<!-- fbi tier end -->
 	
 	<!-- specials-->

--- a/packages/lapd_diff/hard_sc_lapd.xml
+++ b/packages/lapd_diff/hard_sc_lapd.xml
@@ -216,6 +216,14 @@
 	<model				path="units/pd2_mod_lapd/characters/ene_fbi_heavy_1/ene_fbi_heavy_1" />	
 	<material_config	path="units/pd2_mod_lapd/characters/ene_fbi_heavy_1/ene_fbi_heavy_1" />	
 	<material_config	path="units/pd2_mod_lapd/characters/ene_fbi_heavy_1/ene_fbi_heavy_1_contour" />	
+	
+	<!--shield-->
+    <unit				path="units/pd2_mod_lapd/characters/ene_shield_1/ene_shield_1" load="true"/>
+    <unit				path="units/pd2_mod_lapd/characters/ene_shield_1/ene_shield_1_husk" load="true"/>
+    <object				path="units/pd2_mod_lapd/characters/ene_shield_1/ene_shield_1"/>
+	<cooked_physics		path="units/pd2_mod_lapd/characters/ene_shield_1/ene_shield_1"/>
+	<model				path="units/pd2_mod_lapd/characters/ene_shield_1/ene_shield_1"/>
+	
 	<!-- fbi tier end -->
 	
 	<!-- specials-->

--- a/packages/lapd_diff/normal_sc_lapd.xml
+++ b/packages/lapd_diff/normal_sc_lapd.xml
@@ -216,6 +216,14 @@
 	<model				path="units/pd2_mod_lapd/characters/ene_fbi_heavy_1/ene_fbi_heavy_1" />	
 	<material_config	path="units/pd2_mod_lapd/characters/ene_fbi_heavy_1/ene_fbi_heavy_1" />	
 	<material_config	path="units/pd2_mod_lapd/characters/ene_fbi_heavy_1/ene_fbi_heavy_1_contour" />	
+	
+	<!--shield-->
+    <unit				path="units/pd2_mod_lapd/characters/ene_shield_1/ene_shield_1" load="true"/>
+    <unit				path="units/pd2_mod_lapd/characters/ene_shield_1/ene_shield_1_husk" load="true"/>
+    <object				path="units/pd2_mod_lapd/characters/ene_shield_1/ene_shield_1"/>
+	<cooked_physics		path="units/pd2_mod_lapd/characters/ene_shield_1/ene_shield_1"/>
+	<model				path="units/pd2_mod_lapd/characters/ene_shield_1/ene_shield_1"/>
+	
 	<!-- fbi tier end -->
 	
 	<!-- specials-->

--- a/packages/lapd_diff/overkill_145_sc_lapd.xml
+++ b/packages/lapd_diff/overkill_145_sc_lapd.xml
@@ -231,7 +231,16 @@
     <unit				path="units/pd2_mod_lapd/characters/ene_shield_1/ene_shield_1_husk" load="true"/>
     <object				path="units/pd2_mod_lapd/characters/ene_shield_1/ene_shield_1"/>
 	<cooked_physics		path="units/pd2_mod_lapd/characters/ene_shield_1/ene_shield_1"/>
-	<model				path="units/pd2_mod_lapd/characters/ene_shield_1/ene_shield_1"/>		
+	<model				path="units/pd2_mod_lapd/characters/ene_shield_1/ene_shield_1"/>
+	
+	<!-- sniper -->
+    <unit				path="units/payday2/characters/ene_sniper_2_sc/ene_sniper_2_sc" load="true"/>
+    <unit				path="units/payday2/characters/ene_sniper_2_sc/ene_sniper_2_sc_husk" load="true"/>	
+	<model				path="units/payday2/characters/ene_sniper_2_sc/ene_sniper_2_sc" />	
+	<object				path="units/payday2/characters/ene_sniper_2_sc/ene_sniper_2_sc" />	
+	<material_config	path="units/payday2/characters/ene_sniper_2_sc/ene_sniper_2_sc" />	
+	<material_config	path="units/payday2/characters/ene_sniper_2_sc/ene_sniper_2_sc_contour" />	
+	<cooked_physics		path="units/payday2/characters/ene_sniper_2_sc/ene_sniper_2_sc" />
 	<!-- fbi tier end -->
 	
 	<!-- specials-->

--- a/packages/lapd_diff/overkill_sc_lapd.xml
+++ b/packages/lapd_diff/overkill_sc_lapd.xml
@@ -225,6 +225,13 @@
 	<model				path="units/pd2_mod_lapd/characters/ene_fbi_heavy_1/ene_fbi_heavy_1" />	
 	<material_config	path="units/pd2_mod_lapd/characters/ene_fbi_heavy_1/ene_fbi_heavy_1" />	
 	<material_config	path="units/pd2_mod_lapd/characters/ene_fbi_heavy_1/ene_fbi_heavy_1_contour" />
+	
+	<!--shield-->
+    <unit				path="units/pd2_mod_lapd/characters/ene_shield_1/ene_shield_1" load="true"/>
+    <unit				path="units/pd2_mod_lapd/characters/ene_shield_1/ene_shield_1_husk" load="true"/>
+    <object				path="units/pd2_mod_lapd/characters/ene_shield_1/ene_shield_1"/>
+	<cooked_physics		path="units/pd2_mod_lapd/characters/ene_shield_1/ene_shield_1"/>
+	<model				path="units/pd2_mod_lapd/characters/ene_shield_1/ene_shield_1"/>
 
 	<!-- sniper -->
     <unit				path="units/payday2/characters/ene_sniper_2_sc/ene_sniper_2_sc" load="true"/>

--- a/packages/murkywater_diff/hard_sc_murkywater.xml
+++ b/packages/murkywater_diff/hard_sc_murkywater.xml
@@ -155,6 +155,21 @@
 	<!-- blue swat tier end -->
 	
 	<!--for pro jobs-->
+	<!--Murky Shield Acc Lights-->
+	<unit				path="units/pd2_mod_sharks/characters/ene_acc_shield_murky_shield/ene_acc_shield_murky" load="false"/>
+	<model				path="units/pd2_mod_sharks/characters/ene_acc_shield_murky_shield/ene_acc_shield_murky" force="false"/>
+	<object				path="units/pd2_mod_sharks/characters/ene_acc_shield_murky_shield/ene_acc_shield_murky" force="false"/>
+	<material_config	path="units/pd2_mod_sharks/characters/ene_acc_shield_murky_shield/ene_acc_shield_murky" force="false"/>
+	<cooked_physics		path="units/pd2_mod_sharks/characters/ene_acc_shield_murky_shield/ene_acc_shield_murky" force="false"/>
+	<texture			path="units/pd2_mod_sharks/characters/shared_textures/shield_df"/>		
+	
+	<!-- shield -->
+	<unit				path="units/pd2_mod_sharks/characters/ene_murky_shield_fbi/ene_murky_shield_fbi" force="false" load="true"/>
+	<unit				path="units/pd2_mod_sharks/characters/ene_murky_shield_fbi/ene_murky_shield_fbi_husk" force="false" load="true"/>
+	<object				path="units/pd2_mod_sharks/characters/ene_fbi_swat_3/ene_fbi_swat_3" force="false"/>
+	<cooked_physics		path="units/pd2_mod_sharks/characters/ene_fbi_swat_3/ene_fbi_swat_3" force="false"/>
+	<model				path="units/pd2_mod_sharks/characters/ene_fbi_swat_3/ene_fbi_swat_3" force="false"/>
+	
 	<!--Murky FBI SWAT M4-->
 	<object				path="units/pd2_mod_sharks/characters/ene_fbi_swat_1/ene_fbi_swat_1" force="false"/>
 	<cooked_physics		path="units/pd2_mod_sharks/characters/ene_fbi_swat_1/ene_fbi_swat_1" force="false"/>

--- a/packages/murkywater_diff/normal_sc_murkywater.xml
+++ b/packages/murkywater_diff/normal_sc_murkywater.xml
@@ -155,6 +155,21 @@
 	<!-- blue swat tier end -->
 	
 	<!--for pro jobs-->
+	<!--Murky Shield Acc Lights-->
+	<unit				path="units/pd2_mod_sharks/characters/ene_acc_shield_murky_shield/ene_acc_shield_murky" load="false"/>
+	<model				path="units/pd2_mod_sharks/characters/ene_acc_shield_murky_shield/ene_acc_shield_murky" force="false"/>
+	<object				path="units/pd2_mod_sharks/characters/ene_acc_shield_murky_shield/ene_acc_shield_murky" force="false"/>
+	<material_config	path="units/pd2_mod_sharks/characters/ene_acc_shield_murky_shield/ene_acc_shield_murky" force="false"/>
+	<cooked_physics		path="units/pd2_mod_sharks/characters/ene_acc_shield_murky_shield/ene_acc_shield_murky" force="false"/>
+	<texture			path="units/pd2_mod_sharks/characters/shared_textures/shield_df"/>		
+	
+	<!-- shield -->
+	<unit				path="units/pd2_mod_sharks/characters/ene_murky_shield_fbi/ene_murky_shield_fbi" force="false" load="true"/>
+	<unit				path="units/pd2_mod_sharks/characters/ene_murky_shield_fbi/ene_murky_shield_fbi_husk" force="false" load="true"/>
+	<object				path="units/pd2_mod_sharks/characters/ene_fbi_swat_3/ene_fbi_swat_3" force="false"/>
+	<cooked_physics		path="units/pd2_mod_sharks/characters/ene_fbi_swat_3/ene_fbi_swat_3" force="false"/>
+	<model				path="units/pd2_mod_sharks/characters/ene_fbi_swat_3/ene_fbi_swat_3" force="false"/>
+	
 	<!--Murky FBI SWAT M4-->
 	<object				path="units/pd2_mod_sharks/characters/ene_fbi_swat_1/ene_fbi_swat_1" force="false"/>
 	<cooked_physics		path="units/pd2_mod_sharks/characters/ene_fbi_swat_1/ene_fbi_swat_1" force="false"/>

--- a/packages/nypd_diff/hard_sc_nypd.xml
+++ b/packages/nypd_diff/hard_sc_nypd.xml
@@ -220,6 +220,13 @@
 	<cooked_physics		path="units/pd2_mod_nypd/characters/ene_fbi_heavy_r870_sc/ene_fbi_heavy_r870_sc"/>
 	<model				path="units/pd2_mod_nypd/characters/ene_fbi_heavy_r870_sc/ene_fbi_heavy_r870_sc"/>
 	
+	<!--shield-->
+	<unit				path="units/pd2_mod_nypd/characters/ene_shield_1/ene_shield_1" load="true"/>
+	<unit				path="units/pd2_mod_nypd/characters/ene_shield_1/ene_shield_1_husk" load="true"/>
+	<object				path="units/pd2_mod_nypd/characters/ene_shield_1/ene_shield_1" />	
+	<model				path="units/pd2_mod_nypd/characters/ene_shield_1/ene_shield_1" />	
+	<cooked_physics		path="units/pd2_mod_nypd/characters/ene_shield_1/ene_shield_1" />
+	
 	<!-- fbi tier end -->
 	
 	<!-- specials-->

--- a/packages/nypd_diff/normal_sc_nypd.xml
+++ b/packages/nypd_diff/normal_sc_nypd.xml
@@ -220,6 +220,13 @@
 	<cooked_physics		path="units/pd2_mod_nypd/characters/ene_fbi_heavy_r870_sc/ene_fbi_heavy_r870_sc"/>
 	<model				path="units/pd2_mod_nypd/characters/ene_fbi_heavy_r870_sc/ene_fbi_heavy_r870_sc"/>
 	
+	<!--shield-->
+	<unit				path="units/pd2_mod_nypd/characters/ene_shield_1/ene_shield_1" load="true"/>
+	<unit				path="units/pd2_mod_nypd/characters/ene_shield_1/ene_shield_1_husk" load="true"/>
+	<object				path="units/pd2_mod_nypd/characters/ene_shield_1/ene_shield_1" />	
+	<model				path="units/pd2_mod_nypd/characters/ene_shield_1/ene_shield_1" />	
+	<cooked_physics		path="units/pd2_mod_nypd/characters/ene_shield_1/ene_shield_1" />
+	
 	<!-- fbi tier end -->
 	
 	<!-- specials-->

--- a/packages/nypd_diff/overkill_sc_nypd.xml
+++ b/packages/nypd_diff/overkill_sc_nypd.xml
@@ -227,7 +227,8 @@
     <object				path="units/pd2_mod_nypd/characters/ene_fbi_heavy_r870_sc/ene_fbi_heavy_r870_sc"/>
 	<cooked_physics		path="units/pd2_mod_nypd/characters/ene_fbi_heavy_r870_sc/ene_fbi_heavy_r870_sc"/>
 	<model				path="units/pd2_mod_nypd/characters/ene_fbi_heavy_r870_sc/ene_fbi_heavy_r870_sc"/>
-
+	
+	<!--shield-->
 	<unit				path="units/pd2_mod_nypd/characters/ene_shield_1/ene_shield_1" load="true"/>
 	<unit				path="units/pd2_mod_nypd/characters/ene_shield_1/ene_shield_1_husk" load="true"/>
 	<object				path="units/pd2_mod_nypd/characters/ene_shield_1/ene_shield_1" />	

--- a/packages/zombie_diff/hard_sc_zombie.xml
+++ b/packages/zombie_diff/hard_sc_zombie.xml
@@ -19,12 +19,12 @@
 	<material_config	path="units/pd2_dlc_hvh/characters/ene_fbi_heavy_hvh_1_sc/ene_fbi_heavy_hvh_1_sc"  />
 	<material_config	path="units/pd2_dlc_hvh/characters/ene_fbi_heavy_hvh_1_sc/ene_fbi_heavy_hvh_1_sc_contour"  />
 	<object				path="units/pd2_dlc_hvh/characters/ene_fbi_heavy_hvh_1_sc/ene_fbi_heavy_hvh_1_sc"  />
-		
-	<unit				path="units/pd2_dlc_hvh/characters/ene_shield_hvh_2/ene_shield_hvh_2" force="true" load="true"/>
-	<unit				path="units/pd2_dlc_hvh/characters/ene_shield_hvh_2/ene_shield_hvh_2_husk" force="true" load="true"/>
-	<model				path="units/pd2_dlc_hvh/characters/ene_shield_hvh_2/ene_shield_hvh_2" force="true" />
-	<cooked_physics		path="units/pd2_dlc_hvh/characters/ene_shield_hvh_2/ene_shield_hvh_2" force="true" />
-	<object				path="units/pd2_dlc_hvh/characters/ene_shield_hvh_2/ene_shield_hvh_2" force="true" />
+	
+	<unit				path="units/pd2_dlc_hvh/characters/ene_shield_hvh_1/ene_shield_hvh_1" force="true" load="true"/>
+	<unit				path="units/pd2_dlc_hvh/characters/ene_shield_hvh_1/ene_shield_hvh_1_husk" force="true" load="true"/>
+	<model				path="units/pd2_dlc_hvh/characters/ene_shield_hvh_1/ene_shield_hvh_1" force="true" />
+	<cooked_physics		path="units/pd2_dlc_hvh/characters/ene_shield_hvh_1/ene_shield_hvh_1" force="true" />
+	<object				path="units/pd2_dlc_hvh/characters/ene_shield_hvh_1/ene_shield_hvh_1" force="true" />
 	
 	<texture			path="units/pd2_mod_omnia/characters/shared_textures/swat_body_nm"/>
 	
@@ -50,6 +50,12 @@
 	<unit				path="units/pd2_mod_halloween/characters/ene_sniper_1/ene_sniper_1_husk"  load="true"/>
 	<model				path="units/pd2_mod_halloween/characters/ene_sniper_1/ene_sniper_1"  />
 	<object				path="units/pd2_mod_halloween/characters/ene_sniper_1/ene_sniper_1"  />
+	
+	<unit				path="units/pd2_dlc_hvh/characters/ene_shield_hvh_2/ene_shield_hvh_2" force="true" load="true"/>
+	<unit				path="units/pd2_dlc_hvh/characters/ene_shield_hvh_2/ene_shield_hvh_2_husk" force="true" load="true"/>
+	<model				path="units/pd2_dlc_hvh/characters/ene_shield_hvh_2/ene_shield_hvh_2" force="true" />
+	<cooked_physics		path="units/pd2_dlc_hvh/characters/ene_shield_hvh_2/ene_shield_hvh_2" force="true" />
+	<object				path="units/pd2_dlc_hvh/characters/ene_shield_hvh_2/ene_shield_hvh_2" force="true" />
 
 	<texture			path="units/pd2_dlc_hvh/characters/ene_swat_hvh_1/swat_body_hvh_df"  />
 	

--- a/packages/zombie_diff/normal_sc_zombie.xml
+++ b/packages/zombie_diff/normal_sc_zombie.xml
@@ -19,12 +19,12 @@
 	<material_config	path="units/pd2_dlc_hvh/characters/ene_fbi_heavy_hvh_1_sc/ene_fbi_heavy_hvh_1_sc"  />
 	<material_config	path="units/pd2_dlc_hvh/characters/ene_fbi_heavy_hvh_1_sc/ene_fbi_heavy_hvh_1_sc_contour"  />
 	<object				path="units/pd2_dlc_hvh/characters/ene_fbi_heavy_hvh_1_sc/ene_fbi_heavy_hvh_1_sc"  />
-		
-	<unit				path="units/pd2_dlc_hvh/characters/ene_shield_hvh_2/ene_shield_hvh_2" force="true" load="true"/>
-	<unit				path="units/pd2_dlc_hvh/characters/ene_shield_hvh_2/ene_shield_hvh_2_husk" force="true" load="true"/>
-	<model				path="units/pd2_dlc_hvh/characters/ene_shield_hvh_2/ene_shield_hvh_2" force="true" />
-	<cooked_physics		path="units/pd2_dlc_hvh/characters/ene_shield_hvh_2/ene_shield_hvh_2" force="true" />
-	<object				path="units/pd2_dlc_hvh/characters/ene_shield_hvh_2/ene_shield_hvh_2" force="true" />
+	
+	<unit				path="units/pd2_dlc_hvh/characters/ene_shield_hvh_1/ene_shield_hvh_1" force="true" load="true"/>
+	<unit				path="units/pd2_dlc_hvh/characters/ene_shield_hvh_1/ene_shield_hvh_1_husk" force="true" load="true"/>
+	<model				path="units/pd2_dlc_hvh/characters/ene_shield_hvh_1/ene_shield_hvh_1" force="true" />
+	<cooked_physics		path="units/pd2_dlc_hvh/characters/ene_shield_hvh_1/ene_shield_hvh_1" force="true" />
+	<object				path="units/pd2_dlc_hvh/characters/ene_shield_hvh_1/ene_shield_hvh_1" force="true" />
 	
 	<texture			path="units/pd2_mod_omnia/characters/shared_textures/swat_body_nm"/>
 	
@@ -50,6 +50,12 @@
 	<unit				path="units/pd2_mod_halloween/characters/ene_sniper_1/ene_sniper_1_husk"  load="true"/>
 	<model				path="units/pd2_mod_halloween/characters/ene_sniper_1/ene_sniper_1"  />
 	<object				path="units/pd2_mod_halloween/characters/ene_sniper_1/ene_sniper_1"  />
+	
+	<unit				path="units/pd2_dlc_hvh/characters/ene_shield_hvh_2/ene_shield_hvh_2" force="true" load="true"/>
+	<unit				path="units/pd2_dlc_hvh/characters/ene_shield_hvh_2/ene_shield_hvh_2_husk" force="true" load="true"/>
+	<model				path="units/pd2_dlc_hvh/characters/ene_shield_hvh_2/ene_shield_hvh_2" force="true" />
+	<cooked_physics		path="units/pd2_dlc_hvh/characters/ene_shield_hvh_2/ene_shield_hvh_2" force="true" />
+	<object				path="units/pd2_dlc_hvh/characters/ene_shield_hvh_2/ene_shield_hvh_2" force="true" />
 
 	<texture			path="units/pd2_dlc_hvh/characters/ene_swat_hvh_1/swat_body_hvh_df"  />
 	


### PR DESCRIPTION
-FBI Shield now replaces SWAT shields during PONR. (Reapers are not touched yet)
-Fixed an issue when scripted FBI shield tried to spawn on hard and below which caused the game to crash.
Also fixed some other package issues that could cause crashes and unit replace issues.