### PR TITLE
Support for "The Management Simulator" mod.

### DIFF
--- a/lua/sc/states/missionendstate.lua
+++ b/lua/sc/states/missionendstate.lua
@@ -249,6 +249,14 @@ function MissionEndState:at_enter(old_state, params)
 	end
 
 	Telemetry:on_end_heist(self._type, total_exp_gained, self._moneythrower_spending_kills)
+
+	-- I'm not sure this is how MSIM should be fixed, but be my guest to properly fix it - it just works.
+	if msim then
+		msim:load()
+		msim:pick_available_props(3)
+		msim.settings.pp = math.min(msim.settings.pp + msim.settings.pprr, 100)
+		msim:save()
+	end
 end
 
 local on_statistics_result_ori = MissionEndState.on_statistics_result


### PR DESCRIPTION
Note: *this person has zero experience with the PAYDAY's code*

While MSIM works out of the box with Restoration Mod, it doesn't add Purchasing Power after completing the heist like it should.

This PR addresses that by adding the save function from the mod itself.
It's a funky way to fix the issue, but it works.

*You are free to decline this PR and let people cry about it.*