### PR TITLE
Back from the Retirement, eh?

### DIFF
--- a/assets/units/pd2_dlc_vip/characters/ene_phalanx_1_assault/ene_phalanx_1_assault.unit
+++ b/assets/units/pd2_dlc_vip/characters/ene_phalanx_1_assault/ene_phalanx_1_assault.unit
@@ -16,7 +16,7 @@
 			<var name="_tweak_table" value="phalanx_minion_assault" />
 			<var name="_default_weapon_id" value="beretta92_titan" />
 			<var name="_default_weapons" type="table">
-				<var name="primary" value="aa12_npc"/>
+				<var name="primary" value="aa12_conc_npc"/>
 				<var name="secondary" value="beretta92_titan"/>
 			</var>			
 		</extension>

--- a/assets/units/pd2_dlc_vip/characters/ene_phalanx_1_assault/ene_phalanx_1_assault_husk.unit
+++ b/assets/units/pd2_dlc_vip/characters/ene_phalanx_1_assault/ene_phalanx_1_assault_husk.unit
@@ -16,7 +16,7 @@
 			<var name="_tweak_table" value="phalanx_minion_assault" />
 			<var name="_default_weapon_id" value="beretta92_titan" />
 			<var name="_default_weapons" type="table">
-				<var name="primary" value="aa12_npc"/>
+				<var name="primary" value="aa12_conc_npc"/>
 				<var name="secondary" value="beretta92_titan"/>
 			</var>			
 		</extension>

--- a/assets/units/pd2_mod_halloween/characters/ene_phalanx_1_assault/ene_phalanx_1_assault.unit
+++ b/assets/units/pd2_mod_halloween/characters/ene_phalanx_1_assault/ene_phalanx_1_assault.unit
@@ -17,7 +17,7 @@
 			<var name="_tweak_table" value="phalanx_minion_assault" />
 			<var name="_default_weapon_id" value="beretta92_titan" />
 			<var name="_default_weapons" type="table">
-				<var name="primary" value="lmg_titan"/>
+				<var name="primary" value="aa12_conc_npc"/>
 				<var name="secondary" value="beretta92_titan"/>
 			</var>					
 		</extension>

--- a/assets/units/pd2_mod_halloween/characters/ene_phalanx_1_assault/ene_phalanx_1_assault_husk.unit
+++ b/assets/units/pd2_mod_halloween/characters/ene_phalanx_1_assault/ene_phalanx_1_assault_husk.unit
@@ -16,7 +16,7 @@
 			<var name="_tweak_table" value="phalanx_minion_assault" />
 			<var name="_default_weapon_id" value="beretta92_titan" />
 			<var name="_default_weapons" type="table">
-				<var name="primary" value="lmg_titan"/>
+				<var name="primary" value="aa12_conc_npc"/>
 				<var name="secondary" value="beretta92_titan"/>
 			</var>					
 		</extension>

--- a/assets/units/pd2_mod_reapers/characters/ene_phalanx_1_assault/ene_phalanx_1_assault.unit
+++ b/assets/units/pd2_mod_reapers/characters/ene_phalanx_1_assault/ene_phalanx_1_assault.unit
@@ -18,7 +18,7 @@
 			<var name="_tweak_table" value="phalanx_minion_assault" />
 			<var name="_default_weapon_id" value="beretta92_titan" />
 			<var name="_default_weapons" type="table">
-				<var name="primary" value="saiga"/>
+				<var name="primary" value="saiga_conc_npc"/>
 				<var name="secondary" value="beretta92_titan"/>
 			</var>			
 		</extension>

--- a/assets/units/pd2_mod_reapers/characters/ene_phalanx_1_assault/ene_phalanx_1_assault_husk.unit
+++ b/assets/units/pd2_mod_reapers/characters/ene_phalanx_1_assault/ene_phalanx_1_assault_husk.unit
@@ -17,7 +17,7 @@
 			<var name="_tweak_table" value="phalanx_minion_assault" />
 			<var name="_default_weapon_id" value="beretta92_titan" />
 			<var name="_default_weapons" type="table">
-				<var name="primary" value="saiga"/>
+				<var name="primary" value="saiga_conc_npc"/>
 				<var name="secondary" value="beretta92_titan"/>
 			</var>			
 		</extension>

--- a/lua/sc/loc/loc.lua
+++ b/lua/sc/loc/loc.lua
@@ -4401,6 +4401,10 @@ Hooks:Add("LocalizationManagerPostInit", "SC_Localization_Skills", function(loc)
 		["mutator_quickscope360"] = "Eagle Eye",
 		["mutator_quickscope360_desc"] = "Snipers now aim their rifles 100% faster.",
 		["mutator_quickscope360_longdesc"] = "Snipers now aim their rifles 100% faster.",
+		
+		["mutator_goldfarbdozers"] = "Double Firepower",
+		["mutator_goldfarbdozers_desc"] = "All Bulldozers that spawn will always deploy in pairs.",
+		["mutator_goldfarbdozers_longdesc"] = "All Bulldozers that spawn will always deploy in pairs.",
 		--Crime spree modifier changes
 		["cn_crime_spree_brief"] = "A Crime Spree is an endless series of randomly selected heists, executed in succession. With each heist you complete, your Rank and Reward will increase! Each 20th or 26th rank you will need to choose a modifier and each 100th rank there is an increase to the risk level, that will make the next heists harder to complete. After risk level 600, the amount of i-frames that player have starts to decrease and bravo units begin to spawn normally.\n\n##If you invite your crew, make sure they started their own Crime Spree before joining in order to gain ranks and Rewards as well.##",
 		["menu_cs_next_modifier_forced"] = "",
@@ -4429,6 +4433,7 @@ Hooks:Add("LocalizationManagerPostInit", "SC_Localization_Skills", function(loc)
 		["menu_cs_modifier_cloaker_tear_gas"] = "All HRT units have an additional 15% chance to become a ASU unit.",
 		["menu_cs_modifier_dozer_lmg"] = "Whenever a Green or Black Bulldozer spawns, there is a chance that it will be replaced by a Skulldozer.",
 		["menu_cs_modifier_10secondsresponsetime"] = "All police assaults now start at maximum intensity.",
+		["menu_cs_modifier_dozerpairs"] = "Bulldozers will now always spawn in pairs.",
 
 		["bm_menu_skill"] = "Crew Boosts",
 

--- a/lua/sc/loc/locko.lua
+++ b/lua/sc/loc/locko.lua
@@ -2615,7 +2615,7 @@ Hooks:Add("LocalizationManagerPostInit", "SC_Localization_Weapons", function(loc
 					["bm_wp_1911_m_big"] = "캐스킷 탄창",
 					--Crosskill Chunky
 					["bm_w_m1911"] = "Crosskill A1",
-					["bm_w_x_m1911"] = "프라이스 & 맥태비시",	
+					["bm_w_x_m1911"] = "프라이스 & 맥태비시",
 					--Crosskill Guard
 					["bm_w_shrew"] = "Crosskill Guard",
 					["bm_w_x_shrew"] = "베리 & 폴",
@@ -2994,11 +2994,11 @@ Hooks:Add("LocalizationManagerPostInit", "SC_Localization_Weapons", function(loc
 			LocalizationManager:add_localized_strings({
 
 				["bm_w_pl14"] = "WS-14",
-				["bm_w_x_pl14"] = "아킴보 WS-14",		
+				["bm_w_x_pl14"] = "아킴보 WS-14",
 				["bm_w_g22c"] = "Chimano 22C",
 				["bm_w_x_g22c"] = "아킴보 Chimano 22C",
 				["bm_w_x_1911"] = "아킴보 Operator II",
-				["bm_w_x_m1911"] = "아킴보 Crosskill A1",		
+				["bm_w_x_m1911"] = "아킴보 Crosskill A1",
 				["bm_w_x_sparrow"] = "아킴보 Sparrow",
 				["bm_w_scar"] = "VF-7S",
 				["bm_w_scarl"] = "VF-6M",
@@ -4513,6 +4513,10 @@ Hooks:Add("LocalizationManagerPostInit", "SC_Localization_Skills", function(loc)
 		["mutator_quickscope360"] = "독수리의 눈",
 		["mutator_quickscope360_desc"] = "저격수는 이제 소총을 100% 더 빠르게 조준합니다.",
 		["mutator_quickscope360_longdesc"] = "저격수는 이제 소총을 100% 더 빠르게 조준합니다.",
+		
+		["mutator_goldfarbdozers"] = "Double Firepower",
+		["mutator_goldfarbdozers_desc"] = "All Bulldozers that spawn will always deploy in pairs.",
+		["mutator_goldfarbdozers_longdesc"] = "All Bulldozers that spawn will always deploy in pairs.",
 		--Crime spree modifier changes
 		["cn_crime_spree_brief"] = "크라임 스프리는 연속적으로 실행되는 무작위로 선택되는 하이스트의 끝없는 시리즈입니다. 하이스트를 완료할 때마다 등급과 보상이 증가합니다! 20 또는 26 등급마다 개조를 선택해야 하고 100 등급마다 리스크 레벨이 증가하므로 다음 습격을 완료하기가 더 어려워집니다. 리스크 레벨 600 이후에는 플레이어가 가지고 있는 무적 프레임의 양이 감소하기 시작하고 브라보 유닛이 정상적으로 스폰되기 시작합니다.\n\n##팀원을 초대하는 경우 랭크와 보상을 얻기 위해 합류하기 전에 자신만의 크라임 스프리를 시작했는지 확인하십시오.##",
 		["menu_cs_next_modifier_forced"] = "",
@@ -4541,6 +4545,7 @@ Hooks:Add("LocalizationManagerPostInit", "SC_Localization_Skills", function(loc)
 		["menu_cs_modifier_cloaker_tear_gas"] = "모든 HRT 유닛은 15%의 추가 확률로 ASU 유닛이 됩니다.",
 		["menu_cs_modifier_dozer_lmg"] = "그린 또는 블랙 불도저가 생성될 때마다 스컬도저로 교체될 확률이 생깁니다.",
 		["menu_cs_modifier_10secondsresponsetime"] = "모든 경찰 습격은 이제 최대 강도로 시작됩니다.",
+		["menu_cs_modifier_dozerpairs"] = "Bulldozers will now always spawn in pairs.",
 
 		["bm_menu_skill"] = "팀원 부스트",
 

--- a/lua/sc/loc/locru.lua
+++ b/lua/sc/loc/locru.lua
@@ -4540,6 +4540,10 @@ Hooks:Add("LocalizationManagerPostInit", "SC_Localization_Skills", function(loc)
 		["mutator_quickscope360"] = "Орлиный глаз",
 		["mutator_quickscope360_desc"] = "Снайперы теперь прицеливаются на 100% быстрее.",
 		["mutator_quickscope360_longdesc"] = "Снайперы теперь прицеливаются на 100% быстрее.",
+		
+		["mutator_goldfarbdozers"] = "Double Firepower",
+		["mutator_goldfarbdozers_desc"] = "All Bulldozers that spawn will always deploy in pairs.",
+		["mutator_goldfarbdozers_longdesc"] = "All Bulldozers that spawn will always deploy in pairs.",
 		--Crime spree modifier changes
 		["cn_crime_spree_brief"] = "Серия преступлений - режим, в котором вас предстоит сыграть бесконечную серию ограблений, идущих подряд. С каждым пройденным ограблением, ваши Ранг и Награда буду повышаться! Каждый 20-й и 26-й ранг вам предстоит выбрать модификатор, а каждые 100 рангов повысится уровень риска, что сделает последующие ограбления сложнее. После 600 ранга, задержка на получение урона будет уменьшаться, и среди обычных врагов начнут появляться отряды Браво.\n\n##При игре с друзьями, не забудьте убедиться, что они начали свою Серию преступлений, или они не смогут получать Ранги и Награды.##",
 		["menu_cs_next_modifier_forced"] = "",
@@ -4568,6 +4572,7 @@ Hooks:Add("LocalizationManagerPostInit", "SC_Localization_Skills", function(loc)
 		["menu_cs_modifier_cloaker_tear_gas"] = "Все агенты по спасению заложников получают дополнительный 15% шанс стать Титановыми агентами.",
 		["menu_cs_modifier_dozer_lmg"] = "Когда появляется Зеленый или Черный Бульдозер, есть шанс, что его заменит Скаллдозер.",
 		["menu_cs_modifier_10secondsresponsetime"] = "Полицейские штурмы сразу имеют максимальную интенсивность.",
+		["menu_cs_modifier_dozerpairs"] = "Bulldozers will now always spawn in pairs.",
 
 		["bm_menu_skill"] = "Бонусы для команды",
 

--- a/lua/sc/loc/loczh.lua
+++ b/lua/sc/loc/loczh.lua
@@ -4620,6 +4620,10 @@ Hooks:Add("LocalizationManagerPostInit", "SC_Localization_Skills", function(loc)
         ["mutator_quickscope360"] = "Eagle Eye",
         ["mutator_quickscope360_desc"] = "Snipers now aim their rifles 100% faster.",
         ["mutator_quickscope360_longdesc"] = "Snipers now aim their rifles 100% faster.",
+		
+		["mutator_goldfarbdozers"] = "Double Firepower",
+		["mutator_goldfarbdozers_desc"] = "All Bulldozers that spawn will always deploy in pairs.",
+		["mutator_goldfarbdozers_longdesc"] = "All Bulldozers that spawn will always deploy in pairs.",
 
         -- Crime spree modifier changes
         ["cn_crime_spree_brief"] = "\"罪无止境\"是一系列随机选取并需要连续完成的劫案组合。你完成的每次一次劫案都会为你增加罪无止境等级与奖励。每过20级或26级，你都需要选择一次附加难度因子；每过100级都会增加劫案的基础难度(如枪林弹雨到祸乱横行)，这会使劫案更难完成。等级600之后，玩家的无敌帧将会逐渐减少，Bravo临界反应部队将会开始生成。\n\n##如果你想邀请你的好友一起玩，请先确保他们开始了罪无止境以一起获得等级和奖励##",
@@ -4648,6 +4652,7 @@ Hooks:Add("LocalizationManagerPostInit", "SC_Localization_Skills", function(loc)
         ["menu_cs_modifier_cloaker_smoke"] = "幻影特工现在有50%的概率在他们闪避时扔出一颗闪光弹。",
         ["menu_cs_modifier_cloaker_tear_gas"] = "所有人质救援队的单位都有额外15%的概率被替换为支援兵。",
         ["menu_cs_modifier_dozer_lmg"] = "每当有一只绿熊或黑熊被生成时，它都有概率被替换为一只骷髅熊。",
+		["menu_cs_modifier_dozerpairs"] = "Bulldozers will now always spawn in pairs.",
 
         ["bm_menu_skill"] = "小队加成",
 

--- a/lua/sc/managers/mutatorsmanager.lua
+++ b/lua/sc/managers/mutatorsmanager.lua
@@ -44,6 +44,7 @@ function MutatorsManager:init()
 		MutatorQuickScope360:new(self),
 		MutatorCrazyTaser:new(self),
 		MutatorMasterDodger:new(self),
+		MutatorGoldfarbDozers:new(self),
 		MutatorBirthday:new(self)
 	}
 	self._active_mutators = {}

--- a/lua/sc/managers/statisticsmanager.lua
+++ b/lua/sc/managers/statisticsmanager.lua
@@ -262,7 +262,14 @@ function StatisticsManager:init()
 			melee = 0,
 			explosion = 0,
 			tied = 0
-		}		
+		}
+	self._defaults.killed.phalanx_vip_break = {
+			count = 0,
+			head_shots = 0,
+			melee = 0,
+			explosion = 0,
+			tied = 0
+		}	
 	self._defaults.killed.city_swat_guard = {
 			count = 0,
 			head_shots = 0,

--- a/lua/sc/modifiers/new/modifierdozerpairs.lua
+++ b/lua/sc/modifiers/new/modifierdozerpairs.lua
@@ -1,0 +1,139 @@
+--Just be careful of not meeting two Russian Titandozers
+ModifierDozerPairs = ModifierDozerPairs or class(BaseModifier)
+ModifierDozerPairs._type = "ModifierDozerPairs"
+ModifierDozerPairs.name_id = "none"
+ModifierDozerPairs.desc_id = "menu_cs_modifier_dozerpairs"
+
+
+function ModifierDozerPairs:init(data)
+	tweak_data.group_ai.enemy_spawn_groups.GREEN_tanks = {
+			amount = {4, 5},
+			spawn = {
+				{
+					unit = "FBI_tank",
+					freq = 1,
+					amount_min = 2,
+					amount_max = 2,
+					tactics = tweak_data.group_ai._tactics.GREEN_tank_DW,
+					rank = 3
+				},
+				{
+					unit = "boom_M4203",
+					freq = 0.75,
+					amount_max = 1,
+					tactics = tweak_data.group_ai._tactics.ELITE_boom,
+					rank = 2
+				},
+				{
+					unit = "GS_swat_M4",
+					freq = 1,
+					tactics = tweak_data.group_ai._tactics.ELITE_swat_rifle,
+					rank = 1
+				},
+				{
+					unit = "medic_M4",
+					freq = 0.75,
+					amount_max = 1,
+					tactics = tweak_data.group_ai._tactics.FBI_medic_flank,
+					rank = 2
+				}		
+			}
+		}
+		
+		tweak_data.group_ai.enemy_spawn_groups.BLACK_tanks = {
+			amount = {4, 5},
+			spawn = {
+				{
+					unit = "BLACK_tank",
+					freq = 1,
+					amount_min = 2,
+					amount_max = 2,
+					tactics = tweak_data.group_ai._tactics.BLACK_tank_DW,
+					rank = 3
+				},
+				{
+					unit = "CS_tazer",
+					freq = 0.75,
+					amount_max = 1,
+					tactics = tweak_data.group_ai._tactics.DW_tazer,
+					rank = 2
+				},
+				{
+					unit = "GS_swat_M4",
+					freq = 1,
+					tactics = tweak_data.group_ai._tactics.ELITE_swat_rifle,
+					rank = 1
+				},
+				{
+					unit = "medic_M4",
+					freq = 0.75,
+					amount_max = 1,
+					tactics = tweak_data.group_ai._tactics.FBI_medic_flank,
+					rank = 2
+				}		
+			}
+		}	
+		
+		tweak_data.group_ai.enemy_spawn_groups.SKULL_tanks = {
+			amount = {4, 5},
+			spawn = {
+				{
+					unit = "SKULL_tank",
+					freq = 1,
+					amount_min = 2,
+					amount_max = 2,
+					tactics = tweak_data.group_ai._tactics.SKULL_tank,
+					rank = 3
+				},
+				{
+					unit = "CS_tazer",
+					freq = 0.75,
+					amount_max = 1,
+					tactics = tweak_data.group_ai._tactics.DW_tazer,
+					rank = 2
+				},
+				{
+					unit = "GS_swat_R870",
+					freq = 1,
+					amount_max = 3,
+					tactics = tweak_data.group_ai._tactics.ELITE_swat_shotgun,
+					rank = 1
+				},
+				{
+					unit = "medic_M4",
+					freq = 0.75,
+					amount_max = 1,
+					tactics = tweak_data.group_ai._tactics.FBI_medic_flank,
+					rank = 2
+				}	
+			}
+		}
+		
+		tweak_data.group_ai.enemy_spawn_groups.TIT_tanks = {
+			amount = {4, 5},
+			spawn = {
+				{
+					unit = "TIT_tank",
+					freq = 1,
+					amount_min = 2,
+					amount_max = 2,
+					tactics = tweak_data.group_ai._tactics.TIT_tank,
+					rank = 3
+				},
+				{
+					unit = "GS_heavy_R870",
+					freq = 1,
+					amount_min = 1,
+					tactics = tweak_data.group_ai._tactics.ELITE_heavy_shotgun,
+					rank = 1
+				},
+				{
+					unit = "medic_M4",
+					freq = 0.75,
+					amount_max = 2,
+					tactics = tweak_data.group_ai._tactics.FBI_medic_flank,
+					rank = 2
+				}
+			}
+		}
+end

--- a/lua/sc/mutators/new/mutatorgoldfarbdozers.lua
+++ b/lua/sc/mutators/new/mutatorgoldfarbdozers.lua
@@ -1,0 +1,454 @@
+--Just be careful of not meeting two Russian Titandozers
+MutatorGoldfarbDozers = MutatorGoldfarbDozers or class(BaseMutator)
+MutatorGoldfarbDozers._type = "MutatorGoldfarbDozers"
+MutatorGoldfarbDozers.name_id = "mutator_goldfarbdozers"
+MutatorGoldfarbDozers.desc_id = "mutator_goldfarbdozers_desc"
+MutatorGoldfarbDozers.reductions = {
+	money = 0,
+	exp = 0
+}
+MutatorGoldfarbDozers.disables_achievements = false
+MutatorGoldfarbDozers.categories = {"crime_spree"}
+MutatorGoldfarbDozers.icon_coords = {
+	6,
+	4
+}
+ 
+function MutatorGoldfarbDozers:setup()
+	local difficulty = Global.game_settings and Global.game_settings.difficulty or "normal"
+	local difficulty_index = tweak_data:difficulty_to_index(difficulty)
+	
+	--Dozer Pairs, not a pretty way to do it but it works
+	if difficulty_index <= 5 then
+		tweak_data.group_ai.enemy_spawn_groups.GREEN_tanks = {
+			amount = {3, 4},
+			spawn = {
+				{
+					unit = "FBI_tank",
+					freq = 1,
+					amount_min = 2,
+					amount_max = 2,
+					tactics = tweak_data.group_ai._tactics.GREEN_tank,
+					rank = 2
+				},
+				{
+					unit = "FBI_swat_M4",
+					freq = 1,
+					tactics = tweak_data.group_ai._tactics.FBI_swat_rifle,
+					rank = 1
+				}
+			}
+		}	
+	elseif difficulty_index == 6 then
+		tweak_data.group_ai.enemy_spawn_groups.GREEN_tanks = {
+			amount = {3, 4},
+			spawn = {
+				{
+					unit = "FBI_tank",
+					freq = 1,
+					amount_min = 2,
+					amount_max = 2,
+					tactics = tweak_data.group_ai._tactics.GREEN_tank,
+					rank = 2
+				},
+				{
+					unit = "FBI_swat_M4",
+					freq = 1,
+					tactics = tweak_data.group_ai._tactics.FBI_swat_rifle,
+					rank = 1
+				}
+			}
+		}
+	elseif difficulty_index == 7 then
+		tweak_data.group_ai.enemy_spawn_groups.GREEN_tanks = {
+			amount = {4, 5},
+			spawn = {
+				{
+					unit = "FBI_tank",
+					freq = 1,
+					amount_min = 2,
+					amount_max = 2,
+					tactics = tweak_data.group_ai._tactics.GREEN_tank_DW,
+					rank = 3
+				},
+				{
+					unit = "boom_M4203",
+					freq = 0.5,
+					amount_max = 1,
+					tactics = tweak_data.group_ai._tactics.ELITE_boom,
+					rank = 2
+				},
+				{
+					unit = "GS_swat_M4",
+					freq = 1,
+					tactics = tweak_data.group_ai._tactics.DW_swat_rifle,
+					rank = 1
+				},
+				{
+					unit = "medic_M4",
+					freq = 0.75,
+					amount_max = 1,
+					tactics = tweak_data.group_ai._tactics.FBI_medic_flank,
+					rank = 2
+				}					
+			}
+		}	
+	else
+		tweak_data.group_ai.enemy_spawn_groups.GREEN_tanks = {
+			amount = {4, 5},
+			spawn = {
+				{
+					unit = "FBI_tank",
+					freq = 1,
+					amount_min = 2,
+					amount_max = 2,
+					tactics = tweak_data.group_ai._tactics.GREEN_tank_DW,
+					rank = 3
+				},
+				{
+					unit = "boom_M4203",
+					freq = 0.75,
+					amount_max = 1,
+					tactics = tweak_data.group_ai._tactics.ELITE_boom,
+					rank = 2
+				},
+				{
+					unit = "GS_swat_M4",
+					freq = 1,
+					tactics = tweak_data.group_ai._tactics.ELITE_swat_rifle,
+					rank = 1
+				},
+				{
+					unit = "medic_M4",
+					freq = 0.75,
+					amount_max = 1,
+					tactics = tweak_data.group_ai._tactics.FBI_medic_flank,
+					rank = 2
+				}		
+			}
+		}			
+	end
+
+	if difficulty_index <= 5 then
+		tweak_data.group_ai.enemy_spawn_groups.BLACK_tanks = {
+			amount = {3, 4},
+			spawn = {
+				{
+					unit = "BLACK_tank",
+					freq = 1,
+					amount_min = 2,
+					amount_max = 2,
+					tactics = tweak_data.group_ai._tactics.BLACK_tank,
+					rank = 2
+				},
+				{
+					unit = "FBI_swat_M4",
+					freq = 1,
+					tactics = tweak_data.group_ai._tactics.FBI_swat_rifle,
+					rank = 1
+				}
+			}
+		}	
+	elseif difficulty_index == 6 then
+		tweak_data.group_ai.enemy_spawn_groups.BLACK_tanks = {
+			amount = {3, 4},
+			spawn = {
+				{
+					unit = "BLACK_tank",
+					freq = 1,
+					amount_min = 2,
+					amount_max = 2,
+					tactics = tweak_data.group_ai._tactics.BLACK_tank,
+					rank = 2
+				},
+				{
+					unit = "FBI_swat_M4",
+					freq = 1,
+					tactics = tweak_data.group_ai._tactics.FBI_swat_rifle,
+					rank = 1
+				}
+			}
+		}
+	elseif difficulty_index == 7 then
+		tweak_data.group_ai.enemy_spawn_groups.BLACK_tanks = {
+			amount = {4, 5},
+			spawn = {
+				{
+					unit = "BLACK_tank",
+					freq = 1,
+					amount_min = 2,
+					amount_max = 2,
+					tactics = tweak_data.group_ai._tactics.BLACK_tank_DW,
+					rank = 3
+				},
+				{
+					unit = "CS_tazer",
+					freq = 0.5,
+					amount_max = 1,
+					tactics = tweak_data.group_ai._tactics.DW_tazer,
+					rank = 2
+				},
+				{
+					unit = "GS_swat_M4",
+					freq = 1,
+					tactics = tweak_data.group_ai._tactics.DW_swat_rifle,
+					rank = 1
+				},
+				{
+					unit = "medic_M4",
+					freq = 0.75,
+					amount_max = 1,
+					tactics = tweak_data.group_ai._tactics.FBI_medic_flank,
+					rank = 2
+				}	
+			}
+		}	
+	else
+		tweak_data.group_ai.enemy_spawn_groups.BLACK_tanks = {
+			amount = {4, 5},
+			spawn = {
+				{
+					unit = "BLACK_tank",
+					freq = 1,
+					amount_min = 1,
+					amount_max = 1,
+					tactics = tweak_data.group_ai._tactics.BLACK_tank_DW,
+					rank = 3
+				},
+				{
+					unit = "CS_tazer",
+					freq = 0.75,
+					amount_max = 1,
+					tactics = tweak_data.group_ai._tactics.DW_tazer,
+					rank = 2
+				},
+				{
+					unit = "GS_swat_M4",
+					freq = 1,
+					tactics = tweak_data.group_ai._tactics.ELITE_swat_rifle,
+					rank = 1
+				},
+				{
+					unit = "medic_M4",
+					freq = 0.75,
+					amount_max = 1,
+					tactics = tweak_data.group_ai._tactics.FBI_medic_flank,
+					rank = 2
+				}		
+			}
+		}			
+	end
+	
+	if difficulty_index <= 5 then
+		tweak_data.group_ai.enemy_spawn_groups.SKULL_tanks = {
+			amount = {3, 4},
+			spawn = {
+				{
+					unit = "SKULL_tank",
+					freq = 1,
+					amount_min = 2,
+					amount_max = 2,
+					tactics = tweak_data.group_ai._tactics.SKULL_tank,
+					rank = 2
+				},
+				{
+					unit = "FBI_swat_M4",
+					freq = 1,
+					amount_max = 2,
+					tactics = tweak_data.group_ai._tactics.FBI_swat_rifle,
+					rank = 1
+				}
+			}
+		}	
+	elseif difficulty_index == 6 then
+		tweak_data.group_ai.enemy_spawn_groups.SKULL_tanks = {
+			amount = {3, 4},
+			spawn = {
+				{
+					unit = "SKULL_tank",
+					freq = 1,
+					amount_min = 1,
+					amount_max = 1,
+					tactics = tweak_data.group_ai._tactics.SKULL_tank,
+					rank = 2
+				},
+				{
+					unit = "FBI_swat_M4",
+					freq = 1,
+					amount_max = 2,
+					tactics = tweak_data.group_ai._tactics.FBI_swat_rifle,
+					rank = 1
+				}
+			}
+		}
+	elseif difficulty_index == 7 then
+		tweak_data.group_ai.enemy_spawn_groups.SKULL_tanks = {
+			amount = {4, 5},
+			spawn = {
+				{
+					unit = "SKULL_tank",
+					freq = 1,
+					amount_min = 2,
+					amount_max = 2,
+					tactics = tweak_data.group_ai._tactics.SKULL_tank,
+					rank = 3
+				},
+				{
+					unit = "CS_tazer",
+					freq = 0.5,
+					amount_max = 1,
+					tactics = tweak_data.group_ai._tactics.DW_tazer,
+					rank = 2
+				},
+				{
+					unit = "GS_swat_M4",
+					freq = 1,
+					amount_max = 2,
+					tactics = tweak_data.group_ai._tactics.DW_swat_rifle,
+					rank = 1
+				},
+				{
+					unit = "medic_M4",
+					freq = 0.75,
+					amount_max = 1,
+					tactics = tweak_data.group_ai._tactics.FBI_medic_flank,
+					rank = 2
+				}
+			}
+		}	
+	else
+		tweak_data.group_ai.enemy_spawn_groups.SKULL_tanks = {
+			amount = {4, 5},
+			spawn = {
+				{
+					unit = "FBI_tank",
+					freq = 1,
+					amount_min = 2,
+					amount_max = 2,
+					tactics = tweak_data.group_ai._tactics.GREEN_tank_DW,
+					rank = 3
+				},
+				{
+					unit = "boom_M4203",
+					freq = 0.75,
+					amount_max = 1,
+					tactics = tweak_data.group_ai._tactics.ELITE_boom,
+					rank = 2
+				},
+				{
+					unit = "GS_swat_M4",
+					freq = 1,
+					tactics = tweak_data.group_ai._tactics.ELITE_swat_rifle,
+					rank = 1
+				},
+				{
+					unit = "medic_M4",
+					freq = 0.75,
+					amount_max = 1,
+					tactics = tweak_data.group_ai._tactics.FBI_medic_flank,
+					rank = 2
+				}		
+			}
+		}			
+	end
+	
+	if difficulty_index <= 5 then
+		tweak_data.group_ai.enemy_spawn_groups.TIT_tanks = {
+			amount = {3, 4},
+			spawn = {
+				{
+					unit = "TIT_tank",
+					freq = 1,
+					amount_min = 2,
+					amount_max = 2,
+					tactics = tweak_data.group_ai._tactics.TIT_tank,
+					rank = 2
+				},
+				{
+					unit = "FBI_heavy_G36_w",
+					freq = 1,
+					amount_min = 1,
+					tactics = tweak_data.group_ai._tactics.FBI_heavy,
+					rank = 1
+				}
+			}
+		}	
+	elseif difficulty_index == 6 then
+		tweak_data.group_ai.enemy_spawn_groups.TIT_tanks = {
+			amount = {4, 5},
+			spawn = {
+				{
+					unit = "TIT_tank",
+					freq = 1,
+					amount_min = 2,
+					amount_max = 2,
+					tactics = tweak_data.group_ai._tactics.TIT_tank,
+					rank = 2
+				},
+				{
+					unit = "FBI_heavy_G36_w",
+					freq = 1,
+					amount_min = 1,
+					tactics = tweak_data.group_ai._tactics.FBI_heavy,
+					rank = 1
+				}
+			}
+		}
+	elseif difficulty_index == 7 then
+		tweak_data.group_ai.enemy_spawn_groups.TIT_tanks = {
+			amount = {4, 5},
+			spawn = {
+				{
+					unit = "TIT_tank",
+					freq = 1,
+					amount_min = 2,
+					amount_max = 2,
+					tactics = tweak_data.group_ai._tactics.TIT_tank,
+					rank = 3
+				},
+				{
+					unit = "GS_heavy_G36_w",
+					freq = 1,
+					amount_min = 1,
+					tactics = tweak_data.group_ai._tactics.MH_heavy,
+					rank = 1
+				},
+				{
+					unit = "medic_M4",
+					freq = 0.75,
+					amount_max = 2,
+					tactics = tweak_data.group_ai._tactics.FBI_medic_flank,
+					rank = 2
+				}
+			}
+		}	
+	else
+		tweak_data.group_ai.enemy_spawn_groups.TIT_tanks = {
+			amount = {4, 5},
+			spawn = {
+				{
+					unit = "TIT_tank",
+					freq = 1,
+					amount_min = 2,
+					amount_max = 2,
+					tactics = tweak_data.group_ai._tactics.TIT_tank,
+					rank = 3
+				},
+				{
+					unit = "GS_heavy_R870",
+					freq = 1,
+					amount_min = 1,
+					tactics = tweak_data.group_ai._tactics.ELITE_heavy_shotgun,
+					rank = 1
+				},
+				{
+					unit = "medic_M4",
+					freq = 0.75,
+					amount_max = 2,
+					tactics = tweak_data.group_ai._tactics.FBI_medic_flank,
+					rank = 2
+				}
+			}
+		}			
+	end
+end

--- a/lua/sc/tweak_data/crimespreetweakdata.lua
+++ b/lua/sc/tweak_data/crimespreetweakdata.lua
@@ -834,6 +834,13 @@ function CrimeSpreeTweakData:init_modifiers(tweak_data)
 					explosive_resist = {50, "add"}
 				}
 			},
+			--Dozers can now always spawn in pairs
+			{
+				id = "dozer_pairs",
+				class = "ModifierDozerPairs",
+				icon = "crime_spree_more_dozers",
+				data = {}
+			},
 			--MedicDozers have a 50% chance to replace other dozer types
 			{
 				id = "dozer_medic",

--- a/lua/sc/units/enemies/actions/upper_body/copactionshoot.lua
+++ b/lua/sc/units/enemies/actions/upper_body/copactionshoot.lua
@@ -679,6 +679,7 @@ function CopActionShoot:update(t)
 			
 			if self._throw_frag and self._ext_brain._throw_frag_t < t and 2000 >= target_dis and 500 <= target_dis then
                 local is_spring = self._ext_base._tweak_table == "spring"
+				local is_senator_armstrong = self._ext_base._tweak_table == "phalanx_vip_break"
                 local is_tank_mini = self._ext_base._tweak_table == "tank_mini"
                 local frag_cooldown = 6 --This stuff should really be defined via tweakdata in the future.
                 if is_spring then
@@ -704,6 +705,8 @@ function CopActionShoot:update(t)
 						
 					if is_tank_mini then	
 						self._unit:sound():say("g90", true, nil, true)
+					elseif is_senator_armstrong then	
+						self._unit:sound():say("a01", true, nil, true)	
 					else
 						self._unit:sound():say("use_gas", true, nil, true)	
 					end

--- a/main.xml
+++ b/main.xml
@@ -343,6 +343,7 @@
 		<hook file="sc/modifiers/new/modifierfriendlyfire.lua" source_file="lib/modifiers/modifierenemyhealthanddamage"/>
 		<hook file="sc/modifiers/new/modifier10secondsresponsetime.lua" source_file="lib/modifiers/modifierenemyhealthanddamage"/>
 		<hook file="sc/modifiers/new/modifierbravosniper.lua" source_file="lib/modifiers/basemodifier"/>
+		<hook file="sc/modifiers/new/modifierdozerpairs.lua" source_file="lib/modifiers/basemodifier"/>
 		<!--///MUTATORS\\\-->
 		<hook file="sc/managers/mutatorsmanager.lua" source_file="lib/managers/mutatorsmanager"/>
 		<hook file="sc/mutators/mutatorcloakereffect.lua" source_file="lib/mutators/mutatorcloakereffect"/>
@@ -379,6 +380,7 @@
 		<hook file="sc/mutators/new/mutatorcrazytaser.lua" source_file="lib/mutators/basemutator"/>
 		<hook file="sc/mutators/new/mutatormasterdodger.lua" source_file="lib/mutators/basemutator"/>
 		<hook file="sc/mutators/new/mutatorfullautoinbuilding.lua" source_file="lib/mutators/basemutator"/>
+		<hook file="sc/mutators/new/mutatorgoldfarbdozers.lua" source_file="lib/mutators/basemutator"/>
 		<!--///NETWORKING\\\-->
 		<hook file="sc/network/base/handlers/connectionnetworkhandler.lua" source_file="lib/network/base/handlers/connectionnetworkhandler"/>
 		<hook file="sc/network/base/networkmanager.lua" source_file="lib/network/base/networkmanager"/>

--- a/req/mission_script/arena.lua
+++ b/req/mission_script/arena.lua
@@ -1,13 +1,7 @@
 local difficulty = Global.game_settings and Global.game_settings.difficulty or "normal"
 local difficulty_index = tweak_data:difficulty_to_index(difficulty)
-
-	if tweak_data:difficulty_to_index(difficulty) <= 2 then
-		ponr_value = 1350
-	elseif tweak_data:difficulty_to_index(difficulty) == 3 then
-		ponr_value = 1320 	
-	elseif tweak_data:difficulty_to_index(difficulty) == 4 then
-		ponr_value = 1290	
-	elseif tweak_data:difficulty_to_index(difficulty) == 5 then
+	
+	if tweak_data:difficulty_to_index(difficulty) <= 5 then
 		ponr_value = 1260	
 	elseif tweak_data:difficulty_to_index(difficulty) == 6 or tweak_data:difficulty_to_index(difficulty) == 7 then
 		ponr_value = 1230

--- a/req/mission_script/arm_cro.lua
+++ b/req/mission_script/arm_cro.lua
@@ -17,13 +17,7 @@ local difficulty_index = tweak_data:difficulty_to_index(difficulty)
 		gensec_dozer = "units/payday2/characters/ene_bulldozer_3_sc/ene_bulldozer_3_sc"	
 	end
 
-	if tweak_data:difficulty_to_index(difficulty) <= 2 then
-		ponr_value = 780
-	elseif tweak_data:difficulty_to_index(difficulty) == 3 then
-		ponr_value = 740	
-	elseif tweak_data:difficulty_to_index(difficulty) == 4 then
-		ponr_value = 690
-	elseif tweak_data:difficulty_to_index(difficulty) == 5 then
+	if tweak_data:difficulty_to_index(difficulty) <= 5 then
 		ponr_value = 660
 	elseif tweak_data:difficulty_to_index(difficulty) == 6 or tweak_data:difficulty_to_index(difficulty) == 7 then
 		ponr_value = 630	

--- a/req/mission_script/arm_fac.lua
+++ b/req/mission_script/arm_fac.lua
@@ -17,16 +17,10 @@ local difficulty_index = tweak_data:difficulty_to_index(difficulty)
 		gensec_dozer = "units/payday2/characters/ene_bulldozer_3_sc/ene_bulldozer_3_sc"	
 	end
 
-	if tweak_data:difficulty_to_index(difficulty) <= 2 then
-		ponr_value = 780
-	elseif tweak_data:difficulty_to_index(difficulty) == 3 then
-		ponr_value = 740	
-	elseif tweak_data:difficulty_to_index(difficulty) == 4 then
-		ponr_value = 690
-	elseif tweak_data:difficulty_to_index(difficulty) == 5 then
+	if tweak_data:difficulty_to_index(difficulty) <= 5 then
 		ponr_value = 660
 	elseif tweak_data:difficulty_to_index(difficulty) == 6 or tweak_data:difficulty_to_index(difficulty) == 7 then
-		ponr_value = 630
+		ponr_value = 630	
 	elseif tweak_data:difficulty_to_index(difficulty) == 8 then
 		ponr_value = 600	
 	end

--- a/req/mission_script/arm_for.lua
+++ b/req/mission_script/arm_for.lua
@@ -1,13 +1,7 @@
 local difficulty = Global.game_settings and Global.game_settings.difficulty or "normal"
 local difficulty_index = tweak_data:difficulty_to_index(difficulty)
 
-	if tweak_data:difficulty_to_index(difficulty) <= 2 then
-		ponr_value = 1050
-	elseif tweak_data:difficulty_to_index(difficulty) == 3 then
-		ponr_value = 1020
-	elseif tweak_data:difficulty_to_index(difficulty) == 4 then
-		ponr_value = 990
-	elseif tweak_data:difficulty_to_index(difficulty) == 5 then
+	if tweak_data:difficulty_to_index(difficulty) <= 5 then
 		ponr_value = 960
 	elseif tweak_data:difficulty_to_index(difficulty) == 6 or tweak_data:difficulty_to_index(difficulty) == 7 then
 		ponr_value = 930	

--- a/req/mission_script/arm_hcm.lua
+++ b/req/mission_script/arm_hcm.lua
@@ -17,16 +17,10 @@ local difficulty_index = tweak_data:difficulty_to_index(difficulty)
 		gensec_dozer = "units/payday2/characters/ene_bulldozer_3_sc/ene_bulldozer_3_sc"	
 	end
 
-	if tweak_data:difficulty_to_index(difficulty) <= 2 then
-		ponr_value = 780
-	elseif tweak_data:difficulty_to_index(difficulty) == 3 then
-		ponr_value = 740
-	elseif tweak_data:difficulty_to_index(difficulty) == 4 then
-		ponr_value = 690	
-	elseif tweak_data:difficulty_to_index(difficulty) == 5 then
+	if tweak_data:difficulty_to_index(difficulty) <= 5 then
 		ponr_value = 660
 	elseif tweak_data:difficulty_to_index(difficulty) == 6 or tweak_data:difficulty_to_index(difficulty) == 7 then
-		ponr_value = 630
+		ponr_value = 630	
 	elseif tweak_data:difficulty_to_index(difficulty) == 8 then
 		ponr_value = 600	
 	end

--- a/req/mission_script/arm_par.lua
+++ b/req/mission_script/arm_par.lua
@@ -17,18 +17,12 @@ local difficulty_index = tweak_data:difficulty_to_index(difficulty)
 		gensec_dozer = "units/payday2/characters/ene_bulldozer_3_sc/ene_bulldozer_3_sc"	
 	end
 
-	if tweak_data:difficulty_to_index(difficulty) <= 2 then
-		ponr_value = 780
-	elseif tweak_data:difficulty_to_index(difficulty) == 3 then
-		ponr_value = 740	
-	elseif tweak_data:difficulty_to_index(difficulty) == 4 then
-		ponr_value = 690
-	elseif tweak_data:difficulty_to_index(difficulty) == 5 then
+	if tweak_data:difficulty_to_index(difficulty) <= 5 then
 		ponr_value = 660
 	elseif tweak_data:difficulty_to_index(difficulty) == 6 or tweak_data:difficulty_to_index(difficulty) == 7 then
 		ponr_value = 630	
 	elseif tweak_data:difficulty_to_index(difficulty) == 8 then
-		ponr_value = 600		
+		ponr_value = 600	
 	end
 
 return {

--- a/req/mission_script/arm_und.lua
+++ b/req/mission_script/arm_und.lua
@@ -17,16 +17,10 @@ local difficulty_index = tweak_data:difficulty_to_index(difficulty)
 		gensec_dozer = "units/payday2/characters/ene_bulldozer_3_sc/ene_bulldozer_3_sc"	
 	end
 
-	if tweak_data:difficulty_to_index(difficulty) <= 2 then
-		ponr_value = 780
-	elseif tweak_data:difficulty_to_index(difficulty) == 3 then
-		ponr_value = 740
-	elseif tweak_data:difficulty_to_index(difficulty) == 4 then
-		ponr_value = 690	
-	elseif tweak_data:difficulty_to_index(difficulty) == 5 then
-		ponr_value = 660	
+	if tweak_data:difficulty_to_index(difficulty) <= 5 then
+		ponr_value = 660
 	elseif tweak_data:difficulty_to_index(difficulty) == 6 or tweak_data:difficulty_to_index(difficulty) == 7 then
-		ponr_value = 630
+		ponr_value = 630	
 	elseif tweak_data:difficulty_to_index(difficulty) == 8 then
 		ponr_value = 600	
 	end

--- a/req/mission_script/bex.lua
+++ b/req/mission_script/bex.lua
@@ -1,13 +1,7 @@
 local difficulty = Global.game_settings and Global.game_settings.difficulty or "normal"
 local difficulty_index = tweak_data:difficulty_to_index(difficulty)
 
-	if tweak_data:difficulty_to_index(difficulty) <= 2 then
-		ponr_value = 690
-	elseif tweak_data:difficulty_to_index(difficulty) == 3 then
-		ponr_value = 660	
-	elseif tweak_data:difficulty_to_index(difficulty) == 4 then
-		ponr_value = 630
-	elseif tweak_data:difficulty_to_index(difficulty) == 5 then
+	if tweak_data:difficulty_to_index(difficulty) <= 5 then
 		ponr_value = 600	
 	elseif tweak_data:difficulty_to_index(difficulty) == 6 or tweak_data:difficulty_to_index(difficulty) == 7 then
 		ponr_value = 570	
@@ -97,6 +91,72 @@ return {
 	[103317] = {
 		values = {
 			dialogue = "Play_loc_bex_109"
+		}
+	},
+	-- Disable server room reinforce
+	[101835] = {
+		values = {
+			enabled = false
+		}
+	},
+	-- Reinforce second floor above tellers
+	[100027] = {
+		reinforce = {
+			{
+				name = "teller_balcony1",
+				force = 2,
+				position = Vector3(1200, -2200, 400)
+			},
+			{
+				name = "teller_balcony2",
+				force = 2,
+				position = Vector3(-1200, -2200, 400)
+			}
+		}
+	},
+	-- Reinforce drill parts car on first break
+	[103346] = {
+		reinforce = {
+			{
+				name = "parts_car",
+				force = 2,
+				position = Vector3(3100, -1400, 0)
+			}
+		}
+	},
+	[103347] = {
+		reinforce = {
+			{
+				name = "parts_car",
+				force = 2,
+				position = Vector3(1600, 2100, 0)
+			}
+		}
+	},
+	[103352] = {
+		reinforce = {
+			{
+				name = "parts_car",
+				force = 2,
+				position = Vector3(1800, -2000, 0)
+			}
+		}
+	},
+	[103354] = {
+		reinforce = {
+			{
+				name = "parts_car",
+				force = 2,
+				position = Vector3(-1700, 3300, 0)
+			}
+		}
+	},
+	-- Disable parts reinforce when drill is done
+	[101829] = {
+		reinforce = {
+			{
+				name = "parts_car"
+			}
 		}
 	}
 }

--- a/req/mission_script/big.lua
+++ b/req/mission_script/big.lua
@@ -1,18 +1,12 @@
 local difficulty = Global.game_settings and Global.game_settings.difficulty or "normal"
 local difficulty_index = tweak_data:difficulty_to_index(difficulty)
-
-	if tweak_data:difficulty_to_index(difficulty) <= 2 then
-		ponr_value = 1200
-	elseif tweak_data:difficulty_to_index(difficulty) == 3 then
-		ponr_value = 1170
-	elseif tweak_data:difficulty_to_index(difficulty) == 4 then
-		ponr_value = 1140	
-	elseif tweak_data:difficulty_to_index(difficulty) == 5 then
-		ponr_value = 1080	
+	
+	if tweak_data:difficulty_to_index(difficulty) <= 5 then
+		ponr_value = 1080
 	elseif tweak_data:difficulty_to_index(difficulty) == 6 or tweak_data:difficulty_to_index(difficulty) == 7 then
-		ponr_value = 1080	
-	elseif tweak_data:difficulty_to_index(difficulty) == 8 then
 		ponr_value = 1050	
+	elseif tweak_data:difficulty_to_index(difficulty) == 8 then
+		ponr_value = 1020	
 	end
 	
 if Global.game_settings and Global.game_settings.one_down then	

--- a/req/mission_script/glace.lua
+++ b/req/mission_script/glace.lua
@@ -4,16 +4,10 @@ local difficulty_index = tweak_data:difficulty_to_index(difficulty)
 	if tweak_data:difficulty_to_index(difficulty) <= 7 then
 		bulldozer = "units/pd2_mod_nypd/characters/ene_bulldozer_1/ene_bulldozer_1"
 	elseif tweak_data:difficulty_to_index(difficulty) == 8 then
-		bulldozer = "units/pd2_dlc_gitgud/characters/ene_bulldozer_minigun/ene_bulldozer_minigun"
+		bulldozer = "units/pd2_dlc_gitgud/characters/ene_zeal_bulldozer_3_sc/ene_zeal_bulldozer_3_sc"
 	end	
-
-	if tweak_data:difficulty_to_index(difficulty) <= 2 then
-		ponr_value = 540
-	elseif tweak_data:difficulty_to_index(difficulty) == 3 then
-		ponr_value = 510	
-	elseif tweak_data:difficulty_to_index(difficulty) == 4 then
-		ponr_value = 480	
-	elseif tweak_data:difficulty_to_index(difficulty) == 5 then
+	
+	if tweak_data:difficulty_to_index(difficulty) <= 5 then
 		ponr_value = 420	
 	elseif tweak_data:difficulty_to_index(difficulty) == 6 or tweak_data:difficulty_to_index(difficulty) == 7 then
 		ponr_value = 390

--- a/req/mission_script/rat.lua
+++ b/req/mission_script/rat.lua
@@ -9,12 +9,12 @@ local difficulty_index = tweak_data:difficulty_to_index(difficulty)
 	
 return {
 	--Replace Heavy SWATs that spawn from the chopper with cloakers
-	[101650] = {
+	[101571] = {
 		values = {
             enemy = clonker
 		}
 	},
-	[101651] = {
+	[101572] = {
 		values = {
             enemy = clonker
 		}


### PR DESCRIPTION
* Added the Double Firepower mutator that allows dozers to always spawn in pairs (including new Crime Spree modifier as well)
* Tweaked PONR Timers in some heists
* Fixed Cloakers not properly replacing scripted Heavy SWATS on Cook Off
* Added SH Stuff for San Martin Bank
* Replaced Rappeling Zeal Benellidozer with Blackdozer in Green Bridge
* Fixed Titan Non-Shields having non-concussion weapons (Winters' Minions are still using Titan's LMGs to make them unique)
* Captain Winters will now alert when throwing grenades