### PR TITLE
Tweaking PONRs once again and other stuff

### DIFF
--- a/lua/sc/units/enemies/copdamage.lua
+++ b/lua/sc/units/enemies/copdamage.lua
@@ -3328,7 +3328,7 @@ function CopDamage:_comment_death(attacker, killed_unit, special_comment)
 		PlayerStandard.say_line(attacker:sound(), "g31x_any")
 	elseif victim_base:has_tag("sniper") then
 		PlayerStandard.say_line(attacker:sound(), "g35x_any")
-	elseif victim_base:has_tag("medic") then
+	elseif victim_base:has_tag("medic") or victim_base:has_tag("lpf") then
 		PlayerStandard.say_line(attacker:sound(), "g36x_any")
 	elseif victim_base:has_tag("custom") then
 		local delay = TimerManager:game():time() + 1
@@ -3357,7 +3357,7 @@ function CopDamage:_AI_comment_death(unit, killed_unit, special_comment)
 		unit:sound():say("g31x_any", true)
 	elseif victim_base:has_tag("sniper") then
 		unit:sound():say("g35x_any", true)
-	elseif victim_base:has_tag("medic") then
+	elseif victim_base:has_tag("medic") or victim_base:has_tag("lpf") then
 		unit:sound():say("g36x_any", true)
 	elseif victim_base:has_tag("custom") then
 		local delay = TimerManager:game():time() + 1

--- a/req/mission_script/arm_cro.lua
+++ b/req/mission_script/arm_cro.lua
@@ -18,11 +18,11 @@ local difficulty_index = tweak_data:difficulty_to_index(difficulty)
 	end
 
 	if tweak_data:difficulty_to_index(difficulty) <= 5 then
-		ponr_value = 660
+		ponr_value = 300
 	elseif tweak_data:difficulty_to_index(difficulty) == 6 or tweak_data:difficulty_to_index(difficulty) == 7 then
-		ponr_value = 630	
+		ponr_value = 420	
 	elseif tweak_data:difficulty_to_index(difficulty) == 8 then
-		ponr_value = 600	
+		ponr_value = 540	
 	end
 
 return {

--- a/req/mission_script/arm_fac.lua
+++ b/req/mission_script/arm_fac.lua
@@ -18,11 +18,11 @@ local difficulty_index = tweak_data:difficulty_to_index(difficulty)
 	end
 
 	if tweak_data:difficulty_to_index(difficulty) <= 5 then
-		ponr_value = 660
+		ponr_value = 300
 	elseif tweak_data:difficulty_to_index(difficulty) == 6 or tweak_data:difficulty_to_index(difficulty) == 7 then
-		ponr_value = 630	
+		ponr_value = 420	
 	elseif tweak_data:difficulty_to_index(difficulty) == 8 then
-		ponr_value = 600	
+		ponr_value = 540	
 	end
 
 return {

--- a/req/mission_script/arm_for.lua
+++ b/req/mission_script/arm_for.lua
@@ -2,16 +2,42 @@ local difficulty = Global.game_settings and Global.game_settings.difficulty or "
 local difficulty_index = tweak_data:difficulty_to_index(difficulty)
 
 	if tweak_data:difficulty_to_index(difficulty) <= 5 then
-		ponr_value = 960
+		ponr_value = 1080
 	elseif tweak_data:difficulty_to_index(difficulty) == 6 or tweak_data:difficulty_to_index(difficulty) == 7 then
-		ponr_value = 930	
+		ponr_value = 1050	
 	elseif tweak_data:difficulty_to_index(difficulty) == 8 then
-		ponr_value = 900	
+		ponr_value = 1020	
 	end
+	
+local ponr_timer_player_mul = {
+		1,
+		0.85,
+		0.7,
+		0.65,
+		0.65,
+		0.65,
+		0.65,
+		0.65,
+		0.65,
+		0.65,
+		0.65,
+		0.65,
+		0.65,
+		0.65,
+		0.65,
+		0.65,
+		0.65,
+		0.65,
+		0.65,
+		0.65,
+		0.65,
+		0.65
+}	
 
 return {
 	--Pro Job PONR 
 	[105046] = {
+		ponr_player_mul = ponr_timer_player_mul,
 		ponr = ponr_value
 	},
 	-- restores unused sniper spawn

--- a/req/mission_script/arm_hcm.lua
+++ b/req/mission_script/arm_hcm.lua
@@ -18,11 +18,11 @@ local difficulty_index = tweak_data:difficulty_to_index(difficulty)
 	end
 
 	if tweak_data:difficulty_to_index(difficulty) <= 5 then
-		ponr_value = 660
+		ponr_value = 300
 	elseif tweak_data:difficulty_to_index(difficulty) == 6 or tweak_data:difficulty_to_index(difficulty) == 7 then
-		ponr_value = 630	
+		ponr_value = 420	
 	elseif tweak_data:difficulty_to_index(difficulty) == 8 then
-		ponr_value = 600	
+		ponr_value = 540	
 	end
 
 return {

--- a/req/mission_script/arm_par.lua
+++ b/req/mission_script/arm_par.lua
@@ -18,11 +18,11 @@ local difficulty_index = tweak_data:difficulty_to_index(difficulty)
 	end
 
 	if tweak_data:difficulty_to_index(difficulty) <= 5 then
-		ponr_value = 660
+		ponr_value = 300
 	elseif tweak_data:difficulty_to_index(difficulty) == 6 or tweak_data:difficulty_to_index(difficulty) == 7 then
-		ponr_value = 630	
+		ponr_value = 420	
 	elseif tweak_data:difficulty_to_index(difficulty) == 8 then
-		ponr_value = 600	
+		ponr_value = 540	
 	end
 
 return {

--- a/req/mission_script/arm_und.lua
+++ b/req/mission_script/arm_und.lua
@@ -18,11 +18,11 @@ local difficulty_index = tweak_data:difficulty_to_index(difficulty)
 	end
 
 	if tweak_data:difficulty_to_index(difficulty) <= 5 then
-		ponr_value = 660
+		ponr_value = 300
 	elseif tweak_data:difficulty_to_index(difficulty) == 6 or tweak_data:difficulty_to_index(difficulty) == 7 then
-		ponr_value = 630	
+		ponr_value = 420	
 	elseif tweak_data:difficulty_to_index(difficulty) == 8 then
-		ponr_value = 600	
+		ponr_value = 540	
 	end
 
 return {

--- a/req/mission_script/bph.lua
+++ b/req/mission_script/bph.lua
@@ -1,4 +1,19 @@
+local difficulty = Global.game_settings and Global.game_settings.difficulty or "normal"
+local difficulty_index = tweak_data:difficulty_to_index(difficulty)
+local murky_guard = "units/pd2_mod_sharks/characters/ene_murky_cs_cop_r870/ene_murky_cs_cop_r870"
+
+	if Global.game_settings and Global.game_settings.one_down then
+		timelock = 150
+		murky_guard = "units/pd2_mod_sharks/characters/ene_murky_fbi_tank_r870/ene_murky_fbi_tank_r870"
+	end	
+
 return {
+	--More timelock timer on Pro Jobs
+	[101402] = {
+		values = {
+            time = timelock
+		}
+	},
 	-- restores some unused sniper spawns with their SOs
 	[100369] = {
 		values = {
@@ -41,9 +56,10 @@ return {
 		}
 	},
 	--murky spawn changes
+	--Spawn the dozer in security room (PJ only)
 	[101669] = {
 		values = {
-            enemy = "units/pd2_mod_sharks/characters/ene_murky_cs_cop_r870/ene_murky_cs_cop_r870"
+            enemy = murky_guard
 		}
 	},
 	[101670] = {

--- a/req/mission_script/chas.lua
+++ b/req/mission_script/chas.lua
@@ -1,18 +1,12 @@
 local difficulty = Global.game_settings and Global.game_settings.difficulty or "normal"
 local difficulty_index = tweak_data:difficulty_to_index(difficulty)
 
-	if tweak_data:difficulty_to_index(difficulty) <= 2 then
-		ponr_value = 690
-	elseif tweak_data:difficulty_to_index(difficulty) == 3 then
-		ponr_value = 660
-	elseif tweak_data:difficulty_to_index(difficulty) == 4 then
-		ponr_value = 630
-	elseif tweak_data:difficulty_to_index(difficulty) == 5 then
-		ponr_value = 600	
-	elseif tweak_data:difficulty_to_index(difficulty) == 6 or tweak_data:difficulty_to_index(difficulty) == 7 then
-		ponr_value = 570	
-	elseif tweak_data:difficulty_to_index(difficulty) == 8 then
+	if tweak_data:difficulty_to_index(difficulty) <= 5 then
 		ponr_value = 540	
+	elseif tweak_data:difficulty_to_index(difficulty) == 6 or tweak_data:difficulty_to_index(difficulty) == 7 then
+		ponr_value = 480	
+	elseif tweak_data:difficulty_to_index(difficulty) == 8 then
+		ponr_value = 420	
 	end
 
 return {

--- a/req/mission_script/corp.lua
+++ b/req/mission_script/corp.lua
@@ -1,13 +1,7 @@
 local difficulty = Global.game_settings and Global.game_settings.difficulty or "normal"
 local difficulty_index = tweak_data:difficulty_to_index(difficulty)
-
-	if tweak_data:difficulty_to_index(difficulty) <= 2 then
-		ponr_value = 780
-	elseif tweak_data:difficulty_to_index(difficulty) == 3 then
-		ponr_value = 750	
-	elseif tweak_data:difficulty_to_index(difficulty) == 4 then
-		ponr_value = 720	
-	elseif tweak_data:difficulty_to_index(difficulty) == 5 then
+	
+	if tweak_data:difficulty_to_index(difficulty) <= 5 then
 		ponr_value = 660
 	elseif tweak_data:difficulty_to_index(difficulty) == 6 or tweak_data:difficulty_to_index(difficulty) == 7 then
 		ponr_value = 630

--- a/req/mission_script/crimepunishlvl.lua
+++ b/req/mission_script/crimepunishlvl.lua
@@ -1,13 +1,7 @@
 local difficulty = Global.game_settings and Global.game_settings.difficulty or "normal"
 local difficulty_index = tweak_data:difficulty_to_index(difficulty)
-
-	if tweak_data:difficulty_to_index(difficulty) <= 2 then
-		ponr_value = 750
-	elseif tweak_data:difficulty_to_index(difficulty) == 3 then
-		ponr_value = 720
-	elseif tweak_data:difficulty_to_index(difficulty) == 4 then
-		ponr_value = 690	
-	elseif tweak_data:difficulty_to_index(difficulty) == 5 then
+	
+	if tweak_data:difficulty_to_index(difficulty) <= 5 then
 		ponr_value = 660
 	elseif tweak_data:difficulty_to_index(difficulty) == 6 or tweak_data:difficulty_to_index(difficulty) == 7 then
 		ponr_value = 630	

--- a/req/mission_script/crojob2.lua
+++ b/req/mission_script/crojob2.lua
@@ -1,13 +1,7 @@
 local difficulty = Global.game_settings and Global.game_settings.difficulty or "normal"
 local difficulty_index = tweak_data:difficulty_to_index(difficulty)
-
-	if tweak_data:difficulty_to_index(difficulty) <= 2 then
-		ponr_value = 690
-	elseif tweak_data:difficulty_to_index(difficulty) == 3 then
-		ponr_value = 660
-	elseif tweak_data:difficulty_to_index(difficulty) == 4 then
-		ponr_value = 630	
-	elseif tweak_data:difficulty_to_index(difficulty) == 5 then
+	
+	if tweak_data:difficulty_to_index(difficulty) <= 5 then
 		ponr_value = 600	
 	elseif tweak_data:difficulty_to_index(difficulty) == 6 or tweak_data:difficulty_to_index(difficulty) == 7 then
 		ponr_value = 570	

--- a/req/mission_script/crojob3.lua
+++ b/req/mission_script/crojob3.lua
@@ -1,13 +1,7 @@
 local difficulty = Global.game_settings and Global.game_settings.difficulty or "normal"
 local difficulty_index = tweak_data:difficulty_to_index(difficulty)
 
-	if tweak_data:difficulty_to_index(difficulty) <= 2 then
-		ponr_value = 750
-	elseif tweak_data:difficulty_to_index(difficulty) == 3 then
-		ponr_value = 720	
-	elseif tweak_data:difficulty_to_index(difficulty) == 4 then
-		ponr_value = 690
-	elseif tweak_data:difficulty_to_index(difficulty) == 5 then
+	if tweak_data:difficulty_to_index(difficulty) <= 5 then
 		ponr_value = 660	
 	elseif tweak_data:difficulty_to_index(difficulty) == 6 or tweak_data:difficulty_to_index(difficulty) == 7 then
 		ponr_value = 630

--- a/req/mission_script/dah.lua
+++ b/req/mission_script/dah.lua
@@ -1,13 +1,7 @@
 local difficulty = Global.game_settings and Global.game_settings.difficulty or "normal"
 local difficulty_index = tweak_data:difficulty_to_index(difficulty)
 
-	if tweak_data:difficulty_to_index(difficulty) <= 2 then
-		ponr_value = 540
-	elseif tweak_data:difficulty_to_index(difficulty) == 3 then
-		ponr_value = 510
-	elseif tweak_data:difficulty_to_index(difficulty) == 4 then
-		ponr_value = 480
-	elseif tweak_data:difficulty_to_index(difficulty) == 5 then
+	if tweak_data:difficulty_to_index(difficulty) <= 5 then
 		ponr_value = 420
 	elseif tweak_data:difficulty_to_index(difficulty) == 6 or tweak_data:difficulty_to_index(difficulty) == 7 then
 		ponr_value = 390

--- a/req/mission_script/des.lua
+++ b/req/mission_script/des.lua
@@ -1,13 +1,7 @@
 local difficulty = Global.game_settings and Global.game_settings.difficulty or "normal"
 local difficulty_index = tweak_data:difficulty_to_index(difficulty)
 
-	if tweak_data:difficulty_to_index(difficulty) <= 2 then
-		ponr_value = 690
-	elseif tweak_data:difficulty_to_index(difficulty) == 3 then
-		ponr_value = 660
-	elseif tweak_data:difficulty_to_index(difficulty) == 4 then
-		ponr_value = 630
-	elseif tweak_data:difficulty_to_index(difficulty) == 5 then
+	if tweak_data:difficulty_to_index(difficulty) <= 5 then
 		ponr_value = 600	
 	elseif tweak_data:difficulty_to_index(difficulty) == 6 or tweak_data:difficulty_to_index(difficulty) == 7 then
 		ponr_value = 570

--- a/req/mission_script/family.lua
+++ b/req/mission_script/family.lua
@@ -28,5 +28,11 @@ return {
 		values = {
 			enabled = false
 		}
+	},
+	--Disable the SWAT Turret
+	[102124] = {
+		values = {
+			enabled = false
+		}
 	}
 }	

--- a/req/mission_script/family.lua
+++ b/req/mission_script/family.lua
@@ -2,12 +2,10 @@ local difficulty = Global.game_settings and Global.game_settings.difficulty or "
 local difficulty_index = tweak_data:difficulty_to_index(difficulty)
 
 	if tweak_data:difficulty_to_index(difficulty) <= 5 then
-		ponr_value = 860
-	elseif tweak_data:difficulty_to_index(difficulty) == 6 or tweak_data:difficulty_to_index(difficulty) == 7 then
-		ponr_value = 830
-	elseif tweak_data:difficulty_to_index(difficulty) == 8 then
-		ponr_value = 780	
-	end
+		ponr_value = 360
+	elseif tweak_data:difficulty_to_index(difficulty) == 6 or tweak_data:difficulty_to_index(difficulty) == 7 or tweak_data:difficulty_to_index(difficulty) == 8 then
+		ponr_value = 480
+	end	
 
 return {
 	--Pro Job PONR 
@@ -18,6 +16,17 @@ return {
 	[100370] = {
 		values = {
 			enabled = true
+		}
+	},
+	--disable the bad van escape spots
+	[100754] = {
+		values = {
+			enabled = false
+		}
+	},
+	[100755] = {
+		values = {
+			enabled = false
 		}
 	}
 }	

--- a/req/mission_script/fex.lua
+++ b/req/mission_script/fex.lua
@@ -1,18 +1,12 @@
 local difficulty = Global.game_settings and Global.game_settings.difficulty or "normal"
 local difficulty_index = tweak_data:difficulty_to_index(difficulty)
-
-	if tweak_data:difficulty_to_index(difficulty) <= 2 then
-		ponr_value = 690
-	elseif tweak_data:difficulty_to_index(difficulty) == 3 then
-		ponr_value = 660	
-	elseif tweak_data:difficulty_to_index(difficulty) == 4 then
-		ponr_value = 630	
-	elseif tweak_data:difficulty_to_index(difficulty) == 5 then
+	
+	if tweak_data:difficulty_to_index(difficulty) <= 5 then
 		ponr_value = 600	
 	elseif tweak_data:difficulty_to_index(difficulty) == 6 or tweak_data:difficulty_to_index(difficulty) == 7 then
-		ponr_value = 570	
+		ponr_value = 540	
 	elseif tweak_data:difficulty_to_index(difficulty) == 8 then
-		ponr_value = 540		
+		ponr_value = 480		
 	end
 
 return {

--- a/req/mission_script/firestarter_1_res.lua
+++ b/req/mission_script/firestarter_1_res.lua
@@ -1,23 +1,43 @@
 local difficulty = Global.game_settings and Global.game_settings.difficulty or "normal"
 local difficulty_index = tweak_data:difficulty_to_index(difficulty)
-
-	if tweak_data:difficulty_to_index(difficulty) <= 2 then
-		ponr_value = 1200
-	elseif tweak_data:difficulty_to_index(difficulty) == 3 then
-		ponr_value = 1170
-	elseif tweak_data:difficulty_to_index(difficulty) == 4 then
-		ponr_value = 1140	
-	elseif tweak_data:difficulty_to_index(difficulty) == 5 then
+	
+	if tweak_data:difficulty_to_index(difficulty) == 5 then
 		ponr_value = 1080	
 	elseif tweak_data:difficulty_to_index(difficulty) == 6 or tweak_data:difficulty_to_index(difficulty) == 7 then
-		ponr_value = 1080	
+		ponr_value = 1050	
 	elseif tweak_data:difficulty_to_index(difficulty) == 8 then
-		ponr_value = 1050		
+		ponr_value = 1020		
 	end
+
+local ponr_timer_player_mul = {
+		1,
+		0.85,
+		0.7,
+		0.65,
+		0.65,
+		0.65,
+		0.65,
+		0.65,
+		0.65,
+		0.65,
+		0.65,
+		0.65,
+		0.65,
+		0.65,
+		0.65,
+		0.65,
+		0.65,
+		0.65,
+		0.65,
+		0.65,
+		0.65,
+		0.65
+}	
 
 return {
 	--Pro Job PONR 
 	[101791] = {
+		ponr_player_mul = ponr_timer_player_mul,
 		ponr = ponr_value
 	}
 }

--- a/req/mission_script/firestarter_2_res.lua
+++ b/req/mission_script/firestarter_2_res.lua
@@ -1,13 +1,7 @@
 local difficulty = Global.game_settings and Global.game_settings.difficulty or "normal"
 local difficulty_index = tweak_data:difficulty_to_index(difficulty)
 
-	if tweak_data:difficulty_to_index(difficulty) <= 2 then
-		ponr_value = 450
-	elseif tweak_data:difficulty_to_index(difficulty) == 3 then
-		ponr_value = 420
-	elseif tweak_data:difficulty_to_index(difficulty) == 4 then
-		ponr_value = 390
-	elseif tweak_data:difficulty_to_index(difficulty) == 5 then
+	if tweak_data:difficulty_to_index(difficulty) <= 5 then
 		ponr_value = 360	
 	elseif tweak_data:difficulty_to_index(difficulty) == 6 or tweak_data:difficulty_to_index(difficulty) == 7 then
 		ponr_value = 330	

--- a/req/mission_script/firestarter_3_res.lua
+++ b/req/mission_script/firestarter_3_res.lua
@@ -1,23 +1,43 @@
 local difficulty = Global.game_settings and Global.game_settings.difficulty or "normal"
 local difficulty_index = tweak_data:difficulty_to_index(difficulty)
-
-	if tweak_data:difficulty_to_index(difficulty) <= 2 then
-		ponr_value = 450
-	elseif tweak_data:difficulty_to_index(difficulty) == 3 then
-		ponr_value = 420
-	elseif tweak_data:difficulty_to_index(difficulty) == 4 then
-		ponr_value = 390	
-	elseif tweak_data:difficulty_to_index(difficulty) == 5 then
-		ponr_value = 360	
+	
+	if tweak_data:difficulty_to_index(difficulty) <= 5 then
+		ponr_value = 720
 	elseif tweak_data:difficulty_to_index(difficulty) == 6 or tweak_data:difficulty_to_index(difficulty) == 7 then
-		ponr_value = 330	
+		ponr_value = 660	
 	elseif tweak_data:difficulty_to_index(difficulty) == 8 then
-		ponr_value = 300		
+		ponr_value = 600
 	end
+	
+	local ponr_timer_player_mul = {
+		1,
+		0.85,
+		0.7,
+		0.65,
+		0.65,
+		0.65,
+		0.65,
+		0.65,
+		0.65,
+		0.65,
+		0.65,
+		0.65,
+		0.65,
+		0.65,
+		0.65,
+		0.65,
+		0.65,
+		0.65,
+		0.65,
+		0.65,
+		0.65,
+		0.65
+}
 
 return {
 	--Pro Job PONR 
 	[100872] = {
+		ponr_player_mul = ponr_timer_player_mul,
 		ponr = ponr_value
 	}
 }

--- a/req/mission_script/four_stores.lua
+++ b/req/mission_script/four_stores.lua
@@ -1,18 +1,12 @@
 local difficulty = Global.game_settings and Global.game_settings.difficulty or "normal"
 local difficulty_index = tweak_data:difficulty_to_index(difficulty)
 
-	if tweak_data:difficulty_to_index(difficulty) <= 2 then
-		ponr_value = 600
-	elseif tweak_data:difficulty_to_index(difficulty) == 3 then
-		ponr_value = 600	
-	elseif tweak_data:difficulty_to_index(difficulty) == 4 then
-		ponr_value = 570	
-	elseif tweak_data:difficulty_to_index(difficulty) == 5 then
-		ponr_value = 540	
+	if tweak_data:difficulty_to_index(difficulty) <= 5 then
+		ponr_value = 300	
 	elseif tweak_data:difficulty_to_index(difficulty) == 6 or tweak_data:difficulty_to_index(difficulty) == 7 then
-		ponr_value = 520	
+		ponr_value = 360	
 	elseif tweak_data:difficulty_to_index(difficulty) == 8 then
-		ponr_value = 480		
+		ponr_value = 420		
 	end
 
 return {

--- a/req/mission_script/framing_frame_2.lua
+++ b/req/mission_script/framing_frame_2.lua
@@ -1,18 +1,12 @@
 local difficulty = Global.game_settings and Global.game_settings.difficulty or "normal"
 local difficulty_index = tweak_data:difficulty_to_index(difficulty)
-
-	if tweak_data:difficulty_to_index(difficulty) <= 2 then
-		ponr_value = 690
-	elseif tweak_data:difficulty_to_index(difficulty) == 3 then
-		ponr_value = 660	
-	elseif tweak_data:difficulty_to_index(difficulty) == 4 then
-		ponr_value = 630	
-	elseif tweak_data:difficulty_to_index(difficulty) == 5 then
-		ponr_value = 600
+	
+	if tweak_data:difficulty_to_index(difficulty) <= 5 then
+		ponr_value = 300
 	elseif tweak_data:difficulty_to_index(difficulty) == 6 or tweak_data:difficulty_to_index(difficulty) == 7 then
-		ponr_value = 570	
+		ponr_value = 360	
 	elseif tweak_data:difficulty_to_index(difficulty) == 8 then
-		ponr_value = 540		
+		ponr_value = 420		
 	end
 
 return {

--- a/req/mission_script/framing_frame_3.lua
+++ b/req/mission_script/framing_frame_3.lua
@@ -1,13 +1,7 @@
 local difficulty = Global.game_settings and Global.game_settings.difficulty or "normal"
 local difficulty_index = tweak_data:difficulty_to_index(difficulty)
-
-	if tweak_data:difficulty_to_index(difficulty) <= 2 then
-		ponr_value = 450
-	elseif tweak_data:difficulty_to_index(difficulty) == 3 then
-		ponr_value = 420	
-	elseif tweak_data:difficulty_to_index(difficulty) == 4 then
-		ponr_value = 390	
-	elseif tweak_data:difficulty_to_index(difficulty) == 5 then
+	
+	if tweak_data:difficulty_to_index(difficulty) <= 5 then
 		ponr_value = 360	
 	elseif tweak_data:difficulty_to_index(difficulty) == 6 or tweak_data:difficulty_to_index(difficulty) == 7 then
 		ponr_value = 330	

--- a/req/mission_script/hox_2.lua
+++ b/req/mission_script/hox_2.lua
@@ -1,13 +1,7 @@
 local difficulty = Global.game_settings and Global.game_settings.difficulty or "normal"
 local difficulty_index = tweak_data:difficulty_to_index(difficulty)
-
-	if tweak_data:difficulty_to_index(difficulty) <= 2 then
-		ponr_value = 390
-	elseif tweak_data:difficulty_to_index(difficulty) == 3 then
-		ponr_value = 360	
-	elseif tweak_data:difficulty_to_index(difficulty) == 4 then
-		ponr_value = 330	
-	elseif tweak_data:difficulty_to_index(difficulty) == 5 then
+	
+	if tweak_data:difficulty_to_index(difficulty) <= 5 then
 		ponr_value = 300	
 	elseif tweak_data:difficulty_to_index(difficulty) == 6 or tweak_data:difficulty_to_index(difficulty) == 7 then
 		ponr_value = 270

--- a/req/mission_script/hox_3.lua
+++ b/req/mission_script/hox_3.lua
@@ -1,13 +1,7 @@
 local difficulty = Global.game_settings and Global.game_settings.difficulty or "normal"
 local difficulty_index = tweak_data:difficulty_to_index(difficulty)
 
-	if tweak_data:difficulty_to_index(difficulty) <= 2 then
-		ponr_value = 740
-	elseif tweak_data:difficulty_to_index(difficulty) == 3 then
-		ponr_value = 710
-	elseif tweak_data:difficulty_to_index(difficulty) == 4 then
-		ponr_value = 680
-	elseif tweak_data:difficulty_to_index(difficulty) == 5 then
+	if tweak_data:difficulty_to_index(difficulty) <= 5 then
 		ponr_value = 650
 	elseif tweak_data:difficulty_to_index(difficulty) == 6 or tweak_data:difficulty_to_index(difficulty) == 7 then
 		ponr_value = 600

--- a/req/mission_script/hunter_departure.lua
+++ b/req/mission_script/hunter_departure.lua
@@ -1,13 +1,7 @@
 local difficulty = Global.game_settings and Global.game_settings.difficulty or "normal"
 local difficulty_index = tweak_data:difficulty_to_index(difficulty)
-
-	if tweak_data:difficulty_to_index(difficulty) <= 2 then
-		ponr_value = 510
-	elseif tweak_data:difficulty_to_index(difficulty) == 3 then
-		ponr_value = 480	
-	elseif tweak_data:difficulty_to_index(difficulty) == 4 then
-		ponr_value = 450	
-	elseif tweak_data:difficulty_to_index(difficulty) == 5 then
+	
+	if tweak_data:difficulty_to_index(difficulty) <= 5 then
 		ponr_value = 420	
 	elseif tweak_data:difficulty_to_index(difficulty) == 6 or tweak_data:difficulty_to_index(difficulty) == 7 then
 		ponr_value = 390	

--- a/req/mission_script/hunter_party.lua
+++ b/req/mission_script/hunter_party.lua
@@ -1,13 +1,7 @@
 local difficulty = Global.game_settings and Global.game_settings.difficulty or "normal"
 local difficulty_index = tweak_data:difficulty_to_index(difficulty)
-
-	if tweak_data:difficulty_to_index(difficulty) <= 2 then
-		ponr_value = 510
-	elseif tweak_data:difficulty_to_index(difficulty) == 3 then
-		ponr_value = 480	
-	elseif tweak_data:difficulty_to_index(difficulty) == 4 then
-		ponr_value = 450	
-	elseif tweak_data:difficulty_to_index(difficulty) == 5 then
+	
+	if tweak_data:difficulty_to_index(difficulty) <= 5 then
 		ponr_value = 420	
 	elseif tweak_data:difficulty_to_index(difficulty) == 6 or tweak_data:difficulty_to_index(difficulty) == 7 then
 		ponr_value = 390	

--- a/req/mission_script/jewelry_store.lua
+++ b/req/mission_script/jewelry_store.lua
@@ -1,12 +1,12 @@
 local difficulty = Global.game_settings and Global.game_settings.difficulty or "normal"
 local difficulty_index = tweak_data:difficulty_to_index(difficulty)
 	
-	if tweak_data:difficulty_to_index(difficulty) <= 5 then
-		ponr_value = 600
-	elseif tweak_data:difficulty_to_index(difficulty) == 6 or tweak_data:difficulty_to_index(difficulty) == 7 then
-		ponr_value = 540	
-	elseif tweak_data:difficulty_to_index(difficulty) == 8 then
-		ponr_value = 480		
+	if tweak_data:difficulty_to_index(difficulty) <= 4 then
+		ponr_value = 300
+	elseif tweak_data:difficulty_to_index(difficulty) == 5 then
+		ponr_value = 360	
+	elseif tweak_data:difficulty_to_index(difficulty) == 6 or tweak_data:difficulty_to_index(difficulty) == 7 or tweak_data:difficulty_to_index(difficulty) == 8 then
+		ponr_value = 420	
 	end
 
 return {

--- a/req/mission_script/mallcrasher.lua
+++ b/req/mission_script/mallcrasher.lua
@@ -1,18 +1,10 @@
 local difficulty = Global.game_settings and Global.game_settings.difficulty or "normal"
 local difficulty_index = tweak_data:difficulty_to_index(difficulty)
-
-	if tweak_data:difficulty_to_index(difficulty) <= 2 then
-		ponr_value = 690
-	elseif tweak_data:difficulty_to_index(difficulty) == 3 then
-		ponr_value = 660	
-	elseif tweak_data:difficulty_to_index(difficulty) == 4 then
-		ponr_value = 630	
-	elseif tweak_data:difficulty_to_index(difficulty) == 5 then
-		ponr_value = 600	
-	elseif tweak_data:difficulty_to_index(difficulty) == 6 or tweak_data:difficulty_to_index(difficulty) == 7 then
-		ponr_value = 570	
-	elseif tweak_data:difficulty_to_index(difficulty) == 8 then
-		ponr_value = 540		
+	
+	if tweak_data:difficulty_to_index(difficulty) <= 5 then
+		ponr_value = 300	
+	elseif tweak_data:difficulty_to_index(difficulty) == 6 or tweak_data:difficulty_to_index(difficulty) == 7 or tweak_data:difficulty_to_index(difficulty) == 8 then
+		ponr_value = 480
 	end
 
 return {

--- a/req/mission_script/mia_1.lua
+++ b/req/mission_script/mia_1.lua
@@ -1,23 +1,18 @@
 local difficulty = Global.game_settings and Global.game_settings.difficulty or "normal"
 local difficulty_index = tweak_data:difficulty_to_index(difficulty)
 
-	if tweak_data:difficulty_to_index(difficulty) <= 2 then
-		ponr_value = 1050
-	elseif tweak_data:difficulty_to_index(difficulty) == 3 then
-		ponr_value = 1020	
-	elseif tweak_data:difficulty_to_index(difficulty) == 4 then
-		ponr_value = 990	
-	elseif tweak_data:difficulty_to_index(difficulty) == 5 then
-		ponr_value = 960	
+	
+	if tweak_data:difficulty_to_index(difficulty) <= 5 then
+		ponr_value = 600	
 	elseif tweak_data:difficulty_to_index(difficulty) == 6 or tweak_data:difficulty_to_index(difficulty) == 7 then
-		ponr_value = 930	
+		ponr_value = 540	
 	elseif tweak_data:difficulty_to_index(difficulty) == 8 then
-		ponr_value = 900		
+		ponr_value = 480		
 	end
 
 return {
-		--Pro Job PONR 
-		[101289] = {
-			ponr = ponr_value
-		}
+	--Pro Job PONR 
+	[101289] = {
+		ponr = ponr_value
+	}
 }	

--- a/req/mission_script/mia_2.lua
+++ b/req/mission_script/mia_2.lua
@@ -1,18 +1,12 @@
 local difficulty = Global.game_settings and Global.game_settings.difficulty or "normal"
 local difficulty_index = tweak_data:difficulty_to_index(difficulty)
-
-	if tweak_data:difficulty_to_index(difficulty) <= 2 then
-		ponr_value = 450
-	elseif tweak_data:difficulty_to_index(difficulty) == 3 then
-		ponr_value = 420	
-	elseif tweak_data:difficulty_to_index(difficulty) == 4 then
-		ponr_value = 390	
-	elseif tweak_data:difficulty_to_index(difficulty) == 5 then
-		ponr_value = 360
-	elseif tweak_data:difficulty_to_index(difficulty) == 6 or tweak_data:difficulty_to_index(difficulty) == 7 then
+	
+	if tweak_data:difficulty_to_index(difficulty) <= 5 then
 		ponr_value = 330
+	elseif tweak_data:difficulty_to_index(difficulty) == 6 or tweak_data:difficulty_to_index(difficulty) == 7 then
+		ponr_value = 300
 	elseif tweak_data:difficulty_to_index(difficulty) == 8 then
-		ponr_value = 300		
+		ponr_value = 240		
 	end
 
 return {

--- a/req/mission_script/moon.lua
+++ b/req/mission_script/moon.lua
@@ -1,13 +1,7 @@
 local difficulty = Global.game_settings and Global.game_settings.difficulty or "normal"
 local difficulty_index = tweak_data:difficulty_to_index(difficulty)
 
-	if tweak_data:difficulty_to_index(difficulty) <= 2 then
-		ponr_value = 570
-	elseif tweak_data:difficulty_to_index(difficulty) == 3 then
-		ponr_value = 540
-	elseif tweak_data:difficulty_to_index(difficulty) == 4 then
-		ponr_value = 510
-	elseif tweak_data:difficulty_to_index(difficulty) == 5 then
+	if tweak_data:difficulty_to_index(difficulty) <= 5 then
 		ponr_value = 480
 	elseif tweak_data:difficulty_to_index(difficulty) == 6 or tweak_data:difficulty_to_index(difficulty) == 7 then
 		ponr_value = 450

--- a/req/mission_script/mus.lua
+++ b/req/mission_script/mus.lua
@@ -1,18 +1,12 @@
 local difficulty = Global.game_settings and Global.game_settings.difficulty or "normal"
 local difficulty_index = tweak_data:difficulty_to_index(difficulty)
-
-	if tweak_data:difficulty_to_index(difficulty) <= 2 then
-		ponr_value = 1050
-	elseif tweak_data:difficulty_to_index(difficulty) == 3 then
-		ponr_value = 1020	
-	elseif tweak_data:difficulty_to_index(difficulty) == 4 then
-		ponr_value = 990	
-	elseif tweak_data:difficulty_to_index(difficulty) == 5 then
-		ponr_value = 960	
+	
+	if tweak_data:difficulty_to_index(difficulty) <= 5 then
+		ponr_value = 480	
 	elseif tweak_data:difficulty_to_index(difficulty) == 6 or tweak_data:difficulty_to_index(difficulty) == 7 then
-		ponr_value = 930	
+		ponr_value = 540	
 	elseif tweak_data:difficulty_to_index(difficulty) == 8 then
-		ponr_value = 900		
+		ponr_value = 600		
 	end
 
 return {

--- a/req/mission_script/pbr2.lua
+++ b/req/mission_script/pbr2.lua
@@ -2,18 +2,12 @@ local difficulty = Global.game_settings and Global.game_settings.difficulty or "
 local difficulty_index = tweak_data:difficulty_to_index(difficulty)
 
 if Global.game_settings and Global.game_settings.one_down then
-	if tweak_data:difficulty_to_index(difficulty) <= 2 then
-		ponr_value = 1050
-	elseif tweak_data:difficulty_to_index(difficulty) == 3 then
-		ponr_value = 1020
-	elseif tweak_data:difficulty_to_index(difficulty) == 4 then
-		ponr_value = 990
-	elseif tweak_data:difficulty_to_index(difficulty) == 5 then
-		ponr_value = 960	
+	if tweak_data:difficulty_to_index(difficulty) <= 5 then
+		ponr_value = 600	
 	elseif tweak_data:difficulty_to_index(difficulty) == 6 or tweak_data:difficulty_to_index(difficulty) == 7 then
-		ponr_value = 930	
+		ponr_value = 540	
 	elseif tweak_data:difficulty_to_index(difficulty) == 8 then
-		ponr_value = 900		
+		ponr_value = 480		
 	end
 end
 

--- a/req/mission_script/pent.lua
+++ b/req/mission_script/pent.lua
@@ -1,23 +1,43 @@
 local difficulty = Global.game_settings and Global.game_settings.difficulty or "normal"
 local difficulty_index = tweak_data:difficulty_to_index(difficulty)
 
-if tweak_data:difficulty_to_index(difficulty) <= 2 then
-		ponr_value = 1290
-	elseif tweak_data:difficulty_to_index(difficulty) == 3 then
-		ponr_value = 1260
-	elseif tweak_data:difficulty_to_index(difficulty) == 4 then
-		ponr_value = 1260
-	elseif tweak_data:difficulty_to_index(difficulty) == 5 then
-		ponr_value = 1230
-	elseif tweak_data:difficulty_to_index(difficulty) == 6 or tweak_data:difficulty_to_index(difficulty) == 7 then
-		ponr_value = 1230
-	elseif tweak_data:difficulty_to_index(difficulty) == 8 then
+	if tweak_data:difficulty_to_index(difficulty) <= 5 then
 		ponr_value = 1200
+	elseif tweak_data:difficulty_to_index(difficulty) == 6 or tweak_data:difficulty_to_index(difficulty) == 7 then
+		ponr_value = 1140
+	elseif tweak_data:difficulty_to_index(difficulty) == 8 then
+		ponr_value = 1080
 	end
+
+local ponr_timer_player_mul = {
+		1,
+		0.85,
+		0.7,
+		0.65,
+		0.65,
+		0.65,
+		0.65,
+		0.65,
+		0.65,
+		0.65,
+		0.65,
+		0.65,
+		0.65,
+		0.65,
+		0.65,
+		0.65,
+		0.65,
+		0.65,
+		0.65,
+		0.65,
+		0.65,
+		0.65
+}	
 
 return {
 	--Pro Job PONR 
 	[101226] = {
+		ponr_player_mul = ponr_timer_player_mul,
 		ponr = ponr_value
 	},
 	[103595] = {

--- a/req/mission_script/peta.lua
+++ b/req/mission_script/peta.lua
@@ -1,23 +1,3 @@
-local difficulty = Global.game_settings and Global.game_settings.difficulty or "normal"
-local difficulty_index = tweak_data:difficulty_to_index(difficulty)
-
-	if tweak_data:difficulty_to_index(difficulty) <= 2 then
-		ponr_value = 690
-	elseif tweak_data:difficulty_to_index(difficulty) == 3 then
-		ponr_value = 660
-	elseif tweak_data:difficulty_to_index(difficulty) == 4 then
-		ponr_value = 630
-	elseif tweak_data:difficulty_to_index(difficulty) == 5 then
-		ponr_value = 600	
-	elseif tweak_data:difficulty_to_index(difficulty) == 6 or tweak_data:difficulty_to_index(difficulty) == 7 then
-		ponr_value = 570	
-	elseif tweak_data:difficulty_to_index(difficulty) == 8 then
-		ponr_value = 540		
-	end
-
-return {
-		--Pro Job PONR 
-		[100059] = {
-			ponr = ponr_value
-		}
-}	
+--[[
+	There's nothing for now 
+]]--

--- a/req/mission_script/peta2.lua
+++ b/req/mission_script/peta2.lua
@@ -1,23 +1,43 @@
 local difficulty = Global.game_settings and Global.game_settings.difficulty or "normal"
 local difficulty_index = tweak_data:difficulty_to_index(difficulty)
-
-	if tweak_data:difficulty_to_index(difficulty) <= 2 then
-		ponr_value = 1200
-	elseif tweak_data:difficulty_to_index(difficulty) == 3 then
-		ponr_value = 1170	
-	elseif tweak_data:difficulty_to_index(difficulty) == 4 then
-		ponr_value = 1140	
-	elseif tweak_data:difficulty_to_index(difficulty) == 5 then
+	
+	if tweak_data:difficulty_to_index(difficulty) <= 5 then
 		ponr_value = 1080
 	elseif tweak_data:difficulty_to_index(difficulty) == 6 or tweak_data:difficulty_to_index(difficulty) == 7 then
-		ponr_value = 1080	
+		ponr_value = 1050	
 	elseif tweak_data:difficulty_to_index(difficulty) == 8 then
-		ponr_value = 1050		
+		ponr_value = 1020		
 	end
+
+local ponr_timer_player_mul = {
+		1,
+		0.85,
+		0.7,
+		0.65,
+		0.65,
+		0.65,
+		0.65,
+		0.65,
+		0.65,
+		0.65,
+		0.65,
+		0.65,
+		0.65,
+		0.65,
+		0.65,
+		0.65,
+		0.65,
+		0.65,
+		0.65,
+		0.65,
+		0.65,
+		0.65
+}	
 
 return {
 	--Pro Job PONR 
 	[100580] = {
+		ponr_player_mul = ponr_timer_player_mul,
 		ponr = ponr_value
 	},
 	[101217] = {

--- a/req/mission_script/pex.lua
+++ b/req/mission_script/pex.lua
@@ -1,13 +1,7 @@
 local difficulty = Global.game_settings and Global.game_settings.difficulty or "normal"
 local difficulty_index = tweak_data:difficulty_to_index(difficulty)
 
-	if tweak_data:difficulty_to_index(difficulty) <= 2 then
-		ponr_value = 690
-	elseif tweak_data:difficulty_to_index(difficulty) == 3 then
-		ponr_value = 660	
-	elseif tweak_data:difficulty_to_index(difficulty) == 4 then
-		ponr_value = 630
-	elseif tweak_data:difficulty_to_index(difficulty) == 5 then
+	if tweak_data:difficulty_to_index(difficulty) <= 5 then
 		ponr_value = 600	
 	elseif tweak_data:difficulty_to_index(difficulty) == 6 or tweak_data:difficulty_to_index(difficulty) == 7 then
 		ponr_value = 570

--- a/req/mission_script/pines.lua
+++ b/req/mission_script/pines.lua
@@ -1,13 +1,7 @@
 local difficulty = Global.game_settings and Global.game_settings.difficulty or "normal"
 local difficulty_index = tweak_data:difficulty_to_index(difficulty)
-
-if tweak_data:difficulty_to_index(difficulty) <= 2 then
-		ponr_value = 700
-	elseif tweak_data:difficulty_to_index(difficulty) == 3 then
-		ponr_value = 660	
-	elseif tweak_data:difficulty_to_index(difficulty) == 4 then
-		ponr_value = 630	
-	elseif tweak_data:difficulty_to_index(difficulty) == 5 then
+	
+	if tweak_data:difficulty_to_index(difficulty) <= 5 then
 		ponr_value = 590	
 	elseif tweak_data:difficulty_to_index(difficulty) == 6 or tweak_data:difficulty_to_index(difficulty) == 7 then
 		ponr_value = 560	

--- a/req/mission_script/ranc.lua
+++ b/req/mission_script/ranc.lua
@@ -44,6 +44,7 @@ return {
 		ponr = ponr_value_1
 	},
 	[100929] = {
+		ponr_player_mul = ponr_timer_player_mul,
 		ponr = ponr_value_2
 	},
 	--fixes some spawn typos

--- a/req/mission_script/rvd1.lua
+++ b/req/mission_script/rvd1.lua
@@ -1,13 +1,7 @@
 local difficulty = Global.game_settings and Global.game_settings.difficulty or "normal"
 local difficulty_index = tweak_data:difficulty_to_index(difficulty)
 
-	if tweak_data:difficulty_to_index(difficulty) <= 2 then
-		ponr_value = 450
-	elseif tweak_data:difficulty_to_index(difficulty) == 3 then
-		ponr_value = 420	
-	elseif tweak_data:difficulty_to_index(difficulty) == 4 then
-		ponr_value = 390
-	elseif tweak_data:difficulty_to_index(difficulty) == 5 then
+	if tweak_data:difficulty_to_index(difficulty) <= 5 then
 		ponr_value = 360
 	elseif tweak_data:difficulty_to_index(difficulty) == 6 or tweak_data:difficulty_to_index(difficulty) == 7 then
 		ponr_value = 330

--- a/req/mission_script/rvd2.lua
+++ b/req/mission_script/rvd2.lua
@@ -1,13 +1,7 @@
 local difficulty = Global.game_settings and Global.game_settings.difficulty or "normal"
 local difficulty_index = tweak_data:difficulty_to_index(difficulty)
-
-	if tweak_data:difficulty_to_index(difficulty) <= 2 then
-		ponr_value = 690
-	elseif tweak_data:difficulty_to_index(difficulty) == 3 then
-		ponr_value = 660
-	elseif tweak_data:difficulty_to_index(difficulty) == 4 then
-		ponr_value = 630	
-	elseif tweak_data:difficulty_to_index(difficulty) == 5 then
+	
+	if tweak_data:difficulty_to_index(difficulty) <= 5 then
 		ponr_value = 600
 	elseif tweak_data:difficulty_to_index(difficulty) == 6 or tweak_data:difficulty_to_index(difficulty) == 7 then
 		ponr_value = 570	

--- a/req/mission_script/shoutout_raid.lua
+++ b/req/mission_script/shoutout_raid.lua
@@ -1,23 +1,43 @@
 local difficulty = Global.game_settings and Global.game_settings.difficulty or "normal"
 local difficulty_index = tweak_data:difficulty_to_index(difficulty)
 
-	if tweak_data:difficulty_to_index(difficulty) <= 2 then
-		ponr_value = 1650
-	elseif tweak_data:difficulty_to_index(difficulty) == 3 then
-		ponr_value = 1620	
-	elseif tweak_data:difficulty_to_index(difficulty) == 4 then
-		ponr_value = 1590	
-	elseif tweak_data:difficulty_to_index(difficulty) == 5 then
-		ponr_value = 1560	
+	if tweak_data:difficulty_to_index(difficulty) <= 5 then
+		ponr_value = 1260	
 	elseif tweak_data:difficulty_to_index(difficulty) == 6 or tweak_data:difficulty_to_index(difficulty) == 7 then
-		ponr_value = 1530	
+		ponr_value = 1230
 	elseif tweak_data:difficulty_to_index(difficulty) == 8 then
-		ponr_value = 1500	
+		ponr_value = 1200	
 	end
+
+local ponr_timer_player_mul = {
+		1,
+		0.9,
+		0.8,
+		0.7,
+		0.65,
+		0.65,
+		0.65,
+		0.65,
+		0.65,
+		0.65,
+		0.65,
+		0.65,
+		0.65,
+		0.65,
+		0.65,
+		0.65,
+		0.65,
+		0.65,
+		0.65,
+		0.65,
+		0.65,
+		0.65
+}
 
 return {
 	--Pro Job PONR 
 	[102313] = {
+		ponr_player_mul = ponr_timer_player_mul,
 		ponr = ponr_value
 	},
 	[106851] = {

--- a/req/mission_script/spa.lua
+++ b/req/mission_script/spa.lua
@@ -1,13 +1,7 @@
 local difficulty = Global.game_settings and Global.game_settings.difficulty or "normal"
 local difficulty_index = tweak_data:difficulty_to_index(difficulty)
 
-	if tweak_data:difficulty_to_index(difficulty) <= 2 then
-		ponr_value = 450
-	elseif tweak_data:difficulty_to_index(difficulty) == 3 then
-		ponr_value = 420	
-	elseif tweak_data:difficulty_to_index(difficulty) == 4 then
-		ponr_value = 390
-	elseif tweak_data:difficulty_to_index(difficulty) == 5 then
+	if tweak_data:difficulty_to_index(difficulty) <= 5 then
 		ponr_value = 360	
 	elseif tweak_data:difficulty_to_index(difficulty) == 6 or tweak_data:difficulty_to_index(difficulty) == 7 then
 		ponr_value = 330

--- a/req/mission_script/tj_htsb.lua
+++ b/req/mission_script/tj_htsb.lua
@@ -1,19 +1,13 @@
 local difficulty = Global.game_settings and Global.game_settings.difficulty or "normal"
 local difficulty_index = tweak_data:difficulty_to_index(difficulty)
 
-if tweak_data:difficulty_to_index(difficulty) <= 2 then
-	ponr_value = 900
-elseif tweak_data:difficulty_to_index(difficulty) == 3 then
-	ponr_value = 840
-elseif tweak_data:difficulty_to_index(difficulty) == 4 then
-	ponr_value = 780
-elseif tweak_data:difficulty_to_index(difficulty) == 5 then
-	ponr_value = 720
-elseif tweak_data:difficulty_to_index(difficulty) == 6 or tweak_data:difficulty_to_index(difficulty) == 7 then
-	ponr_value = 660	
-elseif tweak_data:difficulty_to_index(difficulty) == 8 then
-	ponr_value = 600
-end
+	if tweak_data:difficulty_to_index(difficulty) <= 5 then
+		ponr_value = 720
+	elseif tweak_data:difficulty_to_index(difficulty) == 6 or tweak_data:difficulty_to_index(difficulty) == 7 then
+		ponr_value = 660	
+	elseif tweak_data:difficulty_to_index(difficulty) == 8 then
+		ponr_value = 600
+	end
     
     if Global.game_settings and Global.game_settings.one_down then	
         if tweak_data:difficulty_to_index(difficulty) == 5 or tweak_data:difficulty_to_index(difficulty) == 6 or tweak_data:difficulty_to_index(difficulty) == 7 or tweak_data:difficulty_to_index(difficulty) == 8 then

--- a/req/mission_script/vit.lua
+++ b/req/mission_script/vit.lua
@@ -1,23 +1,43 @@
 local difficulty = Global.game_settings and Global.game_settings.difficulty or "normal"
 local difficulty_index = tweak_data:difficulty_to_index(difficulty)
-
-	if tweak_data:difficulty_to_index(difficulty) <= 2 then
-		ponr_value = 1050
-	elseif tweak_data:difficulty_to_index(difficulty) == 3 then
-		ponr_value = 1020	
-	elseif tweak_data:difficulty_to_index(difficulty) == 4 then
-		ponr_value = 990	
-	elseif tweak_data:difficulty_to_index(difficulty) == 5 then
+	
+	if tweak_data:difficulty_to_index(difficulty) <= 5 then
 		ponr_value = 960	
 	elseif tweak_data:difficulty_to_index(difficulty) == 6 or tweak_data:difficulty_to_index(difficulty) == 7 then
 		ponr_value = 930
 	elseif tweak_data:difficulty_to_index(difficulty) == 8 then
 		ponr_value = 900	
 	end
+	
+	local ponr_timer_player_mul = {
+		1,
+		0.8,
+		0.6,
+		0.4,
+		0.35,
+		0.35,
+		0.35,
+		0.35,
+		0.35,
+		0.35,
+		0.35,
+		0.35,
+		0.35,
+		0.35,
+		0.35,
+		0.35,
+		0.35,
+		0.35,
+		0.35,
+		0.35,
+		0.35,
+		0.35
+}
 
 return {
 	--Pro Job PONR 
 	[102089] = {
+		ponr_player_mul = ponr_timer_player_mul,
 		ponr = ponr_value
 	}
 }	

--- a/req/mission_script/watchdogs_1.lua
+++ b/req/mission_script/watchdogs_1.lua
@@ -1,13 +1,7 @@
 local difficulty = Global.game_settings and Global.game_settings.difficulty or "normal"
 local difficulty_index = tweak_data:difficulty_to_index(difficulty)
-
-	if tweak_data:difficulty_to_index(difficulty) <= 2 then
-		ponr_value = 750
-	elseif tweak_data:difficulty_to_index(difficulty) == 3 then
-		ponr_value = 720	
-	elseif tweak_data:difficulty_to_index(difficulty) == 4 then
-		ponr_value = 690	
-	elseif tweak_data:difficulty_to_index(difficulty) == 5 then
+	
+	if tweak_data:difficulty_to_index(difficulty) <= 5 then
 		ponr_value = 660	
 	elseif tweak_data:difficulty_to_index(difficulty) == 6 or tweak_data:difficulty_to_index(difficulty) == 7 then
 		ponr_value = 630	

--- a/req/mission_script/watchdogs_2.lua
+++ b/req/mission_script/watchdogs_2.lua
@@ -1,23 +1,43 @@
 local difficulty = Global.game_settings and Global.game_settings.difficulty or "normal"
 local difficulty_index = tweak_data:difficulty_to_index(difficulty)
-
-	if tweak_data:difficulty_to_index(difficulty) <= 2 then
-		ponr_value = 1200
-	elseif tweak_data:difficulty_to_index(difficulty) == 3 then
-		ponr_value = 1170	
-	elseif tweak_data:difficulty_to_index(difficulty) == 4 then
-		ponr_value = 1140	
-	elseif tweak_data:difficulty_to_index(difficulty) == 5 then
+	
+	if tweak_data:difficulty_to_index(difficulty) <= 5 then
 		ponr_value = 1080
 	elseif tweak_data:difficulty_to_index(difficulty) == 6 or tweak_data:difficulty_to_index(difficulty) == 7 then
-		ponr_value = 1080	
+		ponr_value = 1050	
 	elseif tweak_data:difficulty_to_index(difficulty) == 8 then
-		ponr_value = 1050		
+		ponr_value = 1020		
 	end
+	
+	local ponr_timer_player_mul = {
+		1,
+		0.85,
+		0.7,
+		0.65,
+		0.65,
+		0.65,
+		0.65,
+		0.65,
+		0.65,
+		0.65,
+		0.65,
+		0.65,
+		0.65,
+		0.65,
+		0.65,
+		0.65,
+		0.65,
+		0.65,
+		0.65,
+		0.65,
+		0.65,
+		0.65
+}
 
 return {
-		--Pro Job PONR 
-		[100324] = {
-			ponr = ponr_value
+	--Pro Job PONR 
+	[100324] = {
+		ponr_player_mul = ponr_timer_player_mul,
+		ponr = ponr_value
 	}
 }

--- a/req/mission_script/wwh.lua
+++ b/req/mission_script/wwh.lua
@@ -1,23 +1,43 @@
 local difficulty = Global.game_settings and Global.game_settings.difficulty or "normal"
 local difficulty_index = tweak_data:difficulty_to_index(difficulty)
 
-	if tweak_data:difficulty_to_index(difficulty) <= 2 then
-		ponr_value = 1050
-	elseif tweak_data:difficulty_to_index(difficulty) == 3 then
-		ponr_value = 1020	
-	elseif tweak_data:difficulty_to_index(difficulty) == 4 then
-		ponr_value = 990
-	elseif tweak_data:difficulty_to_index(difficulty) == 5 then
+	if tweak_data:difficulty_to_index(difficulty) <= 5 then
 		ponr_value = 960
 	elseif tweak_data:difficulty_to_index(difficulty) == 6 or tweak_data:difficulty_to_index(difficulty) == 7 then
 		ponr_value = 930
 	elseif tweak_data:difficulty_to_index(difficulty) == 8 then
 		ponr_value = 900	
 	end
+	
+local ponr_timer_player_mul = {
+		1,
+		0.8,
+		0.6,
+		0.4,
+		0.35,
+		0.35,
+		0.35,
+		0.35,
+		0.35,
+		0.35,
+		0.35,
+		0.35,
+		0.35,
+		0.35,
+		0.35,
+		0.35,
+		0.35,
+		0.35,
+		0.35,
+		0.35,
+		0.35,
+		0.35
+}	
 
 return {
 	--Pro Job PONR 
 	[100914] = {
+		ponr_player_mul = ponr_timer_player_mul,
 		ponr = ponr_value
 	},
 	-- Gradually increase difficulty

--- a/req/mission_script/xmn_hox2.lua
+++ b/req/mission_script/xmn_hox2.lua
@@ -1,13 +1,7 @@
 local difficulty = Global.game_settings and Global.game_settings.difficulty or "normal"
 local difficulty_index = tweak_data:difficulty_to_index(difficulty)
-
-	if tweak_data:difficulty_to_index(difficulty) <= 2 then
-		ponr_value = 390
-	elseif tweak_data:difficulty_to_index(difficulty) == 3 then
-		ponr_value = 360	
-	elseif tweak_data:difficulty_to_index(difficulty) == 4 then
-		ponr_value = 330	
-	elseif tweak_data:difficulty_to_index(difficulty) == 5 then
+	
+	if tweak_data:difficulty_to_index(difficulty) <= 5 then
 		ponr_value = 300	
 	elseif tweak_data:difficulty_to_index(difficulty) == 6 or tweak_data:difficulty_to_index(difficulty) == 7 then
 		ponr_value = 270


### PR DESCRIPTION
*Tweaked PONRs for all remaining heists
*Added PONR player scaling to following heists:
-Alaskan Deal
-Armored Transport: Train Heist
-Firestarter Day 1 and 3
-Goat Simulator Day 2
-Mountain Master
-Meltdown
-White House
-Watchdogs Day 2

*Removed PONR from the 1st day of Goat Sim
*Fixed heisters not saying kill confirmations lines when killing LPFs

Diamond Store:
*Disabled the SWAT Turret
*Disabled two bad escape van spots

Hell's Island:
*Heist now has increased security room's time lock timer by 1 minute when playing on Pro Jobs 
*Made Bulldozer replace one of the murky guards in security room on Pro Jobs