### PR TITLE
Delete Language Chinese

### DIFF
--- a/lua/sc/loc/coreloc.lua
+++ b/lua/sc/loc/coreloc.lua
@@ -1,14 +1,14 @@
 local russian = Idstring("russian"):key() == SystemInfo:language():key()
 local english = Idstring("english"):key() == SystemInfo:language():key()
-local schinese = Idstring("schinese"):key() == SystemInfo:language():key()
+--local schinese = Idstring("schinese"):key() == SystemInfo:language():key()
 local korean = Idstring("korean"):key() == SystemInfo:language():key()
 
 if english then
     dofile(ModPath .. "lua/sc/loc/loc.lua")
 elseif russian then
     dofile(ModPath .. "lua/sc/loc/locru.lua")
-elseif schinese then
-    dofile(ModPath .. "lua/sc/loc/loczh.lua")
+--[[elseif schinese then
+    dofile(ModPath .. "lua/sc/loc/loczh.lua")--]]
 elseif korean then
     dofile(ModPath .. "lua/sc/loc/locko.lua")
 else


### PR DESCRIPTION
Noob player won't support the Chinese Language for new Resmod anymore, neither the official site nor being in noob player's mod.  You know the reason, and there's no point keeping it sincce it's been outdated and no one else supports it. There's nothing bad for you, and noob player will just make her changes and her own experience on Resmod herself. What do we say? "Each to their own", huh? heh, can't believe someone's still making jokes while things have already reached this point.