### PR TITLE
PONR anti-grief support for other classics, Alesso Heist

### DIFF
--- a/Core.lua
+++ b/Core.lua
@@ -1256,6 +1256,49 @@ function restoration:mission_script_add()
 		}
 	end
 
+	function restoration:gen_instance_input_event(id, name, pos, rot, opts)
+		opts = opts or {}
+		return {
+			id = id,
+			editor_name = name,
+			class = "ElementInstanceInputEvent",
+			module = "CoreElementInstance",
+			values = {
+				execute_on_startup = false,
+				trigger_times = opts.trigger_times or 0,
+				on_executed = opts.on_executed or {},
+				base_delay = opts.base_delay or 0,
+				position = pos,
+				rotation = rot,
+				enabled = opts.enabled or false,
+				instance = nil,  -- string (prefer event_list)
+				event = nil,  -- string (prefer event_list)
+				event_list = opts.event_list or {},
+			},
+		}
+	end
+
+	function restoration:gen_instance_input(id, name, pos, rot, opts)
+		opts = opts or {}
+		return {
+			id = id,
+			editor_name = name,
+			class = "ElementInstanceInput",
+			module = "CoreElementInstance",
+			values = {
+				execute_on_startup = false,
+				trigger_times = opts.trigger_times or 0,
+				on_executed = opts.on_executed or {},
+				base_delay = opts.base_delay or 0,
+				position = pos,
+				rotation = rot,
+				enabled = opts.enabled or false,
+				instance_name = opts.instance_name or "",
+				event = opts.event or "",
+			},
+		}
+	end
+
 	function restoration:log(...)
 		if self.logging then
 			log("[StreamlinedHeistingAI] " .. table.concat({...}, " "))

--- a/lua/sc/core/coreworldinstancemanager.lua
+++ b/lua/sc/core/coreworldinstancemanager.lua
@@ -324,23 +324,19 @@ function CoreWorldInstanceManager:_get_instance_mission_data(path)
 end
 
 
-if Network:is_client() or Global.editor_mode then
-	return
-end
-
 local instance_script_patches = restoration:instance_script_patches()
 if not instance_script_patches then
 	return
 end
 
-restoration:post_hook(CoreWorldInstanceManager, "_get_instance_mission_data", function(self, path)
+Hooks:PostHook(CoreWorldInstanceManager, "_get_instance_mission_data", "res__get_instance_mission_data", function(self, path)
 	local func = instance_script_patches[path]
 
 	if func then
 		local result = Hooks:GetReturn()
 
-		func(result)
-
-		return result
+		if result then
+			func(result)
+		end
 	end
 end)

--- a/req/instance_script/arena.lua
+++ b/req/instance_script/arena.lua
@@ -1,0 +1,70 @@
+local function get_opts_pro_job_ponr()
+	local pro_job = Global.game_settings and Global.game_settings.one_down
+	local difficulty = tweak_data:difficulty_to_index(Global.game_settings and Global.game_settings.difficulty or "normal")
+	local ponr_value = (difficulty <= 5 and 1260 or (difficulty == 6 or difficulty == 7) and 1230) or 1200
+	local ponr_timer_player_mul = {
+		1,
+		0.9,
+		0.8,
+		0.7,
+		0.65,  -- 5 or more players
+	}
+
+	return {
+		elements = { 100035, },
+		time_balance_mul = ponr_timer_player_mul,
+		time_easy = ponr_value,
+		time_normal = ponr_value,
+		time_hard = ponr_value,
+		time_overkill = ponr_value,
+		time_overkill_145 = ponr_value,
+		time_easy_wish = ponr_value,
+		time_overkill_290 = ponr_value,
+		time_sm_wish = ponr_value,
+		enabled = pro_job,
+	}
+end
+
+local function get_opts_pro_job_ponr_input()
+	local pro_job = Global.game_settings and Global.game_settings.one_down
+
+	return {
+		enabled = pro_job,
+		instance_name = "are_heli_escape_001",
+		event = "activate_pro_job_ponr",
+		on_executed = {
+			{ id = 400001, delay = 0, },
+		},
+	}
+end
+
+local opts_pro_job_ponr, opts_pro_job_ponr_input
+local pro_job_ponr, pro_job_ponr_input
+return {
+	["levels/instances/unique/are_heli_escape/world/world"] = function(result)
+		opts_pro_job_ponr = opts_pro_job_ponr or get_opts_pro_job_ponr()
+		pro_job_ponr = pro_job_ponr or restoration:gen_pointofnoreturn(
+			400001,
+			"pro_job_ponr",
+			Vector3(0, 0, 0),
+			Rotation(0, 0, 0),
+			opts_pro_job_ponr
+		)
+		opts_pro_job_ponr_input = opts_pro_job_ponr_input or get_opts_pro_job_ponr_input()
+		pro_job_ponr_input = pro_job_ponr_input or restoration:gen_instance_input(
+			400002,
+			"pro_job_ponr_input",
+			Vector3(0, 0, 0),
+			Rotation(0, 0, 0),
+			opts_pro_job_ponr_input
+		)
+
+		if not table.contains(result.default.elements, pro_job_ponr) then
+			table.insert(result.default.elements, pro_job_ponr)
+		end
+
+		if not table.contains(result.default.elements, pro_job_ponr_input) then
+			table.insert(result.default.elements, pro_job_ponr_input)
+		end
+	end,
+}

--- a/req/mission_script/arena.lua
+++ b/req/mission_script/arena.lua
@@ -1,35 +1,16 @@
-local difficulty = tweak_data:difficulty_to_index(Global.game_settings and Global.game_settings.difficulty or "normal")
-local ponr_value = (difficulty <= 5 and 1260 or (difficulty == 6 or difficulty == 7) and 1230) or 1200
-
-local ponr_timer_player_mul = {
-		1,
-		0.9,
-		0.8,
-		0.7,
-		0.65,
-		0.65,
-		0.65,
-		0.65,
-		0.65,
-		0.65,
-		0.65,
-		0.65,
-		0.65,
-		0.65,
-		0.65,
-		0.65,
-		0.65,
-		0.65,
-		0.65,
-		0.65,
-		0.65,
-		0.65
-}
-
 return {
-	--Pro Job PONR 
+	-- Alarm, enable PONR activation upon completing pyrotechnics, and try to start late PONR if pyrotechnics was already completed
+	[100824] = {
+		on_executed = {
+			{ id = 400004, delay = 0, },
+			{ id = 400003, delay = 0, },
+		},
+	},
+	-- Pyrotechnics complete, enable late PONR activation, and try to start PONR if alarm already went off
 	[101090] = {
-		ponr_player_mul = ponr_timer_player_mul,
-		ponr = ponr_value
-	}
+		on_executed = {
+			{ id = 400002, delay = 0, },
+			{ id = 400005, delay = 0, },
+		},
+	},
 }

--- a/req/mission_script/bridge.lua
+++ b/req/mission_script/bridge.lua
@@ -5,60 +5,81 @@ local zealdozer_green = "units/pd2_dlc_gitgud/characters/ene_bulldozer_minigun/e
 local zealdozer_black = "units/pd2_dlc_gitgud/characters/ene_zeal_bulldozer_3_sc/ene_zeal_bulldozer_3_sc"
 local zealdozer_skull = "units/pd2_dlc_gitgud/characters/ene_zeal_bulldozer_sc/ene_zeal_bulldozer_sc"
 local titandozer = "units/pd2_dlc_vip/characters/ene_vip_2_assault/ene_vip_2_assault"
-local dozertable_ovk = {greendozer, greendozer, blackdozer}
-local dozertable_mh_dw = {greendozer, skulldozer, blackdozer, blackdozer, greendozer}
-local dozertable_ds = {zealdozer_green, zealdozer_black, zealdozer_skull, zealdozer_green, zealdozer_black, zealdozer_skull, titandozer}
+local dozertable_ovk = { greendozer, greendozer, blackdozer, }
+local dozertable_mh_dw = { greendozer, skulldozer, blackdozer, blackdozer, greendozer, }
+local dozertable_ds = { zealdozer_green, zealdozer_black, zealdozer_skull, zealdozer_green, zealdozer_black, zealdozer_skull, titandozer, }
 local difficulty = tweak_data:difficulty_to_index(Global.game_settings and Global.game_settings.difficulty or "normal")
 local bulldozer = (difficulty == 8 and dozertable_ds or (difficulty == 7 or difficulty == 6) and dozertable_mh_dw) or dozertable_ovk
 local ponr_value = (difficulty <= 5 and 420 or (difficulty == 6 or difficulty == 7) and 390) or 360
+local ponr_timer_player_mul = {
+	1,
+	1,
+	1,
+	1,
+	1,  -- 5+ players
+}
 
 local high_interval = {
 	values = {
-		interval = 60
-	}
+		interval = 60,
+	},
 }
 local medium_interval = {
 	values = {
-		interval = 45
-	}
+		interval = 45,
+	},
 }
 local low_interval = {
 	values = {
-		interval = 30
-	}
+		interval = 30,
+	},
 }
 
 return {
-	--Pro Job PONR 
-	[100137] = {
-		ponr = ponr_value
+	-- Point of no return shortly after George takes Kazuo
+	-- Normally always enabled, no time balance mul
+	-- Normally 600s on Normal, 540s on Hard, 480s on Very Hard, 420s on Overkill, 360s on Mayhem/Death Wish/Death Sentence
+	[100763] = {
+		values = {
+			elements = { 100124, },
+			enabled = pro_job,
+			time_balance_mul = ponr_timer_player_mul,
+			time_easy = ponr_value,
+			time_normal = ponr_value,
+			time_hard = ponr_value,
+			time_overkill = ponr_value,
+			time_overkill_145 = ponr_value,
+			time_easy_wish = ponr_value,
+			time_overkill_290 = ponr_value,
+			time_sm_wish = ponr_value,
+		},
 	},
-	--PDTH's OVK 145+ Throwback+Make this dozer spawn loopable like in PDTH (Fixes the special scaffolding spawn not using the zipline and replaces cloaker with bulldozer)
+	-- PDTH's OVK 145+ Throwback+Make this dozer spawn loopable like in PDTH (Fixes the special scaffolding spawn not using the zipline and replaces cloaker with bulldozer)
 	[101320] = {
 		values = {
 			enemy = bulldozer,
-			participate_to_group_ai = true
-		}
+			participate_to_group_ai = true,
+		},
 	},
-	--trigger custom spawns during escape part
+	-- Trigger custom spawns during escape part
 	[103111] = {
 		on_executed = {
-			{id = 400001, delay = 0},
-			{id = 400002, delay = 0},
-			{id = 400003, delay = 0},
-			{id = 400004, delay = 0}
-		}
+			{ id = 400001, delay = 0 },
+			{ id = 400002, delay = 0 },
+			{ id = 400003, delay = 0 },
+			{ id = 400004, delay = 0 },
+		},
 	},
-	--trigger custom spawns in scaffolding part
+	-- Trigger custom spawns in scaffolding part
 	[103543] = {
 		on_executed = {
-			{id = 400005, delay = 0},
-			{id = 400006, delay = 0},
-			{id = 400007, delay = 0},
-			{id = 400008, delay = 0}
-		}
+			{ id = 400005, delay = 0 },
+			{ id = 400006, delay = 0 },
+			{ id = 400007, delay = 0 },
+			{ id = 400008, delay = 0 },
+		},
 	},
-	--Disable this spawn once George the pilot gets Kauzo out
+	-- Disable this spawn once George the pilot gets Kauzo out
 	[100121] = {
 		func = function(self)
 			local turn_this_shit_off = self:get_mission_element(101320)
@@ -66,13 +87,13 @@ return {
 			if turn_this_shit_off then
 				turn_this_shit_off:set_enabled(false)
 			end
-		end
+		end,
 	},
 	-- Remove spawn groups closest to broken bridge part
 	[101176] = {
 		values = {
-			spawn_groups = { 100867, 101153, 101157, 101154, 101160, 101156, 101159 }
-		}
+			spawn_groups = { 100867, 101153, 101157, 101154, 101160, 101156, 101159, },
+		},
 	},
 	-- Increase spawn group intervals next to prison vans, closest to furthest
 	[100867] = high_interval,
@@ -81,5 +102,5 @@ return {
 	[101154] = medium_interval,
 	[101160] = medium_interval,
 	[101156] = low_interval,
-	[101159] = low_interval
-}	
+	[101159] = low_interval,
+}

--- a/req/mission_script/dinner.lua
+++ b/req/mission_script/dinner.lua
@@ -1,28 +1,27 @@
 local low_murkydozers = {
-		"units/pd2_mod_sharks/characters/ene_murky_fbi_tank_r870/ene_murky_fbi_tank_r870",
-		"units/pd2_mod_sharks/characters/ene_murky_fbi_tank_r870/ene_murky_fbi_tank_r870",
-		"units/pd2_mod_sharks/characters/ene_murky_fbi_tank_r870/ene_murky_fbi_tank_r870",
-		"units/pd2_mod_sharks/characters/ene_murky_fbi_tank_r870/ene_murky_fbi_tank_r870",
-		"units/pd2_mod_sharks/characters/ene_murky_fbi_tank_saiga/ene_murky_fbi_tank_saiga"
-
+	"units/pd2_mod_sharks/characters/ene_murky_fbi_tank_r870/ene_murky_fbi_tank_r870",
+	"units/pd2_mod_sharks/characters/ene_murky_fbi_tank_r870/ene_murky_fbi_tank_r870",
+	"units/pd2_mod_sharks/characters/ene_murky_fbi_tank_r870/ene_murky_fbi_tank_r870",
+	"units/pd2_mod_sharks/characters/ene_murky_fbi_tank_r870/ene_murky_fbi_tank_r870",
+	"units/pd2_mod_sharks/characters/ene_murky_fbi_tank_saiga/ene_murky_fbi_tank_saiga",
 }
 local medium_murkydozers = {
-		"units/pd2_mod_sharks/characters/ene_murky_fbi_tank_r870/ene_murky_fbi_tank_r870",
-		"units/pd2_mod_sharks/characters/ene_murky_fbi_tank_saiga/ene_murky_fbi_tank_saiga",
-		"units/pd2_mod_sharks/characters/ene_murky_fbi_tank_r870/ene_murky_fbi_tank_r870",
-		"units/pd2_mod_sharks/characters/ene_murky_fbi_tank_saiga/ene_murky_fbi_tank_saiga"
+	"units/pd2_mod_sharks/characters/ene_murky_fbi_tank_r870/ene_murky_fbi_tank_r870",
+	"units/pd2_mod_sharks/characters/ene_murky_fbi_tank_saiga/ene_murky_fbi_tank_saiga",
+	"units/pd2_mod_sharks/characters/ene_murky_fbi_tank_r870/ene_murky_fbi_tank_r870",
+	"units/pd2_mod_sharks/characters/ene_murky_fbi_tank_saiga/ene_murky_fbi_tank_saiga",
 }
 local hard_murkydozers = {
-		"units/pd2_mod_sharks/characters/ene_murky_fbi_tank_r870/ene_murky_fbi_tank_r870",
-		"units/pd2_mod_sharks/characters/ene_murky_fbi_tank_saiga/ene_murky_fbi_tank_saiga",
-		"units/pd2_mod_sharks/characters/ene_murky_fbi_tank_r870/ene_murky_fbi_tank_r870",
-		"units/pd2_mod_sharks/characters/ene_murky_fbi_tank_m249/ene_murky_fbi_tank_m249"
+	"units/pd2_mod_sharks/characters/ene_murky_fbi_tank_r870/ene_murky_fbi_tank_r870",
+	"units/pd2_mod_sharks/characters/ene_murky_fbi_tank_saiga/ene_murky_fbi_tank_saiga",
+	"units/pd2_mod_sharks/characters/ene_murky_fbi_tank_r870/ene_murky_fbi_tank_r870",
+	"units/pd2_mod_sharks/characters/ene_murky_fbi_tank_m249/ene_murky_fbi_tank_m249",
 }
 local ds_murkydozers = {
-		"units/pd2_mod_sharks/characters/ene_murky_fbi_tank_benelli/ene_murky_fbi_tank_benelli",
-		"units/pd2_mod_sharks/characters/ene_murky_fbi_tank_saiga/ene_murky_fbi_tank_saiga",
-		"units/pd2_mod_sharks/characters/ene_murky_fbi_tank_benelli/ene_murky_fbi_tank_benelli",
-		"units/pd2_mod_sharks/characters/ene_murky_fbi_tank_m249/ene_murky_fbi_tank_m249"
+	"units/pd2_mod_sharks/characters/ene_murky_fbi_tank_benelli/ene_murky_fbi_tank_benelli",
+	"units/pd2_mod_sharks/characters/ene_murky_fbi_tank_saiga/ene_murky_fbi_tank_saiga",
+	"units/pd2_mod_sharks/characters/ene_murky_fbi_tank_benelli/ene_murky_fbi_tank_benelli",
+	"units/pd2_mod_sharks/characters/ene_murky_fbi_tank_m249/ene_murky_fbi_tank_m249",
 }
 local difficulty = tweak_data:difficulty_to_index(Global.game_settings and Global.game_settings.difficulty or "normal")
 local pro_job = Global.game_settings and Global.game_settings.one_down
@@ -32,187 +31,186 @@ local murky_blackdozer = medium_murkydozers
 local murky_skulldozer = (difficulty == 8 and ds_murkydozers) or hard_murkydozers
 local murkyman_1 = ((pro_job and difficulty >= 6) and "units/pd2_mod_sharks/characters/ene_titan_rifle/ene_titan_rifle")
 local murkyman_2 = ((pro_job and difficulty >= 6) and "units/pd2_mod_sharks/characters/ene_titan_shotgun/ene_titan_shotgun")
-local ponr_value = (difficulty <= 5 and 120) or 90
 
 local disabled = {
 	values = {
-        enabled = false
-	}
+		enabled = false,
+	},
 }
 local murky_dozer_green = {
 	values = {
-        enemy = murky_greendozer
-	}
+		enemy = murky_greendozer,
+	},
 }
 local murky_dozer_black = {
 	values = {
-        enemy = murky_blackdozer
-	}
+		enemy = murky_blackdozer,
+	},
 }
 local murky_dozer_skull = {
 	values = {
-        enemy = murky_skulldozer
-	}
+		enemy = murky_skulldozer,
+	},
 }
 local elite_murky_1 = {
 	values = {
-		enemy = murkyman_1
-	}
+		enemy = murkyman_1,
+	},
 }
 local elite_murky_2 = {
 	values = {
-		enemy = murkyman_2
-	}
+		enemy = murkyman_2,
+	},
 }
-	
+
 return {
-	--Pro Job PONR 
+	-- Pro Job PONR
 	[104979] = {
-		ponr = ponr_value
+		on_executed = {
+			{ id = 400063, delay = 0, },
+		},
 	},
 	-- Slightly slower difficulty ramp up
 	[101357] = {
 		values = {
-			difficulty = 0.6
-		}
+			difficulty = 0.6,
+		},
 	},
-	--Murky amount gets increased to 5 on PJs
+	-- Murky amount gets increased to 5 on PJs
 	[101394] = {
 		values = {
-            amount = murky_amount
-		}
+			amount = murky_amount,
+		},
 	},
-	--spawn murkies at the start of 1 assault
-	--spawn scripted dozers after some time
+	-- Spawn murkies at the start of 1 assault
+	-- Spawn scripted dozers after some time
 	[103477] = {
-		on_executed = { 
-			{ id = 400046, delay = 5 },
-			{ id = 400054, delay = 30 }
-		}
+		on_executed = {
+			{ id = 400046, delay = 5, },
+			{ id = 400054, delay = 30, },
+		},
 	},
-	--stop spawning murkies after the end of 1st assault
+	-- Stop spawning murkies after the end of 1st assault
 	[102158] = {
-		on_executed = { 
-			{ id = 400056, delay = 0 }
-		}
+		on_executed = {
+			{ id = 400056, delay = 0, },
+		},
 	},
-	--PDTH styled ambushes
+	-- PDTH styled ambushes
 	[102524] = {
 		on_executed = {
-		--be gone
-			{id = 102442, remove = true},
-		--trigger ambushes
-			{id = 400052, delay = 15},
-			{id = 400053, delay = 15},
-			{id = 400054, delay = 15},
-			{id = 400055, delay = 15}
-		}
+			{ id = 102442, remove = true, },  -- Be gone
+			{ id = 400052, delay = 15, },  -- Trigger ambushes
+			{ id = 400053, delay = 15, },
+			{ id = 400054, delay = 15, },
+			{ id = 400055, delay = 15, },
+		},
 	},
 	[102505] = {
 		values = {
 			elements = {
 				400004,
 				400005,
-				400006
-			}
-		}
+				400006,
+			},
+		},
 	},
-	[102506] = { 
+	[102506] = {
 		values = {
 			elements = {
 				400001,
 				400002,
-				400003
-			}
-		}
+				400003,
+			},
+		},
 	},
 	[102511] = {
 		values = {
 			elements = {
 				400007,
 				400008,
-				400009
-			}
-		}
+				400009,
+			},
+		},
 	},
-	[102512] = { 
+	[102512] = {
 		values = {
 			elements = {
 				400010,
 				400011,
-				400012
-			}
-		}
+				400012,
+			},
+		},
 	},
-	--spawn 3 snipers as a ambush
-	--disable the slaughterhouse dozer and enable 2nd one nearby container area
+	-- Spawn 3 snipers as a ambush
+	-- Disable the slaughterhouse dozer and enable 2nd one nearby container area
 	[105117] = {
-		on_executed = { 
-			{ id = 400013, delay = 0 },
-			{ id = 400014, delay = 0 },
-			{ id = 400015, delay = 0 },
-			{ id = 400055, delay = 90 },
-			{ id = 400045, delay = 0 }
-		}
+		on_executed = {
+			{ id = 400013, delay = 0, },
+			{ id = 400014, delay = 0, },
+			{ id = 400015, delay = 0, },
+			{ id = 400055, delay = 90, },
+			{ id = 400045, delay = 0, },
+		},
 	},
-	--enable van spawngroup if the 2nd van arrived
+	-- Enable van spawngroup if the 2nd van arrived
 	[101656] = {
-		on_executed = { 
-			{ id = 400027, delay = 10 }
-		}
+		on_executed = {
+			{ id = 400027, delay = 10, },
+		},
 	},
-	--Force 2 SWAT vans to spawn regardless of difficulty
+	-- Force 2 SWAT vans to spawn regardless of difficulty
 	[101808] = disabled,
 	[101807] = disabled,
 	[102696] = disabled,
 	[102697] = {
 		values = {
-			difficulty_normal = "true",
-			difficulty_hard = "true"
-		}
+			difficulty_normal = true,
+			difficulty_hard = true,
+		},
 	},
-	--limit scripted van dozers to 2 (just in case if it might spawn like 4 or 5 dozers)
+	-- Limit scripted van dozers to 2 (just in case if it might spawn like 4 or 5 dozers)
 	[101576] = {
 		values = {
-            trigger_times = 2
-		}
+			trigger_times = 2,
+		},
 	},
 	[101636] = {
 		values = {
-            trigger_times = 2
-		}
+			trigger_times = 2,
+		},
 	},
-	--Replace bulldozers with their murky counterparts
-	--1st chopper, right after the ambush
+	-- Replace bulldozers with their murky counterparts
+	-- 1st chopper, right after the ambush
 	[103095] = murky_dozer_green,
 	[103097] = murky_dozer_green,
 	[103087] = murky_dozer_black,
 	[103096] = murky_dozer_black,
 	[102190] = murky_dozer_skull,
 	[100621] = murky_dozer_skull,
-	--2nd chopper, when the gang is in the slaughterhouse
+	-- 2nd chopper, when the gang is in the slaughterhouse
 	[103088] = murky_dozer_green,
 	[103090] = murky_dozer_green,
 	[103091] = murky_dozer_black,
 	[103092] = murky_dozer_black,
 	[103093] = murky_dozer_skull,
 	[103094] = murky_dozer_skull,
-	--gensec van
+	-- GenSec van
 	[101241] = murky_dozer_green,
 	[101242] = murky_dozer_black,
 	[101243] = murky_dozer_skull,
-	--security guards
+	-- Security guards
 	[101375] = {
 		values = {
-            enemy = "units/pd2_mod_nypd/characters/ene_security_1/ene_security_1"
-		}
+			enemy = "units/pd2_mod_nypd/characters/ene_security_1/ene_security_1",
+		},
 	},
 	[101376] = {
 		values = {
-            enemy = "units/pd2_mod_nypd/characters/ene_security_2/ene_security_2"
-		}
+			enemy = "units/pd2_mod_nypd/characters/ene_security_2/ene_security_2",
+		},
 	},
-	--Murky Elite Soldiers replace heli rappeling Murkies on PJ Mayhem and above
+	-- Murky Elite Soldiers replace heli rappeling Murkies on PJ Mayhem and above
 	[103083] = elite_murky_1,
 	[103084] = elite_murky_1,
 	[103085] = elite_murky_2,
@@ -221,10 +219,10 @@ return {
 	[103100] = elite_murky_1,
 	[103101] = elite_murky_2,
 	[103102] = elite_murky_2,
-	--disables the Swat Turret, it's not really needed here, eh?
+	-- Disables the Swat Turret, it's not really needed here, eh?
 	[102484] = {
 		values = {
-            chance = 0
-		}
-	}
+			chance = 0,
+		},
+	},
 }

--- a/req/mission_script/flat.lua
+++ b/req/mission_script/flat.lua
@@ -1,150 +1,180 @@
+local difficulty = tweak_data:difficulty_to_index(Global.game_settings and Global.game_settings.difficulty or "normal")
+local pro_job = Global.game_settings and Global.game_settings.one_down
+local ponr_value = difficulty <= 5 and 1200 or (difficulty == 6 or difficulty == 7) and 1200 or 1200
+local ponr_timer_player_mul = {
+	1,
+	1,
+	1,
+	1,
+	1,  -- 5+ players
+}
 local enabled_blocked_roof_access = math.random() < 0.6
 local enabled = {
 	values = {
-        enabled = true
-	}
+		enabled = true,
+	},
 }
 local disabled = {
 	values = {
-        enabled = false
-	}
+		enabled = false,
+	},
 }
+
 return {
+	-- Point of no return on C4 explosion, uncomment to edit
+	-- Normally 1200s any difficulty, always enabled, no time balance mul
+	[100565] = {
+		values = {
+			elements = { 100245, },
+			--[[
+			enabled = pro_job,
+			time_balance_mul = ponr_timer_player_mul,
+			time_easy = ponr_value,
+			time_normal = ponr_value,
+			time_hard = ponr_value,
+			time_overkill = ponr_value,
+			time_overkill_145 = ponr_value,
+			time_easy_wish = ponr_value,
+			time_overkill_290 = ponr_value,
+			time_sm_wish = ponr_value,
+			]]
+		},
+	},
 	-- Disable roof/stairs reinforcement
 	[102501] = disabled,
 	[103181] = disabled,
-	--Restore roof access blockade
+	-- Restore roof access blockade
 	[100095] = {
 		on_executed = {
-			{id = 100569, remove = true},
-			{id = 400064, delay = 0}
-		}
+			{ id = 100569, remove = true, },
+			{ id = 400064, delay = 0, },
+		},
 	},
 	[100297] = {
 		values = {
-			enabled = enabled_blocked_roof_access
+			enabled = enabled_blocked_roof_access,
 		},
 		on_executed = {
-			{id = 103611, delay = 0},
-			{id = 400065, delay = 0}
-		}
+			{ id = 103611, delay = 0, },
+			{ id = 400065, delay = 0, },
+		},
 	},
 	[100569] = enabled,
 	[103610] = enabled,
 	[103611] = enabled,
 	[103648] = {
 		on_executed = {
-			{id = 103611, remove = true}
-		}
+			{ id = 103611, remove = true, },
+		},
 	},
-	--stop with the smoke bombs, jeez....
+	-- Stop with the smoke bombs, jeez....
 	[103034] = disabled,
 	[103106] = disabled,
-	--Disable cloaker spawns on startup
+	-- Disable cloaker spawns on startup
 	[102263] = {
 		on_executed = {
-			{id = 400039, delay = 3}
-		}
+			{ id = 400039, delay = 3, },
+		},
 	},
-	--Add missing navlinks
+	-- Add missing navlinks
 	[103247] = {
 		on_executed = {
-			{ id = 102468, delay = 0 },
-			{ id = 104179, delay = 0 },
-			{ id = 102455, delay = 0 },
-			{ id = 104720, delay = 0 },
-			{ id = 102454, delay = 0 },
-			{ id = 104721, delay = 0 },
-			{ id = 102453, delay = 0 },
-			{ id = 104341, delay = 0 },
-			{ id = 104338, delay = 0 },
-			{ id = 104342, delay = 0 },
-			{ id = 104343, delay = 0 },
-			{ id = 103402, delay = 0 },
-			{ id = 103888, delay = 0 },
-			{ id = 103890, delay = 0 },
-			{ id = 102377, delay = 0 },
-			{ id = 104709, delay = 0 },
-			{ id = 102399, delay = 0 },
-			{ id = 104708, delay = 0 },
-			{ id = 102401, delay = 0 },
-			{ id = 104707, delay = 0 }
-		}
+			{ id = 102468, delay = 0, },
+			{ id = 104179, delay = 0, },
+			{ id = 102455, delay = 0, },
+			{ id = 104720, delay = 0, },
+			{ id = 102454, delay = 0, },
+			{ id = 104721, delay = 0, },
+			{ id = 102453, delay = 0, },
+			{ id = 104341, delay = 0, },
+			{ id = 104338, delay = 0, },
+			{ id = 104342, delay = 0, },
+			{ id = 104343, delay = 0, },
+			{ id = 103402, delay = 0, },
+			{ id = 103888, delay = 0, },
+			{ id = 103890, delay = 0, },
+			{ id = 102377, delay = 0, },
+			{ id = 104709, delay = 0, },
+			{ id = 102399, delay = 0, },
+			{ id = 104708, delay = 0, },
+			{ id = 102401, delay = 0, },
+			{ id = 104707, delay = 0, },
+		},
 	},
-	--Trigger event spawns after each start of the assault wave
+	-- Trigger event spawns after each start of the assault wave
 	[104656] = {
 		on_executed = {
-			{id = 400015, delay = 30},
-			{id = 400020, delay = 60},
-			{id = 400037, delay = 75}
-		}
+			{ id = 400015, delay = 30, },
+			{ id = 400020, delay = 60, },
+			{ id = 400037, delay = 75, },
+		},
 	},
-	--Spawn Shields after placing the last c4
+	-- Spawn Shields after placing the last c4
 	[101787] = {
 		on_executed = {
-			{ id = 400043, delay = 0}
-		}
+			{ id = 400043, delay = 0, },
+		},
 	},
-	--Spawn Enforcers next to Chavez on DS
+	-- Spawn Enforcers next to Chavez on DS
 	[100201] = {
 		on_executed = {
-			{ id = 400058, delay = 0},
-			{ id = 400059, delay = 0}
-		}
+			{ id = 400058, delay = 0, },
+			{ id = 400059, delay = 0, },
+		},
 	},
 	[100275] = {
 		on_executed = {
-			{ id = 400056, delay = 0},
-			{ id = 400057, delay = 0}
-		}
+			{ id = 400056, delay = 0, },
+			{ id = 400057, delay = 0, },
+		},
 	},
 	[100397] = {
 		on_executed = {
-			{ id = 400060, delay = 0},
-			{ id = 400061, delay = 0}
-		}
+			{ id = 400060, delay = 0, },
+			{ id = 400061, delay = 0, },
+		},
 	},
-	--Spawn Rooftop Heavy SWATs after killing all of the snipers
-	--Enable Cloaker spawns
+	-- Spawn Rooftop Heavy SWATs after killing all of the snipers
+	-- Enable Cloaker spawns
 	[104573] = {
 		on_executed = {
-			{id = 400025, delay = 15},
-			{id = 400038, delay = 0}
-		}
+			{ id = 400025, delay = 15, },
+			{ id = 400038, delay = 0, },
+		},
 	},
-	--Change chopper squad
+	-- Change chopper squad
 	[101658] = {
 		on_executed = {
-			{id = 104561, remove = true},
-			{id = 400032, delay = 17}
-		}
+			{ id = 104561, remove = true, },
+			{ id = 400032, delay = 17, },
+		},
 	},
-	--Trigger dozer spawn
+	-- Trigger dozer spawn
 	[104706] = {
 		on_executed = {
-			{id = 400040, delay = 0},
-			{id = 400042, delay = 0}
-		}
+			{ id = 400040, delay = 0, },
+			{ id = 400042, delay = 0, },
+		},
 	},
-	--Cops now spawn when you open the red door rather than when killing Chavez (like in PDTH)
+	-- Cops now spawn when you open the red door rather than when killing Chavez (like in PDTH)
 	[101853] = {
 		on_executed = {
-			{ id = 104691, remove = true}
-		}
+			{ id = 104691, remove = true, },
+		},
 	},
-	--Spawn Heavy SWAT squad if it's overkill above
-	--Spawns Chavez's Lieutenant in Panic Room on DS
+	-- Spawn Heavy SWAT squad if it's overkill above
+	-- Spawns Chavez's Lieutenant in Panic Room on DS
 	[102680] = {
 		on_executed = {
-			{ id = 104691, delay = 0},
-			{ id = 400001, delay = 7.5},
-			{ id = 400062, delay = 0}
-		}
+			{ id = 104691, delay = 0, },
+			{ id = 400001, delay = 7.5, },
+			{ id = 400062, delay = 0, },
+		},
 	},
-	--Spawn enforcer near the escape on DS
+	-- Spawn enforcer near the escape on DS
 	[100635] = {
 		on_executed = {
-			{ id = 400063, delay = 0}
-		}
-	}
+			{ id = 400063, delay = 0, },
+		},
+	},
 }

--- a/req/mission_script/man.lua
+++ b/req/mission_script/man.lua
@@ -5,110 +5,139 @@ local zeal_bendozer = "units/pd2_dlc_gitgud/characters/ene_bulldozer_minigun/ene
 local zeal_skulldozer = "units/pd2_dlc_gitgud/characters/ene_zeal_bulldozer_sc/ene_zeal_bulldozer_sc"
 local zeal_blackdozer = "units/pd2_dlc_gitgud/characters/ene_zeal_bulldozer_3_sc/ene_zeal_bulldozer_3_sc"
 local titandozer = "units/pd2_dlc_vip/characters/ene_vip_2_assault/ene_vip_2_assault"
-local dozertable_vh_ovk = {greendozer, greendozer, greendozer, blackdozer, blackdozer, blackdozer}
-local dozertable_mayhem_dw = {skulldozer, skulldozer, greendozer, greendozer, blackdozer, blackdozer}
-local dozertable_ds = {zeal_skulldozer, zeal_skulldozer, zeal_skulldozer, zeal_blackdozer, zeal_blackdozer, zeal_blackdozer, zeal_bendozer, zeal_bendozer, zeal_bendozer, titandozer}
+local dozertable_vh_ovk = { greendozer, greendozer, greendozer, blackdozer, blackdozer, blackdozer, }
+local dozertable_mayhem_dw = { skulldozer, skulldozer, greendozer, greendozer, blackdozer, blackdozer, }
+local dozertable_ds = { zeal_skulldozer, zeal_skulldozer, zeal_skulldozer, zeal_blackdozer, zeal_blackdozer, zeal_blackdozer, zeal_bendozer, zeal_bendozer, zeal_bendozer, titandozer, }
 local difficulty = tweak_data:difficulty_to_index(Global.game_settings and Global.game_settings.difficulty or "normal")
 local pro_job = Global.game_settings and Global.game_settings.one_down
 local titan_shield = ((difficulty >= 6 and pro_job) and "units/pd2_dlc_vip/characters/ene_phalanx_1_assault/ene_phalanx_1_assault")
 local woman_spooc = ((difficulty == 8 and pro_job) and "units/pd2_dlc_vip/characters/ene_spook_cloak_1/ene_spook_cloak_1")
 local gas_dozer = (difficulty == 8 and dozertable_ds or (difficulty == 7 or difficulty == 6) and dozertable_mayhem_dw or (difficulty == 5 or difficulty == 4) and dozertable_vh_ovk)
-local overkill_above = difficulty >= 5	
+local overkill_above = difficulty >= 5
 local disabled = {
 	values = {
-        enabled = false
-	}
-}	
+		enabled = false,
+	},
+}
 local dozer_heli = {
 	values = {
-        enemy = gas_dozer,
-		participate_to_group_ai = false
+		enemy = gas_dozer,
+		participate_to_group_ai = false,
 	},
 	on_executed = {
-		{id = 400002, delay = 0}
-	}
+		{ id = 400002, delay = 0, },
+	},
 }
 local tshield = {
 	values = {
-        enemy = titan_shield
-	}
+		enemy = titan_shield,
+	},
 }
+local ponr_value = difficulty <= 2 and 180 or difficulty == 3 and 150 or difficulty == 4 and 135 or difficulty == 5 and 120 or (difficulty == 6 or difficulty == 7) and 105 or 90
+local ponr_timer_player_mul = {
+	1,
+	1,
+	1,
+	1,
+	1,  -- 5+ players
+}
+
 return {
-	 --flashlights, flashlights, flashlights!!!!!!!!!! (enables/disables flashlights when the power is off/on like in PDTH)
+	-- Point of no return on hack completion, uncomment to edit
+	-- Normally always enabled, no time balance mul
+	-- Normally 180s on Normal, 150s on Hard, 135s on Very Hard, 120s on Overkill, 105s on Mayhem/Death Wish, 90s on Death Sentence
+	[100015] = {
+		values = {
+			elements = { 102074, },
+			--[[
+			enabled = pro_job,
+			time_balance_mul = ponr_timer_player_mul,
+			time_easy = ponr_value,
+			time_normal = ponr_value,
+			time_hard = ponr_value,
+			time_overkill = ponr_value,
+			time_overkill_145 = ponr_value,
+			time_easy_wish = ponr_value,
+			time_overkill_290 = ponr_value,
+			time_sm_wish = ponr_value,
+			]]
+		},
+	},
+	-- Flashlights, flashlights, flashlights!!!!!!!!!! (enables/disables flashlights when the power is off/on like in PDTH)
 	[100756] = {
-		flashlight = true
+		flashlight = true,
 	},
 	[101801] = {
-		flashlight = false
+		flashlight = false,
 	},
-	--Give saw to all players (Resmod edit not always give saw for every player)
+	-- Give saw to all players (Resmod edit not always give saw for every player)
 	[101865] = {
 		func = function(self)
 			managers.network:session():send_to_peers_synched("give_equipment", self._values.equipment, self._values.amount)
-		end
+		end,
 	},
-	--Spawn more planks (like in PDTH)
+	-- Spawn more planks (like in PDTH)
 	[101661] = {
 		values = {
-			amount = 20
-		}
+			amount = 20,
+		},
 	},
-	--Have the gas chopper be a dozer chopper that has loopable spawn
-	--Trigger the heli spawn in police_called instead of triggering during hacking
+	-- Have the gas chopper be a dozer chopper that has loopable spawn
+	-- Trigger the heli spawn in police_called instead of triggering during hacking
 	[100131] = {
 		on_executed = {
-			{id = 101608, delay = 240}
-		}
+			{ id = 101608, delay = 240, },
+		},
 	},
-	--remove the line
+	-- Remove the line
 	[102010] = {
 		on_executed = {
-			{ id = 101608, remove = true}
-		}
+			{ id = 101608, remove = true, },
+		},
 	},
-	--switch to 0 to make loopable dozer chopper spawn possible
-	--only on ovk and above
+	-- Switch to 0 to make loopable dozer chopper spawn possible
+	-- Only on ovk and above
 	[101608] = {
 		values = {
 			trigger_times = 0,
-			enabled = overkill_above
-		}
+			enabled = overkill_above,
+		},
 	},
-	--loop the choppa
+	-- Loop the choppa
 	[103297] = {
 		on_executed = {
-			{ id = 101608, delay = 240}
-		}
+			{ id = 101608, delay = 240, },
+		},
 	},
-	--tweak the delays
+	-- Tweak the delays
 	[103295] = {
 		on_executed = {
-			{ id = 103298, delay = 24},
-			{ id = 400001, delay = 22}, --incoming dozers warning
-			{ id = 102950, delay = 16}
-		}
+			{ id = 103298, delay = 24, },
+			{ id = 400001, delay = 22, },  -- Incoming dozers warning
+			{ id = 102950, delay = 16, },
+		},
 	},
 	[102950] = {
 		on_executed = {
-			{ id = 103895, delay = 4}
-		}
+			{ id = 103895, delay = 4, },
+		},
 	},
 	[103298] = {
 		on_executed = {
-			{ id = 101716, delay = 3}
-		}
+			{ id = 101716, delay = 3, },
+		},
 	},
-	--Replace the spawns with dozers
+	-- Replace the spawns with dozers
 	[104045] = dozer_heli,
 	[104046] = dozer_heli,
 	[104047] = dozer_heli,
 	[104048] = dozer_heli,
 	[104049] = dozer_heli,
 	[104050] = dozer_heli,
-	--disable the Gas SO (it's useless anyway)
+	-- Disable the Gas SO (it's useless anyway)
 	[103302] = disabled,
 	[103303] = disabled,
-	--disable this once done with hacking
+	-- Disable this once done with hacking
 	[102754] = {
 		func = function(self)
 			local turn_this_shit_off = self:get_mission_element(103297)
@@ -118,16 +147,16 @@ return {
 			end
 		end
 	},
-	--Pro Job Stuff
-	--Titan Cloaker on DSPJ
+	-- Pro Job Stuff
+	-- Titan Cloaker on DSPJ
 	[102409] = {
 		values = {
-            enemy = woman_spooc
-		}
+			enemy = woman_spooc,
+		},
 	},
-	--Titan Shields replace regular ones during escape part on higher diff
+	-- Titan Shields replace regular ones during escape part on higher diff
 	[102410] = tshield,
 	[102411] = tshield,
 	[102416] = tshield,
-	[102417] = tshield
-}	
+	[102417] = tshield,
+}

--- a/req/mission_script/red2.lua
+++ b/req/mission_script/red2.lua
@@ -16,174 +16,174 @@ local shield = ((difficulty >= 6 and pro_job) and "units/pd2_dlc_vip/characters/
 local dave = (marioinatophat_is_in_fwb_chance and "units/pd2_mod_dave/characters/ene_big_dave/ene_big_dave")
 local vault_guard = (difficulty == 8 and "units/payday2/characters/ene_city_guard_1/ene_city_guard_1" or difficulty == 7 and "units/pd2_mod_nypd/characters/ene_security_gensec_2/ene_security_gensec_2") or "units/pd2_mod_nypd/characters/ene_security_1/ene_security_1"
 local woman_spooc = ((difficulty == 8 and pro_job) and "units/pd2_dlc_vip/characters/ene_spook_cloak_1/ene_spook_cloak_1")
-	
+
 local spooc = {
 	values = {
-        enemy = cloaker
-	}
+		enemy = cloaker,
+	},
 }
 local taser = {
 	values = {
-		enemy = taser
-	}
+		enemy = taser,
+	},
 }
 local swatsg = {
 	values = {
-		enemy = swat_shotgunner
-	}
+		enemy = swat_shotgunner,
+	},
 }
 local shield = {
 	values = {
-		enemy = shield
-	}
+		enemy = shield,
+	},
 }
 local titan_cloaker = {
 	values = {
-        enemy = woman_spooc
-	}
+		enemy = woman_spooc,
+	},
 }
 local windows_swat = {
 	values = {
-		enabled = both_window_swats_only
-	}
+		enabled = both_window_swats_only,
+	},
 }
 local disabled = {
 	values = {
-        enabled = false
-	}
+		enabled = false,
+	},
 }
-	
+
 return {
-	--2 basement dozers on DS (1 on DW below)
+	-- 2 basement dozers on DS (1 on DW below)
 	[100529] = {
 		values = {
-            amount = ambush_amount
-		}
+			amount = ambush_amount,
+		},
 	},
-	--Tweak the basement ambush chance (35% on Overkill below, 50% on Mayhem+)
+	-- Tweak the basement ambush chance (35% on Overkill below, 50% on Mayhem+)
 	[100528] = {
 		values = {
-            chance = ambush_doors_chance
-		}
+			chance = ambush_doors_chance,
+		},
 	},
-	--disable sniper spawns that I don't like
+	-- Disable sniper spawns that I don't like
 	[105826] = disabled,
 	[101619] = disabled,
-	--Glock ready to shoot (15% chance)
+	-- Glock ready to shoot (15% chance)
 	[103609] = {
 		values = {
-			enemy = dave
-		}
+			enemy = dave,
+		},
 	},
-	--Re-enable unused guard that spawn with Bo on the balcony
+	-- Re-enable unused guard that spawn with Bo on the balcony
 	[100671] = {
 		values = {
-			enabled = true
-		}
+			enabled = true,
+		},
 	},
-	--More cloakers in vault hallway on higher diffs
+	-- More cloakers in vault hallway on higher diffs
 	[103996] = {
 		values = {
-            amount = cloaker_ambush_amount_vault_hallway
-		}
+			amount = cloaker_ambush_amount_vault_hallway,
+		},
 	},
-	--Making sure that cloaker ambush in vault hallway works with alt vault entrance
+	-- Making sure that cloaker ambush in vault hallway works with alt vault entrance
 	[101188] = {
 		values = {
-			toggle = "on"
-		}
+			toggle = "on",
+		},
 	},
 	-- Disable forced manager flee objective
 	[100665] = {
 		values = {
-			enabled = false
-		}
+			enabled = false,
+		},
 	},
-	--Pro Job PONR
-	[100057] = { 
+	-- Pro Job PONR
+	[100057] = {
 		on_executed = {
-			{id = 400047, delay = 0},
-			{id = 400048, delay = 0}
-		}
+			{ id = 400047, delay = 0, },
+			{ id = 400048, delay = 0, },
+		},
 	},
-	--Disable lobby shields on startup
-	--Disable surprise tank on startup
-	--Disable Overdrill PONR
-	[100326] = { 
+	-- Disable lobby shields on startup
+	-- Disable surprise tank on startup
+	-- Disable Overdrill PONR
+	[100326] = {
 		on_executed = {
-			{id = 400044, delay = 3},
-			{id = 400049, delay = 3},
-			{id = 400057, delay = 3}
-		}
+			{ id = 400044, delay = 3, },
+			{ id = 400049, delay = 3, },
+			{ id = 400057, delay = 3, },
+		},
 	},
-	--Enable lobby shields on loud
-	--Enable surprise tank on loud
-	[101300] = { 
+	-- Enable lobby shields on loud
+	-- Enable surprise tank on loud
+	[101300] = {
 		on_executed = {
-			{id = 400043, delay = 0},
-			{id = 400056, delay = 0}
-		}
+			{ id = 400043, delay = 0, },
+			{ id = 400056, delay = 0, },
+		},
 	},
-	--Enable Overdrill PONR if Overdrill gets activated
-	[104136] = { 
+	-- Enable Overdrill PONR if Overdrill gets activated
+	[104136] = {
 		on_executed = {
-			{id = 400045, delay = 0},
-			{id = 400046, delay = 0}
-		}
+			{ id = 400045, delay = 0, },
+			{ id = 400046, delay = 0, },
+		},
 	},
-	--Enable the right vault path on mayhem above
+	-- Enable the right vault path on mayhem above
 	[105498] = {
 		values = {
-			enabled = enable_right_path
-		}
+			enabled = enable_right_path,
+		},
 	},
-	--enable vault hallway vent spawns on mayhem and above instead on all diffs
+	-- Enable vault hallway vent spawns on mayhem and above instead on all diffs
 	[105200] = {
 		values = {
-			enabled = vent_spawngroup
-		}
+			enabled = vent_spawngroup,
+		},
 	},
-	--Trigger Hunt on Pro Jobs (Endless Assault)
+	-- Trigger Hunt on Pro Jobs (Endless Assault)
 	[102366] = {
 		values = {
-			enabled = hunt_projob
-		}
+			enabled = hunt_projob,
+		},
 	},
-	--Let the cops finish their spawn anim before moving into SO spot
-	[103720] = { 
+	-- Let the cops finish their spawn anim before moving into SO spot
+	[103720] = {
 		on_executed = {
-			{id = 104029, delay = 2.75}
-		}
+			{ id = 104029, delay = 2.75, },
+		},
 	},
-	[103721] = { 
+	[103721] = {
 		on_executed = {
-			{id = 104071, delay = 2.75}
-		}
+			{ id = 104071, delay = 2.75, },
+		},
 	},
-	[103722] = { 
+	[103722] = {
 		on_executed = {
-			{id = 105734, delay = 2.75}
-		}
+			{ id = 105734, delay = 2.75, },
+		},
 	},
-	[103723] = { 
+	[103723] = {
 		on_executed = {
-			{id = 105736, delay = 2.75}
-		}
+			{ id = 105736, delay = 2.75, },
+		},
 	},
-	[103724] = { 
+	[103724] = {
 		on_executed = {
-			{id = 100226, delay = 2.75}
-		}
+			{ id = 100226, delay = 2.75, },
+		},
 	},
-	[103732] = { 
+	[103732] = {
 		on_executed = {
-			{id = 100077, delay = 2.75}
-		}
+			{ id = 100077, delay = 2.75, },
+		},
 	},
-	[103737] = { 
+	[103737] = {
 		on_executed = {
-			{id = 105732, delay = 2.75}
-		}
+			{ id = 105732, delay = 2.75, },
+		},
 	},
 	[100619] = {
 		values = {
@@ -192,98 +192,98 @@ return {
 					"units/pd2_mod_nypd/characters/ene_cop_1/ene_cop_1",
 					"units/pd2_mod_nypd/characters/ene_cop_2/ene_cop_2",
 					"units/pd2_mod_nypd/characters/ene_cop_3/ene_cop_3",
-					"units/pd2_mod_nypd/characters/ene_cop_4/ene_cop_4"	
-				}
-			}
-		}
+					"units/pd2_mod_nypd/characters/ene_cop_4/ene_cop_4",
+				},
+			},
+		},
 	},
-	--spawn lobby blockade shields
-	[101660] = { 
+	-- Spawn lobby blockade shields
+	[101660] = {
 		on_executed = {
-			{id = 400001, delay = 0},
-			{id = 400002, delay = 0}
-		}
+			{ id = 400001, delay = 0, },
+			{ id = 400002, delay = 0, },
+		},
 	},
-	--Use turret's chance to spawn lobby snipers instead
-	[105914] = { 
+	-- Use turret's chance to spawn lobby snipers instead
+	[105914] = {
 		values = {
-			chance = 45
+			chance = 45,
 		},
 		on_executed = {
-			{id = 105921, remove = true},
-			{id = 400003, delay = 1},
-			{id = 400004, delay = 2},
-			{id = 400005, delay = 3},
-			{id = 400006, delay = 4},
-			{id = 400007, delay = 5},
-			{id = 400008, delay = 6}
-		}
+			{ id = 105921, remove = true, },
+			{ id = 400003, delay = 1, },
+			{ id = 400004, delay = 2, },
+			{ id = 400005, delay = 3, },
+			{ id = 400006, delay = 4, },
+			{ id = 400007, delay = 5, },
+			{ id = 400008, delay = 6, },
+		},
 	},
-	--two extra possible dozers spawn on DW+ (PJ Only)
-	[103705] = { 
+	-- Two extra possible dozers spawn on DW+ (PJ Only)
+	[103705] = {
 		on_executed = {
-			{id = 400024, delay = 15},
-			{id = 400025, delay = 15}
-		}
+			{ id = 400024, delay = 15, },
+			{ id = 400025, delay = 15, },
+		},
 	},
-	--one extra Bo Dozer
-	[101953] = { 
+	-- One extra Bo Dozer
+	[101953] = {
 		on_executed = {
-			{id = 400020, delay = 1}
-		}
+			{ id = 400020, delay = 1, },
+		},
 	},
-	--Make this Bo Dozer use custom set up AI_Hunt
-	[105119] = { 
+	-- Make this Bo Dozer use custom set up AI_Hunt
+	[105119] = {
 		on_executed = {
-			{id = 400023, delay = 3}
-		}
+			{ id = 400023, delay = 3, },
+		},
 	},
-	--Use the unused area trigger to spawn the blackdozer
-	[106042] = { 
+	-- Use the unused area trigger to spawn the blackdozer
+	[106042] = {
 		on_executed = {
-			{id = 400055, delay = 15}
-		}
+			{ id = 400055, delay = 15, },
+		},
 	},
-	--MORE BANK GUARDS, HUH?! (Spawns extra blockade guards after opening the vault gates)
-	--Spawn 2 defend shields on Overkill and above
+	-- MORE BANK GUARDS, HUH?! (Spawns extra blockade guards after opening the vault gates)
+	-- Spawn 2 defend shields on Overkill and above
 	[100635] = {
 		on_executed = {
-			{id = 400010, delay = 0},
-			{id = 400011, delay = 0},
-			{id = 400012, delay = 0},
-			{id = 400013, delay = 0},
-			{id = 400014, delay = 0},
-			{id = 400015, delay = 0},
-			{id = 400016, delay = 0},
-			{id = 400017, delay = 0},
-			{id = 400018, delay = 0},
-			{id = 400019, delay = 0},
-			{id = 400041, delay = 0},
-			{id = 400042, delay = 0}
-		}
+			{ id = 400010, delay = 0, },
+			{ id = 400011, delay = 0, },
+			{ id = 400012, delay = 0, },
+			{ id = 400013, delay = 0, },
+			{ id = 400014, delay = 0, },
+			{ id = 400015, delay = 0, },
+			{ id = 400016, delay = 0, },
+			{ id = 400017, delay = 0, },
+			{ id = 400018, delay = 0, },
+			{ id = 400019, delay = 0, },
+			{ id = 400041, delay = 0, },
+			{ id = 400042, delay = 0, },
+		},
 	},
-	--Spawn two extra dozers on DS as a 193+ throwback
-	[100850] = { 
+	-- Spawn two extra dozers on DS as a 193+ throwback
+	[100850] = {
 		on_executed = {
-			{id = 400021, delay = 20},
-			{id = 400022, delay = 20}
-		}
+			{ id = 400021, delay = 20, },
+			{ id = 400022, delay = 20, },
+		},
 	},
-	--Killing Bo The Manager results of spawning two angry dozers
+	-- Killing Bo The Manager results of spawning two angry dozers
 	[100689] = {
 		on_executed = {
-			{id = 100682, delay = 0}
-		}
+			{ id = 100682, delay = 0, },
+		},
 	},
-	--spawn 3 rushing cloakers after 50 seconds of starting the assault
-	--spawn 2 scripted tasers after 90 seconds of starting the assault
-	[103984] = { 
+	-- Spawn 3 rushing cloakers after 50 seconds of starting the assault
+	-- Spawn 2 scripted tasers after 90 seconds of starting the assault
+	[103984] = {
 		on_executed = {
-			{id = 400030, delay = 50},
-			{id = 400031, delay = 50},
-			{id = 400032, delay = 50},
-			{id = 400037, delay = 90},
-			{id = 400038, delay = 90}
+			{ id = 400030, delay = 50, },
+			{ id = 400031, delay = 50, },
+			{ id = 400032, delay = 50, },
+			{ id = 400037, delay = 90, },
+			{ id = 400038, delay = 90, },
 		}
 	},
 	[102068] = {
@@ -291,48 +291,48 @@ return {
 			elements = {
 				103388,
 				105162,
-				400030
-			}
-		}
+				400030,
+			},
+		},
 	},
-	[102167] = { 
+	[102167] = {
 		values = {
 			elements = {
 				102130,
 				105176,
 				102135,
 				400031,
-				400032
-			}
-		}
+				400032,
+			},
+		},
 	},
-	--remove spawning the group and spawn 3 tasers+1 heavy swat as a 145+ throwback
-	--Spawn 2 dozers as a sudden spawn on DS if there are 3-4 players alive (50% chance, 193+ throwback)
+	-- Remove spawning the group and spawn 3 tasers+1 heavy swat as a 145+ throwback
+	-- Spawn 2 dozers as a sudden spawn on DS if there are 3-4 players alive (50% chance, 193+ throwback)
 	[103710] = { 
 		values = {
-			chance = stair_blockade_chance
+			chance = stair_blockade_chance,
 		},
 		on_executed = {
-			{id = 101400, remove = true},
-			{id = 400026, delay = 0},
-			{id = 400027, delay = 0},
-			{id = 400028, delay = 0},
-			{id = 400029, delay = 0},
-			{id = 400053, delay = 0}
-		}
+			{ id = 101400, remove = true, },
+			{ id = 400026, delay = 0, },
+			{ id = 400027, delay = 0, },
+			{ id = 400028, delay = 0, },
+			{ id = 400029, delay = 0, },
+			{ id = 400053, delay = 0, },
+		},
 	},
-	--Higher diffs forces both scripted window cloaker and taser spawns
+	-- Higher diffs forces both scripted window cloaker and taser spawns
 	[100875] = windows_swat,
 	[102245] = windows_swat,
 	[102271] = windows_swat,
 	[102276] = windows_swat,
-	--why there's a beat cop instead of guard in the vault? I dunno
+	-- Why there's a beat cop instead of guard in the vault? I dunno
 	[104001] = {
 		values = {
-            enemy = vault_guard
-		}
+			enemy = vault_guard,
+		},
 	},
-	--Spawn replacements
+	-- Spawn replacements
 	[101885] = titan_cloaker,
 	[103136] = titan_cloaker,
 	[103143] = titan_cloaker,
@@ -346,5 +346,5 @@ return {
 	[103395] = spooc,
 	[103466] = taser,
 	[103463] = shield,
-	[103465] = swatsg
+	[103465] = swatsg,
 }

--- a/req/mission_script_add/arena.lua
+++ b/req/mission_script_add/arena.lua
@@ -1,0 +1,57 @@
+local pro_job = Global.game_settings and Global.game_settings.one_down
+local opts_pro_job_ponr_input_event = {
+	enabled = true,
+	trigger_times = 1,
+	event_list = {
+		{ instance = "are_heli_escape_001", event = "activate_pro_job_ponr", },
+	},
+}
+local opts_try_start_ponr = {
+	enabled = false,
+	on_executed = {
+		{ id = 400001, delay = 0, },
+	},
+}
+local opts_try_start_ponr_late = opts_try_start_ponr
+local opts_toggle_on_ponr = {
+	enabled = true,
+	elements = { 400002, },
+	toggle = "on",
+}
+local opts_toggle_on_ponr_late = {
+	enabled = true,
+	elements = { 400003, },
+	toggle = "on",
+}
+
+return {
+	elements = {
+		restoration:gen_instance_input_event(
+			400001,
+			"pro_job_ponr_input_event",
+			Vector3(0, 0, 0),
+			Rotation(0, 0, 0),
+			opts_pro_job_ponr_input_event
+		),
+		restoration:gen_missionscript(
+			400002,
+			"try_start_ponr",
+			opts_try_start_ponr
+		),
+		restoration:gen_missionscript(
+			400003,
+			"try_start_ponr_late",
+			opts_try_start_ponr_late
+		),
+		restoration:gen_toggleelement(
+			400004,
+			"toggle_on_ponr",
+			opts_toggle_on_ponr
+		),
+		restoration:gen_toggleelement(
+			400005,
+			"toggle_on_ponr_late",
+			opts_toggle_on_ponr_late
+		),
+	},
+}

--- a/req/mission_script_add/bridge.lua
+++ b/req/mission_script_add/bridge.lua
@@ -12,169 +12,168 @@ local enabled_chance_dozer_scaffold = math.random() < diff_scaling
 local enabled_chance_shield_scaffold = math.random() < diff_scaling
 
 local optsBulldozer = {
-    enemy = dozer,
-    enabled = (overkill_above and enabled_chance_dozer)
+	enemy = dozer,
+	enabled = (overkill_above and enabled_chance_dozer),
 }
 local optsBulldozer_scaffold = {
-    enemy = dozer,
-    enabled = (mayhem_above and enabled_chance_dozer_scaffold)
+	enemy = dozer,
+	enabled = (mayhem_above and enabled_chance_dozer_scaffold),
 }
 local optsShield_1 = {
-    enemy = shield,
-	on_executed = { 
-		{ id = 400009, delay = 0 } 
+	enemy = shield,
+	on_executed = {
+		{ id = 400009, delay = 0, },
 	},
-    enabled = (overkill_above and enabled_chance_taser_and_shields)
+	enabled = (overkill_above and enabled_chance_taser_and_shields),
 }
 local optsShield_2 = {
-    enemy = shield,
-	on_executed = { 
-		{ id = 400010, delay = 0 } 
+	enemy = shield,
+	on_executed = {
+		{ id = 400010, delay = 0, },
 	},
-    enabled = (overkill_above and enabled_chance_taser_and_shields)
+	enabled = (overkill_above and enabled_chance_taser_and_shields),
 }
 local optsShield_scaff_1 = {
-    enemy = shield,
-	on_executed = { 
-		{ id = 400012, delay = 0 } 
+	enemy = shield,
+	on_executed = {
+		{ id = 400012, delay = 0, },
 	},
-    enabled = (overkill_above and enabled_chance_shield_scaffold)
+	enabled = (overkill_above and enabled_chance_shield_scaffold),
 }
 local optsShield_scaff_2 = {
-    enemy = shield,
-	on_executed = { 
-		{ id = 400013, delay = 0 } 
+	enemy = shield,
+	on_executed = {
+		{ id = 400013, delay = 0, },
 	},
-    enabled = (overkill_above and enabled_chance_shield_scaffold)
+	enabled = (overkill_above and enabled_chance_shield_scaffold),
 }
 local optsTaser = {
-    enemy = taser,
-	on_executed = { 
-		{ id = 400011, delay = 0 } 
+	enemy = taser,
+	on_executed = {
+		{ id = 400011, delay = 0, },
 	},
-    enabled = (overkill_above and enabled_chance_taser_and_shields)
+	enabled = (overkill_above and enabled_chance_taser_and_shields),
 }
 local optsDefend_and_Sniper_SO = {
-	SO_access = tostring(2048+8192),
+	SO_access = tostring(2048 + 8192),
 	scan = true,
 	align_position = true,
 	needs_pos_rsrv = true,
 	align_rotation = true,
 	interval = 2,
-    so_action = "AI_sniper"
+	so_action = "AI_sniper",
 }
 local optsrespawn_dozer = {
-	on_executed = { 
-		{id = 101320, delay = 30, delay_rand = 10}
+	on_executed = {
+		{ id = 101320, delay = 30, delay_rand = 10, },
 	},
-	elements = { 
-		101320
+	elements = {
+		101320,
 	},
-    event = "death"
+	event = "death",
 }
 
-
 return {
-    elements = {
-	--spawns near the escape (Similiar to PDTH)
-        restoration:gen_dummy(
-            400001,
-            "dozer_stairs",
-            Vector3(-3129, -48029, 5030.316),
-            Rotation(90, -0, -0),
-            optsBulldozer
-        ),
-        restoration:gen_dummy(
-            400002,
-            "shield_stairs_1",
-            Vector3(-2520.983, -47546.961, 5370.570),
-            Rotation(-87, -0, -0),
-            optsShield_1
-        ),
+	elements = {
+		-- Spawns near the escape (Similiar to PDTH)
 		restoration:gen_dummy(
-            400003,
-            "shield_stairs_2",
-            Vector3(-2524.437, -47481.051, 5372.570),
-            Rotation(-87, -0, -0),
-            optsShield_2
-        ),
-        restoration:gen_dummy(
-            400004,
-            "taser_stairs",
-            Vector3(-2994, -47502, 5225.499),
-            Rotation(-90, -0, -0),
-            optsTaser
-        ),
-	--scaffolding spawns	
+			400001,
+			"dozer_stairs",
+			Vector3(-3129, -48029, 5030.316),
+			Rotation(90, -0, -0),
+			optsBulldozer
+		),
+		restoration:gen_dummy(
+			400002,
+			"shield_stairs_1",
+			Vector3(-2520.983, -47546.961, 5370.570),
+			Rotation(-87, -0, -0),
+			optsShield_1
+		),
+		restoration:gen_dummy(
+			400003,
+			"shield_stairs_2",
+			Vector3(-2524.437, -47481.051, 5372.570),
+			Rotation(-87, -0, -0),
+			optsShield_2
+		),
+		restoration:gen_dummy(
+			400004,
+			"taser_stairs",
+			Vector3(-2994, -47502, 5225.499),
+			Rotation(-90, -0, -0),
+			optsTaser
+		),
+		-- Scaffolding spawns
 		 restoration:gen_dummy(
-            400005,
-            "shield_scaffolding_1",
-            Vector3(-4100, -22849, 7115.008),
-            Rotation(0, -0, -0),
-            optsShield_scaff_1
-        ),
+			400005,
+			"shield_scaffolding_1",
+			Vector3(-4100, -22849, 7115.008),
+			Rotation(0, -0, -0),
+			optsShield_scaff_1
+		),
 		 restoration:gen_dummy(
-            400006,
-            "shield_scaffolding_2",
-            Vector3(-2781.016, -23341.270, 7115.008),
-            Rotation(90, -0, -0),
-            optsShield_scaff_2
-        ),
+			400006,
+			"shield_scaffolding_2",
+			Vector3(-2781.016, -23341.270, 7115.008),
+			Rotation(90, -0, -0),
+			optsShield_scaff_2
+		),
 		restoration:gen_dummy(
-            400007,
-            "dozer_scaffolding_1",
-            Vector3(-3102, -23325, 6519.008),
-            Rotation(90, -0, -0),
-            optsBulldozer_scaffold
-        ),
+			400007,
+			"dozer_scaffolding_1",
+			Vector3(-3102, -23325, 6519.008),
+			Rotation(90, -0, -0),
+			optsBulldozer_scaffold
+		),
 		restoration:gen_dummy(
-            400008,
-            "dozer_scaffolding_2",
-            Vector3(-3580, -22030, 6519.008),
-            Rotation(90, -0, -0),
-            optsBulldozer_scaffold
-        ),
+			400008,
+			"dozer_scaffolding_2",
+			Vector3(-3580, -22030, 6519.008),
+			Rotation(90, -0, -0),
+			optsBulldozer_scaffold
+		),
 		restoration:gen_so(
-            400009,
-            "shield_blockade_so_1",
-            Vector3(-2520.983, -47546.961, 5370.570),
-            Rotation(-87, -0, -0),
-            optsDefend_and_Sniper_SO
-        ),
+			400009,
+			"shield_blockade_so_1",
+			Vector3(-2520.983, -47546.961, 5370.570),
+			Rotation(-87, -0, -0),
+			optsDefend_and_Sniper_SO
+		),
 		restoration:gen_so(
-            400010,
-            "shield_blockade_so_2",
-            Vector3(-2524.437, -47481.051, 5372.570),
-            Rotation(-87, -0, -0),
-            optsDefend_and_Sniper_SO
-        ),
+			400010,
+			"shield_blockade_so_2",
+			Vector3(-2524.437, -47481.051, 5372.570),
+			Rotation(-87, -0, -0),
+			optsDefend_and_Sniper_SO
+		),
 		restoration:gen_so(
-            400011,
-            "taser_blockade_so_1",
-            Vector3(-2994, -47502, 5225.499),
-            Rotation(-90, -0, -0),
-            optsDefend_and_Sniper_SO
-        ),
+			400011,
+			"taser_blockade_so_1",
+			Vector3(-2994, -47502, 5225.499),
+			Rotation(-90, -0, -0),
+			optsDefend_and_Sniper_SO
+		),
 		restoration:gen_so(
-            400012,
-            "shield_scaffold_blockade_so_1",
-            Vector3(-4100, -22849, 7115.008),
-            Rotation(0, -0, -0),
-            optsDefend_and_Sniper_SO
-        ),
+			400012,
+			"shield_scaffold_blockade_so_1",
+			Vector3(-4100, -22849, 7115.008),
+			Rotation(0, -0, -0),
+			optsDefend_and_Sniper_SO
+		),
 		restoration:gen_so(
-            400013,
-            "shield_scaffold_blockade_so_2",
-            Vector3(-2781.016, -23341.270, 7115.008),
-            Rotation(90, -0, -0),
-            optsDefend_and_Sniper_SO
-        ),
+			400013,
+			"shield_scaffold_blockade_so_2",
+			Vector3(-2781.016, -23341.270, 7115.008),
+			Rotation(90, -0, -0),
+			optsDefend_and_Sniper_SO
+		),
 		restoration:gen_dummytrigger(
-            400014,
-            "respawn_bulldozer",
-            Vector3(-2400, -3677, 375),
-            Rotation(90, -0, -0),
-            optsrespawn_dozer
-        )
-    }
+			400014,
+			"respawn_bulldozer",
+			Vector3(-2400, -3677, 375),
+			Rotation(90, -0, -0),
+			optsrespawn_dozer
+		),
+	},
 }

--- a/req/mission_script_add/dinner.lua
+++ b/req/mission_script_add/dinner.lua
@@ -1,44 +1,44 @@
 local murkywater_table = {
-    "units/pd2_mod_sharks/characters/ene_fbi_swat_1/ene_fbi_swat_1",
-    "units/pd2_mod_sharks/characters/ene_fbi_swat_1/ene_fbi_swat_1",
-    "units/pd2_mod_sharks/characters/ene_fbi_swat_3/ene_fbi_swat_3",
-    "units/pd2_mod_sharks/characters/ene_fbi_swat_3/ene_fbi_swat_3",
-    "units/pd2_mod_sharks/characters/ene_fbi_swat_1/ene_fbi_swat_1",
-    "units/pd2_mod_sharks/characters/ene_fbi_swat_1/ene_fbi_swat_1",
-    "units/pd2_mod_sharks/characters/ene_fbi_swat_2/ene_fbi_swat_2",
-    "units/pd2_mod_sharks/characters/ene_fbi_swat_2/ene_fbi_swat_2"
+	"units/pd2_mod_sharks/characters/ene_fbi_swat_1/ene_fbi_swat_1",
+	"units/pd2_mod_sharks/characters/ene_fbi_swat_1/ene_fbi_swat_1",
+	"units/pd2_mod_sharks/characters/ene_fbi_swat_3/ene_fbi_swat_3",
+	"units/pd2_mod_sharks/characters/ene_fbi_swat_3/ene_fbi_swat_3",
+	"units/pd2_mod_sharks/characters/ene_fbi_swat_1/ene_fbi_swat_1",
+	"units/pd2_mod_sharks/characters/ene_fbi_swat_1/ene_fbi_swat_1",
+	"units/pd2_mod_sharks/characters/ene_fbi_swat_2/ene_fbi_swat_2",
+	"units/pd2_mod_sharks/characters/ene_fbi_swat_2/ene_fbi_swat_2",
 }
 local murkywater_table_ovk = {
-    "units/pd2_mod_sharks/characters/ene_fbi_swat_1/ene_fbi_swat_1",
-    "units/pd2_mod_sharks/characters/ene_fbi_swat_1/ene_fbi_swat_1",
-    "units/pd2_mod_sharks/characters/ene_fbi_swat_3/ene_fbi_swat_3",
-    "units/pd2_mod_sharks/characters/ene_fbi_swat_3/ene_fbi_swat_3",
-    "units/pd2_mod_sharks/characters/ene_fbi_swat_1/ene_fbi_swat_1",
-    "units/pd2_mod_sharks/characters/ene_fbi_swat_1/ene_fbi_swat_1",
-    "units/pd2_mod_sharks/characters/ene_fbi_swat_2/ene_fbi_swat_2",
-    "units/pd2_mod_sharks/characters/ene_fbi_swat_2/ene_fbi_swat_2",
-    "units/pd2_mod_sharks/characters/ene_fbi_heavy_1/ene_fbi_heavy_1",
-    "units/pd2_mod_sharks/characters/ene_fbi_heavy_1/ene_fbi_heavy_1",
-    "units/pd2_mod_sharks/characters/ene_fbi_heavy_r870/ene_fbi_heavy_r870",
-    "units/pd2_mod_sharks/characters/ene_fbi_heavy_r870/ene_fbi_heavy_r870"
+	"units/pd2_mod_sharks/characters/ene_fbi_swat_1/ene_fbi_swat_1",
+	"units/pd2_mod_sharks/characters/ene_fbi_swat_1/ene_fbi_swat_1",
+	"units/pd2_mod_sharks/characters/ene_fbi_swat_3/ene_fbi_swat_3",
+	"units/pd2_mod_sharks/characters/ene_fbi_swat_3/ene_fbi_swat_3",
+	"units/pd2_mod_sharks/characters/ene_fbi_swat_1/ene_fbi_swat_1",
+	"units/pd2_mod_sharks/characters/ene_fbi_swat_1/ene_fbi_swat_1",
+	"units/pd2_mod_sharks/characters/ene_fbi_swat_2/ene_fbi_swat_2",
+	"units/pd2_mod_sharks/characters/ene_fbi_swat_2/ene_fbi_swat_2",
+	"units/pd2_mod_sharks/characters/ene_fbi_heavy_1/ene_fbi_heavy_1",
+	"units/pd2_mod_sharks/characters/ene_fbi_heavy_1/ene_fbi_heavy_1",
+	"units/pd2_mod_sharks/characters/ene_fbi_heavy_r870/ene_fbi_heavy_r870",
+	"units/pd2_mod_sharks/characters/ene_fbi_heavy_r870/ene_fbi_heavy_r870",
 }
 local murkywater_table_ds = {
-    "units/pd2_mod_sharks/characters/ene_fbi_swat_1/ene_fbi_swat_1",
-    "units/pd2_mod_sharks/characters/ene_fbi_swat_1/ene_fbi_swat_1",
-    "units/pd2_mod_sharks/characters/ene_fbi_swat_3/ene_fbi_swat_3",
-    "units/pd2_mod_sharks/characters/ene_fbi_swat_3/ene_fbi_swat_3",
-    "units/pd2_mod_sharks/characters/ene_fbi_swat_1/ene_fbi_swat_1",
-    "units/pd2_mod_sharks/characters/ene_fbi_swat_1/ene_fbi_swat_1",
-    "units/pd2_mod_sharks/characters/ene_fbi_swat_2/ene_fbi_swat_2",
-    "units/pd2_mod_sharks/characters/ene_fbi_swat_2/ene_fbi_swat_2",
-    "units/pd2_mod_sharks/characters/ene_titan_rifle/ene_titan_rifle",
-    "units/pd2_mod_sharks/characters/ene_titan_rifle/ene_titan_rifle",
-    "units/pd2_mod_sharks/characters/ene_titan_shotgun/ene_titan_shotgun",
-    "units/pd2_mod_sharks/characters/ene_titan_shotgun/ene_titan_shotgun",
-    "units/pd2_mod_sharks/characters/ene_fbi_heavy_1/ene_fbi_heavy_1",
-    "units/pd2_mod_sharks/characters/ene_fbi_heavy_1/ene_fbi_heavy_1",
-    "units/pd2_mod_sharks/characters/ene_fbi_heavy_r870/ene_fbi_heavy_r870",
-    "units/pd2_mod_sharks/characters/ene_fbi_heavy_r870/ene_fbi_heavy_r870"
+	"units/pd2_mod_sharks/characters/ene_fbi_swat_1/ene_fbi_swat_1",
+	"units/pd2_mod_sharks/characters/ene_fbi_swat_1/ene_fbi_swat_1",
+	"units/pd2_mod_sharks/characters/ene_fbi_swat_3/ene_fbi_swat_3",
+	"units/pd2_mod_sharks/characters/ene_fbi_swat_3/ene_fbi_swat_3",
+	"units/pd2_mod_sharks/characters/ene_fbi_swat_1/ene_fbi_swat_1",
+	"units/pd2_mod_sharks/characters/ene_fbi_swat_1/ene_fbi_swat_1",
+	"units/pd2_mod_sharks/characters/ene_fbi_swat_2/ene_fbi_swat_2",
+	"units/pd2_mod_sharks/characters/ene_fbi_swat_2/ene_fbi_swat_2",
+	"units/pd2_mod_sharks/characters/ene_titan_rifle/ene_titan_rifle",
+	"units/pd2_mod_sharks/characters/ene_titan_rifle/ene_titan_rifle",
+	"units/pd2_mod_sharks/characters/ene_titan_shotgun/ene_titan_shotgun",
+	"units/pd2_mod_sharks/characters/ene_titan_shotgun/ene_titan_shotgun",
+	"units/pd2_mod_sharks/characters/ene_fbi_heavy_1/ene_fbi_heavy_1",
+	"units/pd2_mod_sharks/characters/ene_fbi_heavy_1/ene_fbi_heavy_1",
+	"units/pd2_mod_sharks/characters/ene_fbi_heavy_r870/ene_fbi_heavy_r870",
+	"units/pd2_mod_sharks/characters/ene_fbi_heavy_r870/ene_fbi_heavy_r870",
 }
 local difficulty = tweak_data:difficulty_to_index(Global.game_settings and Global.game_settings.difficulty or "normal")
 local pro_job = Global.game_settings and Global.game_settings.one_down
@@ -57,157 +57,179 @@ local enabled_chance_shields_and_tazer = math.random() < diff_scaling
 local enabled_chance_shields_and_tazer_2 = math.random() < diff_scaling
 local enabled_chance_shields_and_dozer = math.random() < diff_scaling
 local dozer_respawn_delay = (difficulty >= 7 and 120) or 180
+local ponr_value = (difficulty <= 5 and 120) or 90
+local ponr_timer_player_mul = {
+	1,
+	1,
+	1,
+	1,
+	1,  -- 5+ players
+}
 
+local opts_pro_job_ponr = {
+	elements = { 100989 },
+	trigger_times = 0,
+	time_balance_mul = ponr_timer_player_mul,
+	time_easy = ponr_value,
+	time_normal = ponr_value,
+	time_hard = ponr_value,
+	time_overkill = ponr_value,
+	time_overkill_145 = ponr_value,
+	time_easy_wish = ponr_value,
+	time_overkill_290 = ponr_value,
+	time_sm_wish = ponr_value,
+	enabled = pro_job,
+}
 local spawn_cloakers = {
 	enabled = (hard_above and enabled_chance_cloakers),
-	on_executed = { 
-		{ id = 400001, delay = 0 },
-		{ id = 400002, delay = 0 },
-		{ id = 400003, delay = 0 }
-	}
+	on_executed = {
+		{ id = 400001, delay = 0, },
+		{ id = 400002, delay = 0, },
+		{ id = 400003, delay = 0, },
+	},
 }
 local spawn_shields_and_taser_1 = {
 	enabled = enabled_chance_shields_and_tazer,
-	on_executed = { 
-		{ id = 400004, delay = 0 },
-		{ id = 400005, delay = 0 },
-		{ id = 400006, delay = 0 }
-	}
+	on_executed = {
+		{ id = 400004, delay = 0, },
+		{ id = 400005, delay = 0, },
+		{ id = 400006, delay = 0, },
+	},
 }
 local spawn_shields_and_taser_2 = {
 	enabled = enabled_chance_shields_and_tazer_2,
-	on_executed = { 
-		{ id = 400007, delay = 0 },
-		{ id = 400008, delay = 0 },
-		{ id = 400009, delay = 0 }
-	}
+	on_executed = {
+		{ id = 400007, delay = 0, },
+		{ id = 400008, delay = 0, },
+		{ id = 400009, delay = 0, },
+	},
 }
 local spawn_shields_and_dozer = {
 	enabled = enabled_chance_shields_and_dozer,
-	on_executed = { 
-		{ id = 400010, delay = 0 },
-		{ id = 400011, delay = 0 },
-		{ id = 400012, delay = 0 }
-	}
+	on_executed = {
+		{ id = 400010, delay = 0, },
+		{ id = 400011, delay = 0, },
+		{ id = 400012, delay = 0, },
+	},
 }
 local spawn_murkies = {
 	enabled = true,
 	trigger_times = 1,
-	on_executed = { 
-		{ id = 400028, delay = 0 },
-		{ id = 400029, delay = 0 },
-		{ id = 400030, delay = 0 },
-		{ id = 400031, delay = 0 },
-		{ id = 400032, delay = 0 },
-		{ id = 400033, delay = 0 },
-		{ id = 400034, delay = 0 },
-		{ id = 400035, delay = 0 },
-		{ id = 400036, delay = 0 },
-		{ id = 400037, delay = 0 },
-		{ id = 400038, delay = 0 },
-		{ id = 400039, delay = 0 },
-		{ id = 400058, delay = 0 },
-		{ id = 400059, delay = 0 },
-		{ id = 400060, delay = 0 },
-		{ id = 400061, delay = 0 }
-	}
+	on_executed = {
+		{ id = 400028, delay = 0, },
+		{ id = 400029, delay = 0, },
+		{ id = 400030, delay = 0, },
+		{ id = 400031, delay = 0, },
+		{ id = 400032, delay = 0, },
+		{ id = 400033, delay = 0, },
+		{ id = 400034, delay = 0, },
+		{ id = 400035, delay = 0, },
+		{ id = 400036, delay = 0, },
+		{ id = 400037, delay = 0, },
+		{ id = 400038, delay = 0, },
+		{ id = 400039, delay = 0, },
+		{ id = 400058, delay = 0, },
+		{ id = 400059, delay = 0, },
+		{ id = 400060, delay = 0, },
+		{ id = 400061, delay = 0, },
+	},
 }
 local optsBesiegeDummy = {
-    participate_to_group_ai = true,
-    enabled = true,
-    spawn_action = "e_sp_armored_truck_1st"
+	participate_to_group_ai = true,
+	enabled = true,
+	spawn_action = "e_sp_armored_truck_1st",
 }
 local optsCloaker = {
-    enemy = cloaker,
-	on_executed = { 
-		{ id = 400057, delay = 3 }
+	enemy = cloaker,
+	on_executed = {
+		{ id = 400057, delay = 3, },
 	},
-    enabled = true
+	enabled = true,
 }
 local optsTaser = {
-    enemy = taser,
-	on_executed = { 
-		{ id = 400057, delay = 3 }
+	enemy = taser,
+	on_executed = {
+		{ id = 400057, delay = 3, },
 	},
-    enabled = true
+	enabled = true,
 }
 local optsShield = {
-    enemy = shield,
-	on_executed = { 
-		{ id = 400057, delay = 3 }
+	enemy = shield,
+	on_executed = {
+		{ id = 400057, delay = 3, },
 	},
-    enabled = true
+	enabled = true,
 }
 local optsBulldozer_Ambush = {
-    enemy = tank,
-	on_executed = { 
-		{ id = 400057, delay = 3 }
+	enemy = tank,
+	on_executed = {
+		{ id = 400057, delay = 3, },
 	},
-    enabled = true
+	enabled = true,
 }
 local spawn_dozer_1 = {
 	enabled = true,
 	trigger_times = 1,
 	on_executed = {
-		{ id = 400019, delay = 0 }
-	}
+		{ id = 400019, delay = 0, },
+	},
 }
 local spawn_dozer_2 = {
 	enabled = true,
 	trigger_times = 1,
-	on_executed = { 
-		{ id = 400020, delay = 0 }
-	}
+	on_executed = {
+		{ id = 400020, delay = 0, },
+	},
 }
 local optsBulldozer = {
-    enemy = tank,
+	enemy = tank,
 	on_executed = {
-        { id = 400021, delay = 0.5 },
-		{ id = 400048, delay = 0 }
-    },
-    enabled = true
+		{ id = 400021, delay = 0.5, },
+		{ id = 400048, delay = 0, },
+	},
+	enabled = true,
 }
 local optsBulldozer_SO = {
-    SO_access = "4096",
+	SO_access = "4096",
 	path_style = "none",
 	scan = true,
 	interval = 2,
-    so_action = "AI_hunt"
+	so_action = "AI_hunt",
 }
 local optsHunt_SO = {
-    SO_access = tostring(1024+2048+4096+8192),
+	SO_access = tostring(1024 + 2048 + 4096 + 8192),
 	path_style = "none",
 	scan = true,
 	interval = 2,
-    so_action = "AI_hunt"
+	so_action = "AI_hunt",
 }
 local optsSniper_1 = {
 	enemy = sniper,
 	on_executed = {
-        { id = 400016, delay = 0 },
-    },
-    enabled = enabled_chance_snipers
+		{ id = 400016, delay = 0, },
+	},
+	enabled = enabled_chance_snipers,
 }
 local optsSniper_2 = {
 	enemy = sniper,
 	spawn_action = "e_sp_up_ledge",
 	on_executed = {
-        { id = 400017, delay = 2 }
-    },
-    enabled = (overkill_above and enabled_chance_snipers)
+		{ id = 400017, delay = 2, },
+	},
+	enabled = (overkill_above and enabled_chance_snipers),
 }
 local optsSniper_3 = {
 	enemy = sniper,
 	spawn_action = "e_sp_up_ledge",
 	on_executed = {
-        { id = 400018, delay = 2 }
-    },
-    enabled = (overkill_above and enabled_chance_snipers)
+		{ id = 400018, delay = 2, },
+	},
+	enabled = (overkill_above and enabled_chance_snipers),
 }
 local optsMurky = {
-    enemy_table = murkies,
+	enemy_table = murkies,
 	participate_to_group_ai = true,
-    enabled = true
+	enabled = true,
 }
 local optsSniper_SO = {
 	scan = true,
@@ -215,282 +237,282 @@ local optsSniper_SO = {
 	needs_pos_rsrv = true,
 	align_rotation = true,
 	interval = 2,
-    so_action = "AI_sniper"
+	so_action = "AI_sniper",
 }
 local optsrespawn_murkies_1 = {
-	on_executed = { 
-		{ id = 400028, delay = 35 },
-		{ id = 400029, delay = 35 },
-		{ id = 400030, delay = 35 },
-		{ id = 400031, delay = 35 }
+	on_executed = {
+		{ id = 400028, delay = 35, },
+		{ id = 400029, delay = 35, },
+		{ id = 400030, delay = 35, },
+		{ id = 400031, delay = 35, },
 	},
-	elements = { 
-		400028
+	elements = {
+		400028,
 	},
-    event = "death"
+	event = "death",
 }
 local optsrespawn_murkies_2 = {
-	on_executed = { 
-		{ id = 400032, delay = 35 },
-		{ id = 400033, delay = 35 },
-		{ id = 400034, delay = 35 },
-		{ id = 400035, delay = 35 }
+	on_executed = {
+		{ id = 400032, delay = 35, },
+		{ id = 400033, delay = 35, },
+		{ id = 400034, delay = 35, },
+		{ id = 400035, delay = 35, },
 	},
-	elements = { 
-		400032
+	elements = {
+		400032,
 	},
-    event = "death"
+	event = "death",
 }
 local optsrespawn_murkies_3 = {
-	on_executed = { 
-		{ id = 400036, delay = 35 },
-		{ id = 400037, delay = 35 },
-		{ id = 400038, delay = 35 },
-		{ id = 400039, delay = 35 }
+	on_executed = {
+		{ id = 400036, delay = 35, },
+		{ id = 400037, delay = 35, },
+		{ id = 400038, delay = 35, },
+		{ id = 400039, delay = 35, },
 	},
-	elements = { 
-		400036
+	elements = {
+		400036,
 	},
-    event = "death"
+	event = "death",
 }
 local optsrespawn_murkies_4 = {
-	on_executed = { 
-		{ id = 400058, delay = 35 },
-		{ id = 400059, delay = 35 },
-		{ id = 400060, delay = 35 },
-		{ id = 400061, delay = 35 }
+	on_executed = {
+		{ id = 400058, delay = 35, },
+		{ id = 400059, delay = 35, },
+		{ id = 400060, delay = 35, },
+		{ id = 400061, delay = 35, },
 	},
-	elements = { 
-		400058
+	elements = {
+		400058,
 	},
-    event = "death"
+	event = "death",
 }
 local optsrespawn_dozer_1 = {
-	on_executed = { 
-		{ id = 400019, delay = dozer_respawn_delay }
+	on_executed = {
+		{ id = 400019, delay = dozer_respawn_delay, },
 	},
-	elements = { 
-		400019
+	elements = {
+		400019,
 	},
-    event = "death"
+	event = "death"
 }
 local optsrespawn_dozer_2 = {
-	on_executed = { 
-		{ id = 400020, delay = dozer_respawn_delay }
+	on_executed = {
+		{ id = 400020, delay = dozer_respawn_delay, },
 	},
-	elements = { 
-		400020
+	elements = {
+		400020,
 	},
-    event = "death"
+	event = "death"
 }
 local Bain_senddozers = {
 	dialogue = "Play_ban_s02_a",
-	can_not_be_muted = true
+	can_not_be_muted = true,
 }
-local van_spawngroup  = {
+local van_spawngroup = {
 	spawn_groups = {
-		400026
-	}
+		400026,
+	},
 }
 local disable_dozer = {
 	enabled = true,
 	toggle = "off",
-	elements = { 
-		400019
-	}
+	elements = {
+		400019,
+	},
 }
 local disable_murkies = {
 	enabled = true,
 	toggle = "off",
-	elements = { 
+	elements = {
 		400040,
 		400041,
 		400042,
-		400062
-	}
+		400062,
+	},
 }
 
 return {
-    elements = {
-        --Ambush
-        restoration:gen_dummy(
-            400001,
-            "cloaker_1",
-            Vector3(-12545, 7176, 4.995),
-            Rotation(-180, 0, -0),
-            optsCloaker
-        ),
-        restoration:gen_dummy(
-            400002,
-            "cloaker_2",
-            Vector3(-12458, 7282, 4.995),
-            Rotation(-180, 0, -0),
-            optsCloaker
-        ),
+	elements = {
+		-- Ambush
 		restoration:gen_dummy(
-            400003,
-            "cloaker_3",
-            Vector3(-12607, 7282, 4.995),
-            Rotation(-180, 0, -0),
-            optsCloaker
-        ),
+			400001,
+			"cloaker_1",
+			Vector3(-12545, 7176, 4.995),
+			Rotation(-180, 0, -0),
+			optsCloaker
+		),
 		restoration:gen_dummy(
-            400004,
-            "shield_1",
-            Vector3(-12073, 7142, 4.995),
-            Rotation(-180, 0, -0),
-            optsShield
-        ),
-        restoration:gen_dummy(
-            400005,
-            "shield_2",
-            Vector3(-11981, 7142, 4.995),
-            Rotation(-180, 0, -0),
-            optsShield
-        ),
+			400002,
+			"cloaker_2",
+			Vector3(-12458, 7282, 4.995),
+			Rotation(-180, 0, -0),
+			optsCloaker
+		),
 		restoration:gen_dummy(
-            400006,
-            "taser_1",
-            Vector3(-12023, 7209, 4.995),
-            Rotation(-180, 0, -0),
-            optsTaser
-        ),
+			400003,
+			"cloaker_3",
+			Vector3(-12607, 7282, 4.995),
+			Rotation(-180, 0, -0),
+			optsCloaker
+		),
 		restoration:gen_dummy(
-            400007,
-            "shield_3",
-            Vector3(-13408, 7176, 4.995),
-            Rotation(-180, 0, -0),
-            optsShield
-        ),
-        restoration:gen_dummy(
-            400008,
-            "shield_4",
-            Vector3(-13334, 7176, 4.995),
-            Rotation(-180, 0, -0),
-            optsShield
-        ),
+			400004,
+			"shield_1",
+			Vector3(-12073, 7142, 4.995),
+			Rotation(-180, 0, -0),
+			optsShield
+		),
 		restoration:gen_dummy(
-            400009,
-            "taser_2",
-            Vector3(-13371, 7262, 4.995),
-            Rotation(-180, 0, -0),
-            optsTaser
-        ),
+			400005,
+			"shield_2",
+			Vector3(-11981, 7142, 4.995),
+			Rotation(-180, 0, -0),
+			optsShield
+		),
 		restoration:gen_dummy(
-            400010,
-            "shield_3",
-            Vector3(-13666, 6195, 4.995),
-            Rotation(0, 0, -0),
-            optsShield
-        ),
-        restoration:gen_dummy(
-            400011,
-            "shield_4",
-            Vector3(-13756, 6195, 4.995),
-            Rotation(0, 0, -0),
-            optsShield
-        ),
+			400006,
+			"taser_1",
+			Vector3(-12023, 7209, 4.995),
+			Rotation(-180, 0, -0),
+			optsTaser
+		),
 		restoration:gen_dummy(
-            400012,
-            "bulldozer_1",
-            Vector3(-13707, 6078, 4.995),
-            Rotation(0, 0, -0),
-            optsBulldozer_Ambush
-        ),
-		--Snipers
+			400007,
+			"shield_3",
+			Vector3(-13408, 7176, 4.995),
+			Rotation(-180, 0, -0),
+			optsShield
+		),
 		restoration:gen_dummy(
-            400013,
-            "sniper_1",
-            Vector3(-13496, 6470, 889.902),
-            Rotation(90, 0, -0),
-            optsSniper_1
-        ),
+			400008,
+			"shield_4",
+			Vector3(-13334, 7176, 4.995),
+			Rotation(-180, 0, -0),
+			optsShield
+		),
 		restoration:gen_dummy(
-            400014,
-            "sniper_2",
-            Vector3(-20101, 6888, 747.404),
-            Rotation(-90, 0, -0),
-            optsSniper_2
-        ),
+			400009,
+			"taser_2",
+			Vector3(-13371, 7262, 4.995),
+			Rotation(-180, 0, -0),
+			optsTaser
+		),
 		restoration:gen_dummy(
-            400015,
-            "sniper_3",
-            Vector3(-16210, 9663, 1012.404),
-            Rotation(180, 0, -0),
-            optsSniper_3
-        ),
+			400010,
+			"shield_3",
+			Vector3(-13666, 6195, 4.995),
+			Rotation(0, 0, -0),
+			optsShield
+		),
+		restoration:gen_dummy(
+			400011,
+			"shield_4",
+			Vector3(-13756, 6195, 4.995),
+			Rotation(0, 0, -0),
+			optsShield
+		),
+		restoration:gen_dummy(
+			400012,
+			"bulldozer_1",
+			Vector3(-13707, 6078, 4.995),
+			Rotation(0, 0, -0),
+			optsBulldozer_Ambush
+		),
+		-- Snipers
+		restoration:gen_dummy(
+			400013,
+			"sniper_1",
+			Vector3(-13496, 6470, 889.902),
+			Rotation(90, 0, -0),
+			optsSniper_1
+		),
+		restoration:gen_dummy(
+			400014,
+			"sniper_2",
+			Vector3(-20101, 6888, 747.404),
+			Rotation(-90, 0, -0),
+			optsSniper_2
+		),
+		restoration:gen_dummy(
+			400015,
+			"sniper_3",
+			Vector3(-16210, 9663, 1012.404),
+			Rotation(180, 0, -0),
+			optsSniper_3
+		),
 		restoration:gen_so(
-            400016,
-            "sniper_so_1",
-            Vector3(-14101.043, 7791.234, 624.654),
-            Rotation(134, 0, -0),
-            optsSniper_SO
-        ),
+			400016,
+			"sniper_so_1",
+			Vector3(-14101.043, 7791.234, 624.654),
+			Rotation(134, 0, -0),
+			optsSniper_SO
+		),
 		restoration:gen_so(
-            400017,
-            "sniper_so_2",
-            Vector3(-19603, 6971, 747.404),
-            Rotation(-90, 0, -0),
-            optsSniper_SO
-        ),
+			400017,
+			"sniper_so_2",
+			Vector3(-19603, 6971, 747.404),
+			Rotation(-90, 0, -0),
+			optsSniper_SO
+		),
 		restoration:gen_so(
-            400018,
-            "sniper_so_3",
-            Vector3(-16155, 9187, 1012.404),
-            Rotation(180, 0, -0),
-            optsSniper_SO
-        ),
-		--Dozers
+			400018,
+			"sniper_so_3",
+			Vector3(-16155, 9187, 1012.404),
+			Rotation(180, 0, -0),
+			optsSniper_SO
+		),
+		-- Dozers
 		restoration:gen_dummy(
-            400019,
-            "bulldozer_2",
-            Vector3(-8785, 3730, -72),
-            Rotation(-90, 0, -0),
-            optsBulldozer
-        ),
+			400019,
+			"bulldozer_2",
+			Vector3(-8785, 3730, -72),
+			Rotation(-90, 0, -0),
+			optsBulldozer
+		),
 		restoration:gen_dummy(
-            400020,
-            "bulldozer_3",
-            Vector3(-13231, 6749, 889.902),
-            Rotation(90, 0, -0),
-            optsBulldozer
-        ),
+			400020,
+			"bulldozer_3",
+			Vector3(-13231, 6749, 889.902),
+			Rotation(90, 0, -0),
+			optsBulldozer
+		),
 		restoration:gen_so(
-            400021,
-            "dozer_hunt_so",
-            Vector3(3600, 2473, -1200),
-            Rotation(0, 0, 0),
-            optsBulldozer_SO
-        ),
+			400021,
+			"dozer_hunt_so",
+			Vector3(3600, 2473, -1200),
+			Rotation(0, 0, 0),
+			optsBulldozer_SO
+		),
 		--SWAT
 		restoration:gen_dummy(
-            400022,
-            "van_dummy_1",
-            Vector3(-15438.496, 5177.672, -81.025),
-            Rotation(170, 0, -0),
-            optsBesiegeDummy
-        ),
+			400022,
+			"van_dummy_1",
+			Vector3(-15438.496, 5177.672, -81.025),
+			Rotation(170, 0, -0),
+			optsBesiegeDummy
+		),
 		restoration:gen_dummy(
-            400023,
-            "van_dummy_2",
-            Vector3(-15371.752, 5177.833, -81.025),
-            Rotation(172, 0, -0),
-            optsBesiegeDummy
-        ),
+			400023,
+			"van_dummy_2",
+			Vector3(-15371.752, 5177.833, -81.025),
+			Rotation(172, 0, -0),
+			optsBesiegeDummy
+		),
 		restoration:gen_dummy(
-            400024,
-            "van_dummy_3",
-            Vector3(-15495.743, 4220.271, -81.025),
-            Rotation(-171, 0, -0),
-            optsBesiegeDummy
-        ),
+			400024,
+			"van_dummy_3",
+			Vector3(-15495.743, 4220.271, -81.025),
+			Rotation(-171, 0, -0),
+			optsBesiegeDummy
+		),
 		restoration:gen_dummy(
-            400025,
-            "van_dummy_4",
-            Vector3(-15430.557, 4230.596, -81.025),
-            Rotation(-171, 0, -0),
-            optsBesiegeDummy
-        ),
+			400025,
+			"van_dummy_4",
+			Vector3(-15430.557, 4230.596, -81.025),
+			Rotation(-171, 0, -0),
+			optsBesiegeDummy
+		),
 		restoration:gen_spawngroup(
 			400026,
 			"van_spawngroup",
@@ -498,221 +520,228 @@ return {
 			5
 		),
 		restoration:gen_preferedadd(
-            400027,
-            "spawn_the_van_spawngroup",
-            van_spawngroup
-        ),
-		--Murkies & Respawns
+			400027,
+			"spawn_the_van_spawngroup",
+			van_spawngroup
+		),
+		-- Murkies & Respawns
 		restoration:gen_dummy(
-            400028,
-            "murky_1",
-            Vector3(-8611, 3648, -72),
-            Rotation(-90, 0, -0),
-            optsMurky
-        ),
+			400028,
+			"murky_1",
+			Vector3(-8611, 3648, -72),
+			Rotation(-90, 0, -0),
+			optsMurky
+		),
 		restoration:gen_dummy(
-            400029,
-            "murky_2",
-            Vector3(-8611, 3750, -72),
-            Rotation(-90, 0, -0),
-            optsMurky
-        ),
+			400029,
+			"murky_2",
+			Vector3(-8611, 3750, -72),
+			Rotation(-90, 0, -0),
+			optsMurky
+		),
 		restoration:gen_dummy(
-            400030,
-            "murky_3",
-            Vector3(-8525, 3669, -72),
-            Rotation(-90, 0, -0),
-            optsMurky
-        ),
+			400030,
+			"murky_3",
+			Vector3(-8525, 3669, -72),
+			Rotation(-90, 0, -0),
+			optsMurky
+		),
 		restoration:gen_dummy(
-            400031,
-            "murky_4",
-            Vector3(-8525, 3750, -72),
-            Rotation(-90, 0, -0),
-            optsMurky
-        ),
+			400031,
+			"murky_4",
+			Vector3(-8525, 3750, -72),
+			Rotation(-90, 0, -0),
+			optsMurky
+		),
 		restoration:gen_dummy(
-            400032,
-            "murky_5",
-            Vector3(-7567, 7768, 898.834),
-            Rotation(0, 0, -0),
-            optsMurky
-        ),
+			400032,
+			"murky_5",
+			Vector3(-7567, 7768, 898.834),
+			Rotation(0, 0, -0),
+			optsMurky
+		),
 		restoration:gen_dummy(
-            400033,
-            "murky_6",
-            Vector3(-7653, 7768, 898.834),
-            Rotation(0, 0, -0),
-            optsMurky
-        ),
+			400033,
+			"murky_6",
+			Vector3(-7653, 7768, 898.834),
+			Rotation(0, 0, -0),
+			optsMurky
+		),
 		restoration:gen_dummy(
-            400034,
-            "murky_7",
-            Vector3(-7653, 7838, 898.834),
-            Rotation(0, 0, -0),
-            optsMurky
-        ),
+			400034,
+			"murky_7",
+			Vector3(-7653, 7838, 898.834),
+			Rotation(0, 0, -0),
+			optsMurky
+		),
 		restoration:gen_dummy(
-            400035,
-            "murky_8",
-            Vector3(-7567, 7838, 898.834),
-            Rotation(0, 0, -0),
-            optsMurky
-        ),
+			400035,
+			"murky_8",
+			Vector3(-7567, 7838, 898.834),
+			Rotation(0, 0, -0),
+			optsMurky
+		),
 		restoration:gen_dummy(
-            400036,
-            "murky_9",
-            Vector3(-6933, 9746, 9.261),
-            Rotation(90, -0, -0),
-            optsMurky
-        ),
+			400036,
+			"murky_9",
+			Vector3(-6933, 9746, 9.261),
+			Rotation(90, -0, -0),
+			optsMurky
+		),
 		restoration:gen_dummy(
-            400037,
-            "murky_10",
-            Vector3(-6933, 9666, 9.261),
-            Rotation(90, -0, -0),
-            optsMurky
-        ),
+			400037,
+			"murky_10",
+			Vector3(-6933, 9666, 9.261),
+			Rotation(90, -0, -0),
+			optsMurky
+		),
 		restoration:gen_dummy(
-            400038,
-            "murky_11",
-            Vector3(-7011, 9744, 9.261),
-            Rotation(90, -0, -0),
-            optsMurky
-        ),
+			400038,
+			"murky_11",
+			Vector3(-7011, 9744, 9.261),
+			Rotation(90, -0, -0),
+			optsMurky
+		),
 		restoration:gen_dummy(
-            400039,
-            "murky_12",
-            Vector3(-7011, 9668, 9.261),
-            Rotation(90, -0, -0),
-            optsMurky
-        ),
+			400039,
+			"murky_12",
+			Vector3(-7011, 9668, 9.261),
+			Rotation(90, -0, -0),
+			optsMurky
+		),
 		restoration:gen_dummytrigger(
-            400040,
-            "respawn_murkies_1",
-            Vector3(-2400, -3677, 375),
-            Rotation(90, -0, -0),
-            optsrespawn_murkies_1
-        ),
+			400040,
+			"respawn_murkies_1",
+			Vector3(-2400, -3677, 375),
+			Rotation(90, -0, -0),
+			optsrespawn_murkies_1
+		),
 		restoration:gen_dummytrigger(
-            400041,
-            "respawn_murkies_2",
-            Vector3(-2400, -3577, 375),
-            Rotation(90, -0, -0),
-            optsrespawn_murkies_2
-        ),
+			400041,
+			"respawn_murkies_2",
+			Vector3(-2400, -3577, 375),
+			Rotation(90, -0, -0),
+			optsrespawn_murkies_2
+		),
 		restoration:gen_dummytrigger(
-            400042,
-            "respawn_murkies_3",
-            Vector3(-2400, -3577, 375),
-            Rotation(90, -0, -0),
-            optsrespawn_murkies_3
-        ),
+			400042,
+			"respawn_murkies_3",
+			Vector3(-2400, -3577, 375),
+			Rotation(90, -0, -0),
+			optsrespawn_murkies_3
+		),
 		restoration:gen_dummytrigger(
-            400043,
-            "respawn_dozer_1",
-            Vector3(-2400, -3577, 375),
-            Rotation(90, -0, -0),
-            optsrespawn_dozer_1
-        ),
+			400043,
+			"respawn_dozer_1",
+			Vector3(-2400, -3577, 375),
+			Rotation(90, -0, -0),
+			optsrespawn_dozer_1
+		),
 		restoration:gen_dummytrigger(
-            400044,
-            "respawn_dozer_2",
-            Vector3(-2400, -3577, 375),
-            Rotation(90, -0, -0),
-            optsrespawn_dozer_2
-        ),
+			400044,
+			"respawn_dozer_2",
+			Vector3(-2400, -3577, 375),
+			Rotation(90, -0, -0),
+			optsrespawn_dozer_2
+		),
 		restoration:gen_toggleelement(
-            400045,
-            "disable_dozer",
-            disable_dozer
-        ),
+			400045,
+			"disable_dozer",
+			disable_dozer
+		),
 		restoration:gen_missionscript(
-            400046,
-            "spawn_murkies",
-            spawn_murkies
-        ),
+			400046,
+			"spawn_murkies",
+			spawn_murkies
+		),
 		restoration:gen_dialogue(
-            400048,
-            "they_sending_dozers",
-            Bain_senddozers
-        ),
+			400048,
+			"they_sending_dozers",
+			Bain_senddozers
+		),
 		restoration:gen_missionscript(
-            400050,
-            "spawn_cloakers",
-            spawn_cloakers
-        ),
+			400050,
+			"spawn_cloakers",
+			spawn_cloakers
+		),
 		restoration:gen_missionscript(
-            400051,
-            "spawn_shields_and_taser_1",
-            spawn_shields_and_taser_1
-        ),
+			400051,
+			"spawn_shields_and_taser_1",
+			spawn_shields_and_taser_1
+		),
 		restoration:gen_missionscript(
-            400052,
-            "spawn_shields_and_taser_2",
-            spawn_shields_and_taser_2
-        ),
+			400052,
+			"spawn_shields_and_taser_2",
+			spawn_shields_and_taser_2
+		),
 		restoration:gen_missionscript(
-            400053,
-            "spawn_shields_and_dozer",
-            spawn_shields_and_dozer
-        ),
+			400053,
+			"spawn_shields_and_dozer",
+			spawn_shields_and_dozer
+		),
 		restoration:gen_missionscript(
-            400054,
-            "spawn_dozer_1",
-            spawn_dozer_1
-        ),
+			400054,
+			"spawn_dozer_1",
+			spawn_dozer_1
+		),
 		restoration:gen_missionscript(
-            400055,
-            "spawn_dozer_2",
-            spawn_dozer_2
-        ),
+			400055,
+			"spawn_dozer_2",
+			spawn_dozer_2
+		),
 		restoration:gen_toggleelement(
-            400056,
-            "disable_murkies",
-            disable_murkies
-        ),
+			400056,
+			"disable_murkies",
+			disable_murkies
+		),
 		restoration:gen_so(
-            400057,
-            "hunt_so",
-            Vector3(3600, 2473, -1200),
-            Rotation(0, 0, 0),
-            optsHunt_SO
-        ),
+			400057,
+			"hunt_so",
+			Vector3(3600, 2473, -1200),
+			Rotation(0, 0, 0),
+			optsHunt_SO
+		),
 		restoration:gen_dummy(
-            400058,
-            "murky_13",
-            Vector3(-11422.900, 5427.540, 282.287),
-            Rotation(-30, 0, -0),
-            optsMurky
-        ),
+			400058,
+			"murky_13",
+			Vector3(-11422.900, 5427.540, 282.287),
+			Rotation(-30, 0, -0),
+			optsMurky
+		),
 		restoration:gen_dummy(
-            400059,
-            "murky_14",
-            Vector3(-11450.400, 5379.910, 282.287),
-            Rotation(-30, 0, -0),
-            optsMurky
-        ),
+			400059,
+			"murky_14",
+			Vector3(-11450.400, 5379.910, 282.287),
+			Rotation(-30, 0, -0),
+			optsMurky
+		),
 		restoration:gen_dummy(
-            400060,
-            "murky_15",
-            Vector3(-11472.900, 5340.940, 282.287),
-            Rotation(-30, 0, -0),
-            optsMurky
-        ),
+			400060,
+			"murky_15",
+			Vector3(-11472.900, 5340.940, 282.287),
+			Rotation(-30, 0, -0),
+			optsMurky
+		),
 		restoration:gen_dummy(
-            400061,
-            "murky_16",
-            Vector3(-11496.900, 5299.370, 282.287),
-            Rotation(-30, 0, -0),
-            optsMurky
-        ),
+			400061,
+			"murky_16",
+			Vector3(-11496.900, 5299.370, 282.287),
+			Rotation(-30, 0, -0),
+			optsMurky
+		),
 		restoration:gen_dummytrigger(
-            400062,
-            "respawn_murkies_4",
-            Vector3(-2400, -3577, 375),
-            Rotation(90, -0, -0),
-            optsrespawn_murkies_4
-        )
-    }
+			400062,
+			"respawn_murkies_4",
+			Vector3(-2400, -3577, 375),
+			Rotation(90, -0, -0),
+			optsrespawn_murkies_4
+		),
+		restoration:gen_pointofnoreturn(
+			400063,
+			"pro_job_ponr",
+			Vector3(0, 0, 0),
+			Rotation(0, 0, 0),
+			opts_pro_job_ponr
+		),
+	},
 }

--- a/req/mission_script_add/flat.lua
+++ b/req/mission_script_add/flat.lua
@@ -15,153 +15,153 @@ local enabled_chance_shields = math.random() < diff_scaling
 local bain_specials_warning = (difficulty >= 7 and "Play_ban_s05") or "Play_ban_s01_b"
 
 local optsSWAT_Heavy145 = {
-    enemy = swat_shotgunner,
+	enemy = swat_shotgunner,
 	participate_to_group_ai = true,
-	on_executed = { 
-		{ id = 400014, delay = 0 },
-		{ id = 400014, delay = 5 }
+	on_executed = {
+		{ id = 400014, delay = 0, },
+		{ id = 400014, delay = 5, },
 	},
-    enabled = true
+	enabled = true,
 }
 local optsSWAT_Rooftop_1 = {
-    enemy = swat_shotgunner,
+	enemy = swat_shotgunner,
 	spawn_action = "e_sp_crh_to_std_rifle",
-	on_executed = { 
-		{ id = 400023, delay = 0 }
+	on_executed = {
+		{ id = 400023, delay = 0, },
 	},
-    enabled = true
+	enabled = true,
 }
 local optsSWAT_Rooftop_2 = {
-    enemy = swat_shotgunner,
+	enemy = swat_shotgunner,
 	spawn_action = "e_sp_crh_to_std_rifle",
-	on_executed = { 
-		{ id = 400024, delay = 0 }
+	on_executed = {
+		{ id = 400024, delay = 0, },
 	},
-    enabled = true
+	enabled = true,
 }
 local optsBulldozer = {
-    enemy = tank,
-	on_executed = { 
+	enemy = tank,
+	on_executed = {
 		{ id = 400014, delay = 1.5 },
-		{ id = 400016, delay = 0 }
+		{ id = 400016, delay = 0, },
 	},
-    enabled = hard_above
+	enabled = hard_above,
 }
 local optsBulldozerscripted = {
-    enemy = tank,
-	on_executed = { 
-		{ id = 400041, delay = 1.5 },
-		{ id = 400016, delay = 0 }
+	enemy = tank,
+	on_executed = {
+		{ id = 400041, delay = 1.5, },
+		{ id = 400016, delay = 0, },
 	},
-    enabled = hard_above
+	enabled = hard_above,
 }
 local optsCloaker = {
-    enemy = cloaker,
+	enemy = cloaker,
 	participate_to_group_ai = true,
-    enabled = hard_above
+	enabled = hard_above,
 }
 local optsShield_1 = {
-    enemy = shield,
+	enemy = shield,
 	participate_to_group_ai = true,
-	on_executed = { 
-		{ id = 400050, delay = 0 }
+	on_executed = {
+		{ id = 400050, delay = 0, },
 	},
-    enabled = true
+	enabled = true,
 }
 local optsShield_2 = {
-    enemy = shield,
+	enemy = shield,
 	participate_to_group_ai = true,
-	on_executed = { 
-		{ id = 400051, delay = 0 }
+	on_executed = {
+		{ id = 400051, delay = 0, },
 	},
-    enabled = true
+	enabled = true,
 }
 local optsShield_3 = {
-    enemy = shield,
+	enemy = shield,
 	participate_to_group_ai = true,
-	on_executed = { 
-		{ id = 400052, delay = 0 }
+	on_executed = {
+		{ id = 400052, delay = 0, },
 	},
-    enabled = true
+	enabled = true,
 }
 local optsShield_4 = {
-    enemy = shield,
+	enemy = shield,
 	participate_to_group_ai = true,
-	on_executed = { 
-		{ id = 400053, delay = 0 }
+	on_executed = {
+		{ id = 400053, delay = 0, },
 	},
-    enabled = true
+	enabled = true,
 }
 local optsShield_5 = {
-    enemy = shield,
+	enemy = shield,
 	participate_to_group_ai = true,
-	on_executed = { 
-		{ id = 400054, delay = 0 }
+	on_executed = {
+		{ id = 400054, delay = 0, },
 	},
-    enabled = true
+	enabled = true,
 }
 local optsShield_6 = {
-    enemy = shield,
+	enemy = shield,
 	participate_to_group_ai = true,
-	on_executed = { 
-		{ id = 400055, delay = 0 }
+	on_executed = {
+		{ id = 400055, delay = 0, },
 	},
-    enabled = true
+	enabled = true,
 }
 local optsEnforcer = {
-    enemy = chavez_enforcer,
+	enemy = chavez_enforcer,
 	team = "mobster1",
-    enabled = death_sentence
+	enabled = death_sentence,
 }
 local optsEnforcerPJ = {
-    enemy = chavez_enforcer,
+	enemy = chavez_enforcer,
 	team = "mobster1",
-    enabled = (death_sentence and pro_job)
+	enabled = (death_sentence and pro_job),
 }
 local optsLieutenant = {
-    enemy = chavez_lieutenant,
+	enemy = chavez_lieutenant,
 	team = "mobster1",
-    enabled = death_sentence
+	enabled = death_sentence,
 }
 local optsTaser = {
-    enemy = taser,
+	enemy = taser,
 	spawn_action = "e_sp_run_jump_far",
 	participate_to_group_ai = true,
-    enabled = true
+	enabled = true,
 }
 local optsBulldozerchopper = {
-    enemy = tank,
+	enemy = tank,
 	participate_to_group_ai = true,
 	spawn_action = "e_sp_jump_down_heli_cbt_left",
-	on_executed = { 
-		{ id = 400016, delay = 0 }
+	on_executed = {
+		{ id = 400016, delay = 0, },
 	},
-    enabled = true
+	enabled = true,
 }
 local optsTaserChopper = {
-    enemy = taser,
+	enemy = taser,
 	spawn_action = "e_sp_jump_down_heli_cbt_right",
 	participate_to_group_ai = true,
-    enabled = true
+	enabled = true,
 }
 local optsSWAT_HeavyChopper_1 = {
 	enemy = swat_shotgunner,
 	spawn_action = "e_sp_jump_down_heli_cbt_left",
 	participate_to_group_ai = true,
-    enabled = true
+	enabled = true,
 }
 local optsSWAT_HeavyChopper_2 = {
 	enemy = swat_shotgunner,
 	spawn_action = "e_sp_jump_down_heli_cbt_right",
 	participate_to_group_ai = true,
-    enabled = true
+	enabled = true,
 }
 local optsShare_AIHunt = {
-    SO_access = tostring(128+4096),
+	SO_access = tostring(128 + 4096),
 	path_style = "none",
 	scan = true,
 	interval = 2,
-    so_action = "AI_hunt"
+	so_action = "AI_hunt",
 }
 local optsSniper_SO = {
 	SO_access = "128",
@@ -171,16 +171,16 @@ local optsSniper_SO = {
 	align_rotation = true,
 	pose = "crouch",
 	interval = 2,
-    so_action = "AI_sniper"
+	so_action = "AI_sniper",
 }
 local optsAI_Defend = {
-    SO_access = "4096",
+	SO_access = "4096",
 	scan = true,
 	align_position = true,
 	needs_pos_rsrv = true,
 	align_rotation = true,
 	interval = 2,
-    so_action = "AI_defend"
+	so_action = "AI_defend",
 }
 local optsShield_Defend_SO = {
 	SO_access = "2048",
@@ -189,561 +189,561 @@ local optsShield_Defend_SO = {
 	needs_pos_rsrv = true,
 	align_rotation = true,
 	interval = 2,
-    so_action = "AI_sniper"
+	so_action = "AI_sniper",
 }
 local Bain_senddozers = {
 	dialogue = "Play_ban_s02_a",
-	can_not_be_muted = true
+	can_not_be_muted = true,
 }
 local Bain_sendshields = {
 	dialogue = "Play_ban_s03_b",
-	can_not_be_muted = true
+	can_not_be_muted = true,
 }
 local Bain_sendcloakers = {
 	dialogue = "Play_ban_s04",
-	can_not_be_muted = true
+	can_not_be_muted = true,
 }
 local Bain_sendtasers = {
 	dialogue = bain_specials_warning,
-	can_not_be_muted = true
+	can_not_be_muted = true,
 }
 local spawn_heavy_swat_145 = {
 	enabled = overkill_above,
-	on_executed = { 
-		{ id = 400002, delay = 0 },
-		{ id = 400003, delay = 0 },
-		{ id = 400004, delay = 0 },
-		{ id = 400005, delay = 0 },
-		{ id = 400006, delay = 0 },
-		{ id = 400007, delay = 0 },
-		{ id = 400008, delay = 0 },
-		{ id = 400009, delay = 0 },
-		{ id = 400010, delay = 0 },
-		{ id = 400011, delay = 0 },
-		{ id = 400012, delay = 0 },
-		{ id = 400013, delay = 0 }
-	}
+	on_executed = {
+		{ id = 400002, delay = 0, },
+		{ id = 400003, delay = 0, },
+		{ id = 400004, delay = 0, },
+		{ id = 400005, delay = 0, },
+		{ id = 400006, delay = 0, },
+		{ id = 400007, delay = 0, },
+		{ id = 400008, delay = 0, },
+		{ id = 400009, delay = 0, },
+		{ id = 400010, delay = 0, },
+		{ id = 400011, delay = 0, },
+		{ id = 400012, delay = 0, },
+		{ id = 400013, delay = 0, },
+	},
 }
 local spawn_tasers = {
 	enabled = hard_above,
-	on_executed = { 
-		{ id = 400017, delay = 0 },
-		{ id = 400018, delay = 0 },
-		{ id = 400019, delay = 0 }
-	}
+	on_executed = {
+		{ id = 400017, delay = 0, },
+		{ id = 400018, delay = 0, },
+		{ id = 400019, delay = 0, },
+	},
 }
 local spawn_cloakers = {
 	enabled = hard_above,
-	on_executed = { 
-		{ id = 400033, delay = 0 },
-		{ id = 400034, delay = 0 },
-		{ id = 400035, delay = 0 },
-		{ id = 400036, delay = 0 }
-	}
+	on_executed = {
+		{ id = 400033, delay = 0, },
+		{ id = 400034, delay = 0, },
+		{ id = 400035, delay = 0, },
+		{ id = 400036, delay = 0, },
+	},
 }
 local spawn_rooftopSWAT = {
 	enabled = true,
-	on_executed = { 
-		{ id = 400021, delay = 0 },
-		{ id = 400022, delay = 0 }
-	}
+	on_executed = {
+		{ id = 400021, delay = 0, },
+		{ id = 400022, delay = 0, },
+	},
 }
 local spawn_SWATsquad = {
 	enabled = true,
-	on_executed = { 
-		{ id = 400028, delay = 0 },
-		{ id = 400029, delay = 0.5 },
-		{ id = 400030, delay = 1 },
-		{ id = 400031, delay = 1.5 }
-	}
+	on_executed = {
+		{ id = 400028, delay = 0, },
+		{ id = 400029, delay = 0.5, },
+		{ id = 400030, delay = 1, },
+		{ id = 400031, delay = 1.5, },
+	},
 }
 local spawn_Shields = {
 	enabled = (hard_above and enabled_chance_shields),
-	on_executed = { 
-		{ id = 400044, delay = 0 },
-		{ id = 400045, delay = 0 },
-		{ id = 400046, delay = 0 },
-		{ id = 400047, delay = 0 },
-		{ id = 400048, delay = 0 },
-		{ id = 400049, delay = 0 }
-	}
+	on_executed = {
+		{ id = 400044, delay = 0, },
+		{ id = 400045, delay = 0, },
+		{ id = 400046, delay = 0, },
+		{ id = 400047, delay = 0, },
+		{ id = 400048, delay = 0, },
+		{ id = 400049, delay = 0, },
+	},
 }
 local optsrespawn_swat_1 = {
-	on_executed = { 
-		{ id = 400021, delay = 30 }
+	on_executed = {
+		{ id = 400021, delay = 30, },
 	},
-	elements = { 
-		400021
+	elements = {
+		400021,
 	},
-    event = "death"
+	event = "death",
 }
 local optsrespawn_swat_2 = {
-	on_executed = { 
-		{ id = 400022, delay = 30 }
+	on_executed = {
+		{ id = 400022, delay = 30, },
 	},
-	elements = { 
-		400022
+	elements = {
+		400022,
 	},
-    event = "death"
+	event = "death",
 }
 local enable_cloakers = {
 	enabled = hard_above,
-	elements = { 
-		400037
-	}
+	elements = {
+		400037,
+	},
 }
 local disable_cloakers = {
 	enabled = true,
 	toggle = "off",
-	elements = { 
-		400037
-	}
+	elements = {
+		400037,
+	},
 }
 local Roof_access_block = {
 	enabled = overkill_above,
 	trigger_times = 1,
-	on_executed = { 
-		{ id = 100297, delay = 0.5 },
-		{ id = 100569, delay = 1 }
-	}
+	on_executed = {
+		{ id = 100297, delay = 0.5, },
+		{ id = 100569, delay = 1, },
+	},
 }
 local disable_open_roof_access = {
 	enabled = overkill_above,
 	toggle = "off",
-	elements = { 
-		100569
-	}
+	elements = {
+		100569,
+	},
 }
 
 return {
-    elements = {
-        --Heavy Shotgunners
+	elements = {
+		-- Heavy Shotgunners
 		restoration:gen_missionscript(
-            400001,
-            "spawn_heavy_shotgunners",
-            spawn_heavy_swat_145
-        ),
+			400001,
+			"spawn_heavy_shotgunners",
+			spawn_heavy_swat_145
+		),
 		restoration:gen_dummy(
-            400002,
-            "swat_heavy_1",
-            Vector3(-2782, 2936, -25.190),
-            Rotation(-90, 0, -0),
-            optsSWAT_Heavy145
-        ),
+			400002,
+			"swat_heavy_1",
+			Vector3(-2782, 2936, -25.190),
+			Rotation(-90, 0, -0),
+			optsSWAT_Heavy145
+		),
 		restoration:gen_dummy(
-            400003,
-            "swat_heavy_2",
-            Vector3(-2782, 2977, -25.190),
-            Rotation(-90, 0, -0),
-            optsSWAT_Heavy145
-        ),
+			400003,
+			"swat_heavy_2",
+			Vector3(-2782, 2977, -25.190),
+			Rotation(-90, 0, -0),
+			optsSWAT_Heavy145
+		),
 		restoration:gen_dummy(
-            400004,
-            "swat_heavy_3",
-            Vector3(-2782, 3033, -25.190),
-            Rotation(-90, 0, -0),
-            optsSWAT_Heavy145
-        ),
+			400004,
+			"swat_heavy_3",
+			Vector3(-2782, 3033, -25.190),
+			Rotation(-90, 0, -0),
+			optsSWAT_Heavy145
+		),
 		restoration:gen_dummy(
-            400005,
-            "swat_heavy_4",
-            Vector3(-2840, 3025, -25.190),
-            Rotation(-90, 0, -0),
-            optsSWAT_Heavy145
-        ),
+			400005,
+			"swat_heavy_4",
+			Vector3(-2840, 3025, -25.190),
+			Rotation(-90, 0, -0),
+			optsSWAT_Heavy145
+		),
 		restoration:gen_dummy(
-            400006,
-            "swat_heavy_5",
-            Vector3(-2840, 2983, -25.190),
-            Rotation(-90, 0, -0),
-            optsSWAT_Heavy145
-        ),
+			400006,
+			"swat_heavy_5",
+			Vector3(-2840, 2983, -25.190),
+			Rotation(-90, 0, -0),
+			optsSWAT_Heavy145
+		),
 		restoration:gen_dummy(
-            400007,
-            "swat_heavy_6",
-            Vector3(-2837, 2945, -25.190),
-            Rotation(-90, 0, -0),
-            optsSWAT_Heavy145
-        ),
+			400007,
+			"swat_heavy_6",
+			Vector3(-2837, 2945, -25.190),
+			Rotation(-90, 0, -0),
+			optsSWAT_Heavy145
+		),
 		restoration:gen_dummy(
-            400008,
-            "swat_heavy_7",
-            Vector3(1908, 2685, -24.825),
-            Rotation(-180, 0, -0),
-            optsSWAT_Heavy145
-        ),
+			400008,
+			"swat_heavy_7",
+			Vector3(1908, 2685, -24.825),
+			Rotation(-180, 0, -0),
+			optsSWAT_Heavy145
+		),
 		restoration:gen_dummy(
-            400009,
-            "swat_heavy_8",
-            Vector3(1964, 2685, -24.825),
-            Rotation(-180, 0, -0),
-            optsSWAT_Heavy145
-        ),
+			400009,
+			"swat_heavy_8",
+			Vector3(1964, 2685, -24.825),
+			Rotation(-180, 0, -0),
+			optsSWAT_Heavy145
+		),
 		restoration:gen_dummy(
-            400010,
-            "swat_heavy_9",
-            Vector3(2017, 2685, -24.825),
-            Rotation(-180, 0, -0),
-            optsSWAT_Heavy145
-        ),
+			400010,
+			"swat_heavy_9",
+			Vector3(2017, 2685, -24.825),
+			Rotation(-180, 0, -0),
+			optsSWAT_Heavy145
+		),
 		restoration:gen_dummy(
-            400011,
-            "swat_heavy_10",
-            Vector3(1916, 2734, -24.825),
-            Rotation(-180, 0, -0),
-            optsSWAT_Heavy145
-        ),
+			400011,
+			"swat_heavy_10",
+			Vector3(1916, 2734, -24.825),
+			Rotation(-180, 0, -0),
+			optsSWAT_Heavy145
+		),
 		restoration:gen_dummy(
-            400012,
-            "swat_heavy_11",
-            Vector3(1964, 2734, -24.825),
-            Rotation(-180, 0, -0),
-            optsSWAT_Heavy145
-        ),
+			400012,
+			"swat_heavy_11",
+			Vector3(1964, 2734, -24.825),
+			Rotation(-180, 0, -0),
+			optsSWAT_Heavy145
+		),
 		restoration:gen_dummy(
-            400013,
-            "swat_heavy_12",
-            Vector3(2017, 2734, -24.825),
-            Rotation(-180, 0, -0),
-            optsSWAT_Heavy145
-        ),
+			400013,
+			"swat_heavy_12",
+			Vector3(2017, 2734, -24.825),
+			Rotation(-180, 0, -0),
+			optsSWAT_Heavy145
+		),
 		restoration:gen_so(
-            400014,
-            "global_hunt_so",
-            Vector3(3600, 2473, -1200),
-            Rotation(0, 0, 0),
-            optsShare_AIHunt
-        ),
+			400014,
+			"global_hunt_so",
+			Vector3(3600, 2473, -1200),
+			Rotation(0, 0, 0),
+			optsShare_AIHunt
+		),
 		restoration:gen_dummy(
-            400015,
-            "bulldozer",
-            Vector3(-2228, -3266, -25),
-            Rotation(90, -0, -0),
-            optsBulldozer
-        ),
+			400015,
+			"bulldozer",
+			Vector3(-2228, -3266, -25),
+			Rotation(90, -0, -0),
+			optsBulldozer
+		),
 		restoration:gen_dialogue(
-            400016,
-            "they_sending_dozers",
-            Bain_senddozers
-        ),
+			400016,
+			"they_sending_dozers",
+			Bain_senddozers
+		),
 		restoration:gen_dummy(
-            400017,
-            "taser_1",
-            Vector3(372, 1302, 1674.944),
-            Rotation(90, -0, -0),
-            optsTaser
-        ),
+			400017,
+			"taser_1",
+			Vector3(372, 1302, 1674.944),
+			Rotation(90, -0, -0),
+			optsTaser
+		),
 		restoration:gen_dummy(
-            400018,
-            "taser_2",
-            Vector3(372, 163, 1674.944),
-            Rotation(90, -0, -0),
-            optsTaser
-        ),
+			400018,
+			"taser_2",
+			Vector3(372, 163, 1674.944),
+			Rotation(90, -0, -0),
+			optsTaser
+		),
 		restoration:gen_dialogue(
-            400019,
-            "they_sending_tasers",
-            Bain_sendtasers
-        ),
+			400019,
+			"they_sending_tasers",
+			Bain_sendtasers
+		),
 		restoration:gen_missionscript(
-            400020,
-            "go_hard_with_tasers",
-            spawn_tasers
-        ),
+			400020,
+			"go_hard_with_tasers",
+			spawn_tasers
+		),
 		restoration:gen_dummy(
-            400021,
-            "swat_rooftop_1",
-            Vector3(-1855, 3449, 1931.656),
-            Rotation(90, -0, -0),
-            optsSWAT_Rooftop_1
-        ),
+			400021,
+			"swat_rooftop_1",
+			Vector3(-1855, 3449, 1931.656),
+			Rotation(90, -0, -0),
+			optsSWAT_Rooftop_1
+		),
 		restoration:gen_dummy(
-            400022,
-            "swat_rooftop_2",
-            Vector3(-4081, 1580, 1937.656),
-            Rotation(180, 0, -0),
-            optsSWAT_Rooftop_2
-        ),
+			400022,
+			"swat_rooftop_2",
+			Vector3(-4081, 1580, 1937.656),
+			Rotation(180, 0, -0),
+			optsSWAT_Rooftop_2
+		),
 		restoration:gen_so(
-            400023,
-            "swat_spot_so_1",
-            Vector3(-1522.207, 2149.161, 1936.735),
-            Rotation(180, 0, 0),
-            optsSniper_SO
-        ),
+			400023,
+			"swat_spot_so_1",
+			Vector3(-1522.207, 2149.161, 1936.735),
+			Rotation(180, 0, 0),
+			optsSniper_SO
+		),
 		restoration:gen_so(
-            400024,
-            "swat_spot_so_2",
-            Vector3(-2673, 675, 1936.735),
-            Rotation(-76, 0, 0),
-            optsSniper_SO
-        ),
+			400024,
+			"swat_spot_so_2",
+			Vector3(-2673, 675, 1936.735),
+			Rotation(-76, 0, 0),
+			optsSniper_SO
+		),
 		restoration:gen_missionscript(
-            400025,
-            "annoying_Heavy_SWAT",
-            spawn_rooftopSWAT
-        ),
+			400025,
+			"annoying_Heavy_SWAT",
+			spawn_rooftopSWAT
+		),
 		restoration:gen_dummytrigger(
-            400026,
-            "respawn_swat_1",
-            Vector3(-2400, -3677, 375),
-            Rotation(90, -0, -0),
-            optsrespawn_swat_1
-        ),
+			400026,
+			"respawn_swat_1",
+			Vector3(-2400, -3677, 375),
+			Rotation(90, -0, -0),
+			optsrespawn_swat_1
+		),
 		restoration:gen_dummytrigger(
-            400027,
-            "respawn_swat_2",
-            Vector3(-2400, -3577, 375),
-            Rotation(90, -0, -0),
-            optsrespawn_swat_2
-        ),
+			400027,
+			"respawn_swat_2",
+			Vector3(-2400, -3577, 375),
+			Rotation(90, -0, -0),
+			optsrespawn_swat_2
+		),
 		restoration:gen_dummy(
-            400028,
-            "swat_1",
-            Vector3(-1339.660, 875.868, 1675),
-            Rotation(73, -0, -0),
-            optsSWAT_HeavyChopper_2
-        ),
+			400028,
+			"swat_1",
+			Vector3(-1339.660, 875.868, 1675),
+			Rotation(73, -0, -0),
+			optsSWAT_HeavyChopper_2
+		),
 		restoration:gen_dummy(
-            400029,
-            "swat_2",
-            Vector3(-920.705, 850.572, 1675),
-            Rotation(-80, -0, -0),
-            optsSWAT_HeavyChopper_1
-        ),
+			400029,
+			"swat_2",
+			Vector3(-920.705, 850.572, 1675),
+			Rotation(-80, -0, -0),
+			optsSWAT_HeavyChopper_1
+		),
 		restoration:gen_dummy(
-            400030,
-            "taser",
-            Vector3(-1377.150, 807.061, 1675),
-            Rotation(97, -0, -0),
-            optsTaserChopper
-        ),
+			400030,
+			"taser",
+			Vector3(-1377.150, 807.061, 1675),
+			Rotation(97, -0, -0),
+			optsTaserChopper
+		),
 		restoration:gen_dummy(
-            400031,
-            "bulldozer",
-            Vector3(-936.857, 821.147, 1675),
-            Rotation(-80, 0, -0),
-            optsBulldozerchopper
-        ),
+			400031,
+			"bulldozer",
+			Vector3(-936.857, 821.147, 1675),
+			Rotation(-80, 0, -0),
+			optsBulldozerchopper
+		),
 		restoration:gen_missionscript(
-            400032,
-            "spawn_the_squad",
-            spawn_SWATsquad
-        ),
+			400032,
+			"spawn_the_squad",
+			spawn_SWATsquad
+		),
 		restoration:gen_dummy(
-            400033,
-            "cloaker_1",
-            Vector3(188.860, 3694.086, 1931.656),
-            Rotation(90, -0, -0),
-            optsCloaker
-        ),
+			400033,
+			"cloaker_1",
+			Vector3(188.860, 3694.086, 1931.656),
+			Rotation(90, -0, -0),
+			optsCloaker
+		),
 		restoration:gen_dummy(
-            400034,
-            "cloaker_2",
-            Vector3(124.860, 3694.086, 1931.656),
-            Rotation(90, -0, -0),
-            optsCloaker
-        ),
+			400034,
+			"cloaker_2",
+			Vector3(124.860, 3694.086, 1931.656),
+			Rotation(90, -0, -0),
+			optsCloaker
+		),
 		restoration:gen_dummy(
-            400035,
-            "cloaker_3",
-            Vector3(61.860, 3694.086, 1931.656),
-            Rotation(90, -0, -0),
-            optsCloaker
-        ),
+			400035,
+			"cloaker_3",
+			Vector3(61.860, 3694.086, 1931.656),
+			Rotation(90, -0, -0),
+			optsCloaker
+		),
 		restoration:gen_dialogue(
-            400036,
-            "they_sending_cloakers",
-            Bain_sendcloakers
-        ),
+			400036,
+			"they_sending_cloakers",
+			Bain_sendcloakers
+		),
 		restoration:gen_missionscript(
-            400037,
-            "spawn_cloakers",
-            spawn_cloakers
-        ),
+			400037,
+			"spawn_cloakers",
+			spawn_cloakers
+		),
 		restoration:gen_toggleelement(
-            400038,
-            "enable_cloakers",
-            enable_cloakers
-        ),
+			400038,
+			"enable_cloakers",
+			enable_cloakers
+		),
 		restoration:gen_toggleelement(
-            400039,
-            "disable_cloakers",
-            disable_cloakers
-        ),
+			400039,
+			"disable_cloakers",
+			disable_cloakers
+		),
 		restoration:gen_dummy(
-            400040,
-            "bulldozer",
-            Vector3(1916, 2375, -24.825),
-            Rotation(180, 0, -0),
-            optsBulldozerscripted
-        ),
+			400040,
+			"bulldozer",
+			Vector3(1916, 2375, -24.825),
+			Rotation(180, 0, -0),
+			optsBulldozerscripted
+		),
 		restoration:gen_so(
-            400041,
-            "dozer_defend_so",
-            Vector3(11, 1132, 53.185),
-            Rotation(180, 0, -0),
-            optsAI_Defend
-        ),
+			400041,
+			"dozer_defend_so",
+			Vector3(11, 1132, 53.185),
+			Rotation(180, 0, -0),
+			optsAI_Defend
+		),
 		restoration:gen_dialogue(
-            400042,
-            "they_sending_shields",
-            Bain_sendshields
-        ),
+			400042,
+			"they_sending_shields",
+			Bain_sendshields
+		),
 		restoration:gen_missionscript(
-            400043,
-            "spawn_defend_shields",
-            spawn_Shields
-        ),
+			400043,
+			"spawn_defend_shields",
+			spawn_Shields
+		),
 		restoration:gen_dummy(
-            400044,
-            "shield_1",
-            Vector3(-889.027, 18.536, 700.001),
-            Rotation(-90, 0, -0),
-            optsShield_1
-        ),
+			400044,
+			"shield_1",
+			Vector3(-889.027, 18.536, 700.001),
+			Rotation(-90, 0, -0),
+			optsShield_1
+		),
 		restoration:gen_dummy(
-            400045,
-            "shield_2",
-            Vector3(-956.985, 16.162, 700.001),
-            Rotation(-90, -0, -0),
-            optsShield_2
-        ),
+			400045,
+			"shield_2",
+			Vector3(-956.985, 16.162, 700.001),
+			Rotation(-90, -0, -0),
+			optsShield_2
+		),
 		restoration:gen_dummy(
-            400046,
-            "shield_3",
-            Vector3(-1012.951, 14.208, 700.001),
-            Rotation(-90, 0, -0),
-            optsShield_3
-        ),
+			400046,
+			"shield_3",
+			Vector3(-1012.951, 14.208, 700.001),
+			Rotation(-90, 0, -0),
+			optsShield_3
+		),
 		restoration:gen_dummy(
-            400047,
-            "shield_4",
-            Vector3(-57, 1640, 697.988),
-            Rotation(90, -0, -0),
-            optsShield_4
-        ),
+			400047,
+			"shield_4",
+			Vector3(-57, 1640, 697.988),
+			Rotation(90, -0, -0),
+			optsShield_4
+		),
 		restoration:gen_dummy(
-            400048,
-            "shield_5",
-            Vector3(-1704, 1478, 375.600),
-            Rotation(-90, -0, -0),
-            optsShield_5
-        ),
+			400048,
+			"shield_5",
+			Vector3(-1704, 1478, 375.600),
+			Rotation(-90, -0, -0),
+			optsShield_5
+		),
 		restoration:gen_dummy(
-            400049,
-            "shield_6",
-            Vector3(22, 1430, 375.600),
-            Rotation(90, -0, -0),
-            optsShield_6
-        ),
+			400049,
+			"shield_6",
+			Vector3(22, 1430, 375.600),
+			Rotation(90, -0, -0),
+			optsShield_6
+		),
 		restoration:gen_so(
-            400050,
-            "shield_defend_so_1",
-            Vector3(-1057, 497, 700.001),
-            Rotation(78, -0, -0),
-            optsShield_Defend_SO
-        ),
+			400050,
+			"shield_defend_so_1",
+			Vector3(-1057, 497, 700.001),
+			Rotation(78, -0, -0),
+			optsShield_Defend_SO
+		),
 		restoration:gen_so(
-            400051,
-            "shield_defend_so_2",
-            Vector3(-1037.821, 698.270, 700.001),
-            Rotation(109, -0, -0),
-            optsShield_Defend_SO
-        ),
+			400051,
+			"shield_defend_so_2",
+			Vector3(-1037.821, 698.270, 700.001),
+			Rotation(109, -0, -0),
+			optsShield_Defend_SO
+		),
 		restoration:gen_so(
-            400052,
-            "shield_defend_so_3",
-            Vector3(-962.004, 583.511, 700.001),
-            Rotation(89, -0, -0),
-            optsShield_Defend_SO
-        ),
+			400052,
+			"shield_defend_so_3",
+			Vector3(-962.004, 583.511, 700.001),
+			Rotation(89, -0, -0),
+			optsShield_Defend_SO
+		),
 		restoration:gen_so(
-            400053,
-            "shield_defend_so_4",
-            Vector3(-684, 1663, 746.988),
-            Rotation(90, -0, -0),
-            optsShield_Defend_SO
-        ),
+			400053,
+			"shield_defend_so_4",
+			Vector3(-684, 1663, 746.988),
+			Rotation(90, -0, -0),
+			optsShield_Defend_SO
+		),
 		restoration:gen_so(
-            400054,
-            "shield_defend_so_5",
-            Vector3(-1470, 1486, 375.600),
-            Rotation(0, 0, -0),
-            optsShield_Defend_SO
-        ),
+			400054,
+			"shield_defend_so_5",
+			Vector3(-1470, 1486, 375.600),
+			Rotation(0, 0, -0),
+			optsShield_Defend_SO
+		),
 		restoration:gen_so(
-            400055,
-            "shield_defend_so_6",
-            Vector3(-289, 1521, 375.600),
-            Rotation(0, 0, -0),
-            optsShield_Defend_SO
-        ),
+			400055,
+			"shield_defend_so_6",
+			Vector3(-289, 1521, 375.600),
+			Rotation(0, 0, -0),
+			optsShield_Defend_SO
+		),
 		restoration:gen_dummy(
-            400056,
-            "enforcer_1",
-            Vector3(245, 361, 1349.998),
-            Rotation(65, 0, -0),
-            optsEnforcer
-        ),
+			400056,
+			"enforcer_1",
+			Vector3(245, 361, 1349.998),
+			Rotation(65, 0, -0),
+			optsEnforcer
+		),
 		restoration:gen_dummy(
-            400057,
-            "enforcer_2",
-            Vector3(134.792, 232.511, 1349.998),
-            Rotation(33, -0, -0),
-            optsEnforcerPJ
-        ),
+			400057,
+			"enforcer_2",
+			Vector3(134.792, 232.511, 1349.998),
+			Rotation(33, -0, -0),
+			optsEnforcerPJ
+		),
 		restoration:gen_dummy(
-            400058,
-            "enforcer_3",
-            Vector3(-1741.349, 268.777, 1351.463),
-            Rotation(-63, 0, -0),
-            optsEnforcer
-        ),
+			400058,
+			"enforcer_3",
+			Vector3(-1741.349, 268.777, 1351.463),
+			Rotation(-63, 0, -0),
+			optsEnforcer
+		),
 		restoration:gen_dummy(
-            400059,
-            "enforcer_4",
-            Vector3(-1643, 115, 1351.463),
-            Rotation(-53, 0, -0),
-            optsEnforcerPJ
-        ),
+			400059,
+			"enforcer_4",
+			Vector3(-1643, 115, 1351.463),
+			Rotation(-53, 0, -0),
+			optsEnforcerPJ
+		),
 		restoration:gen_dummy(
-            400060,
-            "enforcer_5",
-            Vector3(299, -181, 700.001),
-            Rotation(0, 0, -0),
-            optsEnforcer
-        ),
+			400060,
+			"enforcer_5",
+			Vector3(299, -181, 700.001),
+			Rotation(0, 0, -0),
+			optsEnforcer
+		),
 		restoration:gen_dummy(
-            400061,
-            "enforcer_6",
-            Vector3(106, -181, 700.001),
-            Rotation(0, 0, -0),
-            optsEnforcerPJ
-        ),
+			400061,
+			"enforcer_6",
+			Vector3(106, -181, 700.001),
+			Rotation(0, 0, -0),
+			optsEnforcerPJ
+		),
 		restoration:gen_dummy(
-            400062,
-            "chavez_lieutenant",
-            Vector3(-1549.617, 1427.445, 702.700),
-            Rotation(172, 0, -0),
-            optsLieutenant
-        ),
+			400062,
+			"chavez_lieutenant",
+			Vector3(-1549.617, 1427.445, 702.700),
+			Rotation(172, 0, -0),
+			optsLieutenant
+		),
 		restoration:gen_dummy(
-            400063,
-            "enforcer_7",
-            Vector3(-295, 465, -322.531),
-            Rotation(0, 0, -0),
-            optsEnforcer
-        ),
+			400063,
+			"enforcer_7",
+			Vector3(-295, 465, -322.531),
+			Rotation(0, 0, -0),
+			optsEnforcer
+		),
 		restoration:gen_missionscript(
-            400064,
-            "roof_access_blockade_random",
-            Roof_access_block
-        ),
+			400064,
+			"roof_access_blockade_random",
+			Roof_access_block
+		),
 		restoration:gen_toggleelement(
-            400065,
-            "disable_open_roof_access",
-            disable_open_roof_access
-        )
-    }
+			400065,
+			"disable_open_roof_access",
+			disable_open_roof_access
+		),
+	},
 }

--- a/req/mission_script_add/man.lua
+++ b/req/mission_script_add/man.lua
@@ -1,28 +1,28 @@
 local Bain_senddozers = {
 	dialogue = "Play_ban_s02_b",
-	can_not_be_muted = true
+	can_not_be_muted = true,
 }
 local optsBulldozer_SO = {
-    SO_access = "4096",
+	SO_access = "4096",
 	path_style = "none",
 	scan = true,
 	interval = 2,
-    so_action = "AI_hunt"
+	so_action = "AI_hunt",
 }
 
 return {
-    elements = {
+	elements = {
 		restoration:gen_dialogue(
-            400001,
-            "they_sending_dozers",
-            Bain_senddozers
-        ),
-        restoration:gen_so(
-            400002,
-            "dozer_hunt_so",
-            Vector3(-2657, -3569, -90),
-            Rotation(90, -0, -0),
-            optsBulldozer_SO
-        ),
-    }
+			400001,
+			"they_sending_dozers",
+			Bain_senddozers
+		),
+		restoration:gen_so(
+			400002,
+			"dozer_hunt_so",
+			Vector3(-2657, -3569, -90),
+			Rotation(90, -0, -0),
+			optsBulldozer_SO
+		),
+	},
 }

--- a/req/mission_script_add/red2.lua
+++ b/req/mission_script_add/red2.lua
@@ -1,7 +1,7 @@
 local security_guard_1 = "units/payday2/characters/ene_security_1/ene_security_1"
 local security_guard_2 = "units/payday2/characters/ene_security_2/ene_security_2"
 local security_guard_3 = "units/payday2/characters/ene_security_3/ene_security_3"
-local security_table = {security_guard_1, security_guard_1, security_guard_2, security_guard_2, security_guard_3}
+local security_table = { security_guard_1, security_guard_1, security_guard_2, security_guard_2, security_guard_3, }
 local difficulty = tweak_data:difficulty_to_index(Global.game_settings and Global.game_settings.difficulty or "normal")
 local pro_job = Global.game_settings and Global.game_settings.one_down
 local diff_scaling = 0.065 * difficulty
@@ -22,144 +22,180 @@ local enabled_chance_shields = math.random() < diff_scaling
 local enabled_chance_dozers_exitvault = math.random() < diff_scaling
 local enabled_chance_dozers_ambush_escape = math.random() < 0.5
 local surprise_tank_chance = math.random() < 0.5
+local normal_ponr_value = difficulty <= 5 and 420 or (difficulty == 6 or difficulty == 7) and 540 or 540
+local normal_ponr_timer_player_mul = {
+	1,
+	1,
+	1,
+	1,
+	1,  -- 5+ players
+}
+local overdrill_ponr_value = difficulty <= 5 and 1800 or (difficulty == 6 or difficulty == 7) and 1800 or 1800
+local overdrill_ponr_timer_player_mul = {
+	1,
+	1,
+	1,
+	1,
+	1,  -- 5+ players
+}
 
 local optsSecurity = {
-    enemy_table = security,
-    enabled = (hard_above and enabled_chance_more_guards)
+	enemy_table = security,
+	enabled = (hard_above and enabled_chance_more_guards)
 }
 local optsShield_1 = {
-    enemy = shield,
-    on_executed = { { id = 100696, delay = 0 } },
+	enemy = shield,
+	on_executed = {
+		{ id = 100696, delay = 0, },
+	},
 	participate_to_group_ai = true,
-    enabled = true
+	enabled = true,
 }
 local optsShield_2 = {
-    enemy = shield,
-    on_executed = { { id = 100695, delay = 0 } },
+	enemy = shield,
+	on_executed = {
+		{ id = 100695, delay = 0, },
+	},
 	participate_to_group_ai = true,
-    enabled = true
+	enabled = true,
 }
 local optsSniper_1 = {
 	enemy = sniper,
-	on_executed = { { id = 103091, delay = 3 } },
+	on_executed = {
+		{ id = 103091, delay = 3, },
+	},
 	spawn_action = "e_sp_repel_into_window",
-    enabled = very_hard_above
+	enabled = very_hard_above,
 }
 local optsSniper_2 = {
 	enemy = sniper,
-	on_executed = { { id = 103090, delay = 3 } },
+	on_executed = {
+		{ id = 103090, delay = 3, },
+	},
 	spawn_action = "e_sp_repel_into_window",
-    enabled = very_hard_above
+	enabled = very_hard_above,
 }
 local optsSniper_3 = {
 	enemy = sniper,
-	on_executed = { { id = 103117, delay = 3 } },
+	on_executed = {
+		{ id = 103117, delay = 3, },
+	},
 	spawn_action = "e_sp_repel_into_window",
-    enabled = very_hard_above
+	enabled = very_hard_above,
 }
 local optsSniper_4 = {
 	enemy = sniper,
-	on_executed = { { id = 400033, delay = 3 } },
+	on_executed = {
+		{ id = 400033, delay = 3, },
+	},
 	spawn_action = "e_sp_repel_into_window",
-    enabled = very_hard_above
+	enabled = very_hard_above,
 }
 local optsSniper_5 = {
 	enemy = sniper,
-	on_executed = { { id = 400034, delay = 3 } },
+	on_executed = {
+		{ id = 400034, delay = 3, },
+	},
 	spawn_action = "e_sp_repel_into_window",
-    enabled = very_hard_above
+	enabled = very_hard_above,
 }
 local optsSniper_6 = {
 	enemy = sniper,
-	on_executed = { { id = 400009, delay = 3 } },
+	on_executed = {
+		{ id = 400009, delay = 3, },
+	},
 	spawn_action = "e_sp_repel_into_window",
-    enabled = death_wish_above
+	enabled = death_wish_above,
 }
 local optsBulldozer_193 = {
-    enemy = tank,
-	on_executed = { 
-		{ id = 400023, delay = 3 },
-		{ id = 400052, delay = 0 },
+	enemy = tank,
+	on_executed = {
+		{ id = 400023, delay = 3, },
+		{ id = 400052, delay = 0, },
 	},
-    enabled = death_sentence
+	enabled = death_sentence,
 }
 local optsBulldozer_special = {
-    enemy = tank,
+	enemy = tank,
 	on_executed = {
-		{ id = 400052, delay = 0 }
+		{ id = 400052, delay = 0, },
 	},
-    enabled = (death_wish_above and pro_job and enabled_chance_dozers_exitvault)
+	enabled = (death_wish_above and pro_job and enabled_chance_dozers_exitvault),
 }
 local optsCloaker_rush_1 = {
-    enemy = cloaker,
+	enemy = cloaker,
 	participate_to_group_ai = true,
 	spawn_action = "e_sp_clk_jump_dwn_5m_heli_l",
 	on_executed = { 
-		{ id = 400051, delay = 0 }
+		{ id = 400051, delay = 0, },
 	},
-    enabled = hard_above
+	enabled = hard_above,
 }
 local optsCloaker_rush_2 = {
 	enemy = cloaker,
 	participate_to_group_ai = true,
 	spawn_action = "e_sp_repel_into_window",
-    enabled = hard_above
+	enabled = hard_above,
 }
 local optsBulldozer_BO = {
-    enemy = tank,
-	on_executed = { 
-		{ id = 400023, delay = 3 },
-		{ id = 400052, delay = 0 }
+	enemy = tank,
+	on_executed = {
+		{ id = 400023, delay = 3, },
+		{ id = 400052, delay = 0, },
 	},
-    enabled = true
+	enabled = true,
 }
 local optsTaser = {
-    enemy = taser,
-    enabled = true
+	enemy = taser,
+	enabled = true,
 }
 local optsTaser_special = {
-    enemy = taser,
+	enemy = taser,
 	participate_to_group_ai = true,
 	spawn_action = "e_sp_down_12m",
-	on_executed = { 
-		{ id = 400050, delay = 0 }
+	on_executed = {
+		{ id = 400050, delay = 0, },
 	},
-    enabled = true
+	enabled = true,
 }
 local optsDozerAmbush = {
-    enemy = tank,
+	enemy = tank,
 	participate_to_group_ai = true,
 	spawn_action = "e_sp_down_10m_swing_in_var2",
-    enabled = true
+	enabled = true,
 }
 local optsDozerAmbush_2 = {
-    enemy = tank,
+	enemy = tank,
 	participate_to_group_ai = true,
 	spawn_action = "e_sp_clk_3_5m_dwn_vent",
-    enabled = (death_sentence and surprise_tank_chance)
+	enabled = (death_sentence and surprise_tank_chance),
 }
 local optsShield_Defend_1 = {
-    enemy = shield,
-    on_executed = { { id = 400040, delay = 0 } },
+	enemy = shield,
+	on_executed = {
+		{ id = 400040, delay = 0, },
+	},
 	participate_to_group_ai = true,
-    enabled = overkill_above
+	enabled = overkill_above,
 }
 local optsShield_Defend_2 = {
-    enemy = shield,
-    on_executed = { { id = 400039, delay = 0 } },
+	enemy = shield,
+	on_executed = {
+		{ id = 400039, delay = 0, },
+	},
 	participate_to_group_ai = true,
-    enabled = overkill_above
+	enabled = overkill_above,
 }
 local optsSWAT_Heavy = {
-    enemy = swat_shotgunner,
-    enabled = true
+	enemy = swat_shotgunner,
+	enabled = true,
 }
 local optsBulldozer_SO = {
-    SO_access = "4096",
+	SO_access = "4096",
 	path_style = "none",
 	scan = true,
 	interval = 2,
-    so_action = "AI_hunt"
+	so_action = "AI_hunt",
 }
 local optsSniper_SO = {
 	scan = true,
@@ -167,7 +203,7 @@ local optsSniper_SO = {
 	needs_pos_rsrv = true,
 	align_rotation = true,
 	interval = 2,
-    so_action = "AI_sniper"
+	so_action = "AI_sniper",
 }
 local optsShieldDefend_SO = {
 	SO_access = "2048",
@@ -176,490 +212,496 @@ local optsShieldDefend_SO = {
 	needs_pos_rsrv = true,
 	align_rotation = true,
 	interval = 2,
-    so_action = "AI_sniper"
+	so_action = "AI_sniper",
 }
 local enable_shields = {
 	enabled = enabled_chance_shields,
-	elements = { 
+	elements = {
 		400001,
-		400002
-	}
+		400002,
+	},
 }
 local disable_shields = {
 	enabled = true,
 	toggle = "off",
-	elements = { 
+	elements = {
 		400001,
-		400002
-	}
+		400002,
+	},
 }
 local disable_OverdrillPONR = {
 	enabled = pro_job,
 	toggle = "off",
-	elements = { 
-		400048
-	}
+	elements = {
+		400048,
+	},
 }
 local enable_OverdrillPONR = {
 	enabled = pro_job,
-	elements = { 
-		400048
-	}
+	elements = {
+		400048,
+	},
 }
 local disable_RegularPONR = {
 	enabled = pro_job,
 	toggle = "off",
-	elements = { 
-		400047
-	}
+	elements = {
+		400047,
+	},
 }
 local disable_thetank = {
 	enabled = true,
 	toggle = "off",
-	elements = { 
-		400055
-	}
+	elements = {
+		400055,
+	},
 }
 local enable_thetank = {
 	enabled = true,
-	elements = { 
-		400055
-	}
+	elements = {
+		400055,
+	},
 }
 local optsRegularPONR = {
-	time_normal = 420,
-	time_hard = 420,
-	time_overkill = 420,
-	time_overkill_145 = 420,
-	time_easy_wish = 540,
-    time_overkill_290 = 540,
-	time_sm_wish = 540,
-	enabled = pro_job
+	elements = { 101727, },
+	time_balance_mul = normal_ponr_timer_player_mul,
+	time_easy = normal_ponr_value,
+	time_normal = normal_ponr_value,
+	time_hard = normal_ponr_value,
+	time_overkill = normal_ponr_value,
+	time_overkill_145 = normal_ponr_value,
+	time_easy_wish = normal_ponr_value,
+	time_overkill_290 = normal_ponr_value,
+	time_sm_wish = normal_ponr_value,
+	enabled = pro_job,
 }
 local optsOverdrillPONR = {
-	time_normal = 1800,
-	time_hard = 1800,
-	time_overkill = 1800,
-	time_overkill_145 = 1800,
-	time_easy_wish = 1800,
-    time_overkill_290 = 1800,
-	time_sm_wish = 1800,
-	enabled = pro_job
+	elements = { 101727, },
+	time_balance_mul = overdrill_ponr_timer_player_mul,
+	time_easy = overdrill_ponr_value,
+	time_normal = overdrill_ponr_value,
+	time_hard = overdrill_ponr_value,
+	time_overkill = overdrill_ponr_value,
+	time_overkill_145 = overdrill_ponr_value,
+	time_easy_wish = overdrill_ponr_value,
+	time_overkill_290 = overdrill_ponr_value,
+	time_sm_wish = overdrill_ponr_value,
+	enabled = pro_job,
 }
 local Bain_sendtasers = {
 	dialogue = "Play_ban_s05",
-	can_not_be_muted = true
+	can_not_be_muted = true,
 }
 local Bain_senddozers = {
 	dialogue = "Play_ban_s02_b",
-	can_not_be_muted = true
+	can_not_be_muted = true,
 }
 local Bain_sendcloakers = {
 	dialogue = "Play_ban_s04",
-	can_not_be_muted = true
+	can_not_be_muted = true,
 }
 local optsBlackTankAmbushFilter = {
 	difficulty_sm_wish = true,
 	player_3 = true,
 	player_4 = true,
 	enabled = enabled_chance_dozers_ambush_escape,
-	on_executed = { 
-		{ id = 400035, delay = 5},
-		{ id = 400036, delay = 5}
-	}
+	on_executed = {
+		{ id = 400035, delay = 5, },
+		{ id = 400036, delay = 5, },
+	},
 }
 local spawn_the_surprise_tank = {
 	enabled = true,
-	on_executed = { 
-		{ id = 400054, delay = 0 }
-	}
+	on_executed = {
+		{ id = 400054, delay = 0, },
+	},
 }
 
 return {
-    elements = {
-        --Lobby Shields
-        restoration:gen_dummy(
-            400001,
-            "shield_lobby_wall_1",
-            Vector3(-3123, -3103, -24.998),
-            Rotation(0, 0, -0),
-            optsShield_1
-        ),
-        restoration:gen_dummy(
-            400002,
-            "shield_lobby_wall_2",
-            Vector3(-3190, -3098, -24.998),
-            Rotation(0, 0, -0),
-            optsShield_2
-        ),
-		--Lobby Snipers
+	elements = {
+		-- Lobby Shields
 		restoration:gen_dummy(
-            400003,
-            "sniper_lobby_1",
-            Vector3(677, 57, 475.020),
-            Rotation(90, -0, -0),
-            optsSniper_1
-        ),
+			400001,
+			"shield_lobby_wall_1",
+			Vector3(-3123, -3103, -24.998),
+			Rotation(0, 0, -0),
+			optsShield_1
+		),
 		restoration:gen_dummy(
-            400004,
-            "sniper_lobby_2",
-            Vector3(677, 12, 475.020),
-            Rotation(90, -0, -0),
-            optsSniper_2
-        ),
+			400002,
+			"shield_lobby_wall_2",
+			Vector3(-3190, -3098, -24.998),
+			Rotation(0, 0, -0),
+			optsShield_2
+		),
+		-- Lobby Snipers
 		restoration:gen_dummy(
-            400005,
-            "sniper_lobby_3",
-            Vector3(677, 57, 475.020),
-            Rotation(90, -0, -0),
-            optsSniper_3
-        ),
+			400003,
+			"sniper_lobby_1",
+			Vector3(677, 57, 475.020),
+			Rotation(90, -0, -0),
+			optsSniper_1
+		),
 		restoration:gen_dummy(
-            400006,
-            "sniper_lobby_4",
-            Vector3(677, 12, 475.020),
-            Rotation(90, -0, -0),
-            optsSniper_4
-        ),
+			400004,
+			"sniper_lobby_2",
+			Vector3(677, 12, 475.020),
+			Rotation(90, -0, -0),
+			optsSniper_2
+		),
 		restoration:gen_dummy(
-            400007,
-            "sniper_lobby_5",
-            Vector3(677, 57, 475.020),
-            Rotation(90, -0, -0),
-            optsSniper_5
-        ),
+			400005,
+			"sniper_lobby_3",
+			Vector3(677, 57, 475.020),
+			Rotation(90, -0, -0),
+			optsSniper_3
+		),
 		restoration:gen_dummy(
-            400008,
-            "sniper_lobby_6",
-            Vector3(677, 12, 475.020),
-            Rotation(90, -0, -0),
-            optsSniper_6
-        ),
+			400006,
+			"sniper_lobby_4",
+			Vector3(677, 12, 475.020),
+			Rotation(90, -0, -0),
+			optsSniper_4
+		),
+		restoration:gen_dummy(
+			400007,
+			"sniper_lobby_5",
+			Vector3(677, 57, 475.020),
+			Rotation(90, -0, -0),
+			optsSniper_5
+		),
+		restoration:gen_dummy(
+			400008,
+			"sniper_lobby_6",
+			Vector3(677, 12, 475.020),
+			Rotation(90, -0, -0),
+			optsSniper_6
+		),
 		restoration:gen_so(
-            400009,
-            "special_sniper_so_1",
-            Vector3(90, -1882, 475),
-            Rotation(90, -0, -0),
-            optsSniper_SO
-        ),
-		--Damn bank guards! Are we done with them, yet?
+			400009,
+			"special_sniper_so_1",
+			Vector3(90, -1882, 475),
+			Rotation(90, -0, -0),
+			optsSniper_SO
+		),
+		-- Damn bank guards! Are we done with them, yet?
 		restoration:gen_dummy(
-            400010,
-            "guard_blockade_1",
-            Vector3(1887, 1002, -24.895),
-            Rotation(90, -0, -0),
-            optsSecurity
-        ),
+			400010,
+			"guard_blockade_1",
+			Vector3(1887, 1002, -24.895),
+			Rotation(90, -0, -0),
+			optsSecurity
+		),
 		restoration:gen_dummy(
-            400011,
-            "guard_blockade_2",
-            Vector3(1887, 1493, -24.895),
-            Rotation(90, 0, -0),
-            optsSecurity
-        ),
+			400011,
+			"guard_blockade_2",
+			Vector3(1887, 1493, -24.895),
+			Rotation(90, 0, -0),
+			optsSecurity
+		),
 		restoration:gen_dummy(
-            400012,
-            "guard_blockade_3",
-            Vector3(2276, 1493, -24.895),
-            Rotation(90, -0, -0),
-            optsSecurity
-        ),
+			400012,
+			"guard_blockade_3",
+			Vector3(2276, 1493, -24.895),
+			Rotation(90, -0, -0),
+			optsSecurity
+		),
 		restoration:gen_dummy(
-            400013,
-            "guard_blockade_4",
-            Vector3(2276, 998, -24.895),
-            Rotation(90, -0, -0),
-            optsSecurity
-        ),
+			400013,
+			"guard_blockade_4",
+			Vector3(2276, 998, -24.895),
+			Rotation(90, -0, -0),
+			optsSecurity
+		),
 		restoration:gen_dummy(
-            400014,
-            "guard_blockade_5",
-            Vector3(2797, 1243, -24.895),
-            Rotation(90, -0, -0),
-            optsSecurity
-        ),
+			400014,
+			"guard_blockade_5",
+			Vector3(2797, 1243, -24.895),
+			Rotation(90, -0, -0),
+			optsSecurity
+		),
 		restoration:gen_dummy(
-            400015,
-            "guard_blockade_6",
-            Vector3(3447, 1794, -14.895),
-            Rotation(90, -0, -0),
-            optsSecurity
-        ),
+			400015,
+			"guard_blockade_6",
+			Vector3(3447, 1794, -14.895),
+			Rotation(90, -0, -0),
+			optsSecurity
+		),
 		restoration:gen_dummy(
-            400016,
-            "guard_blockade_7",
-            Vector3(3447, 704, -14.895),
-            Rotation(90, -0, -0),
-            optsSecurity
-        ),
+			400016,
+			"guard_blockade_7",
+			Vector3(3447, 704, -14.895),
+			Rotation(90, -0, -0),
+			optsSecurity
+		),
 		restoration:gen_dummy(
-            400017,
-            "guard_blockade_8",
-            Vector3(5959, 704, -21.895),
-            Rotation(90, -0, -0),
-            optsSecurity
-        ),
+			400017,
+			"guard_blockade_8",
+			Vector3(5959, 704, -21.895),
+			Rotation(90, -0, -0),
+			optsSecurity
+		),
 		restoration:gen_dummy(
-            400018,
-            "guard_blockade_9",
-            Vector3(5959, 1810, -21.895),
-            Rotation(90, -0, -0),
-            optsSecurity
-        ),
+			400018,
+			"guard_blockade_9",
+			Vector3(5959, 1810, -21.895),
+			Rotation(90, -0, -0),
+			optsSecurity
+		),
 		restoration:gen_dummy(
-            400019,
-            "guard_blockade_10",
-            Vector3(6650, 1249, -21.895),
-            Rotation(90, -0, -0),
-            optsSecurity
-        ),
-		--2 dozers spawn after killing Bo The Manager+2 extra dozers on DS (even if you did not killed Bo)
+			400019,
+			"guard_blockade_10",
+			Vector3(6650, 1249, -21.895),
+			Rotation(90, -0, -0),
+			optsSecurity
+		),
+		-- 2 dozers spawn after killing Bo The Manager+2 extra dozers on DS (even if you did not kill Bo)
 		restoration:gen_dummy(
-            400020,
-            "ai_spawn_enemy_Bo's_bulldozer_2",
-            Vector3(-2682, -3588, -125),
-            Rotation(90, -0, -0),
-            optsBulldozer_BO
-        ),
+			400020,
+			"ai_spawn_enemy_Bo's_bulldozer_2",
+			Vector3(-2682, -3588, -125),
+			Rotation(90, -0, -0),
+			optsBulldozer_BO
+		),
 		restoration:gen_dummy(
-            400021,
-            "extra_tank_1",
-            Vector3(-3176, 3750, -125),
-            Rotation(90, -0, -0),
-            optsBulldozer_193
-        ),
+			400021,
+			"extra_tank_1",
+			Vector3(-3176, 3750, -125),
+			Rotation(90, -0, -0),
+			optsBulldozer_193
+		),
 		restoration:gen_dummy(
-            400022,
-            "extra_tank_2",
-            Vector3(-2657, -3569, -125),
-            Rotation(90, -0, -0),
-            optsBulldozer_193
-        ),
+			400022,
+			"extra_tank_2",
+			Vector3(-2657, -3569, -125),
+			Rotation(90, -0, -0),
+			optsBulldozer_193
+		),
 		restoration:gen_so(
-            400023,
-            "dozer_hunt_so",
-            Vector3(-2657, -3569, -90),
-            Rotation(90, -0, -0),
-            optsBulldozer_SO
-        ),
-		--two PJ dozers when leaving the vault
-		restoration:gen_dummy(
-            400024,
-            "projob_tank_exit_vault_1",
-            Vector3(3359, 1790, -15),
-            Rotation(-90, 0, -0),
-            optsBulldozer_special
-        ),
-		restoration:gen_dummy(
-            400025,
-            "projob_tank_exit_vault_2",
-            Vector3(3359, 713, -15),
-            Rotation(-90, 0, -0),
-            optsBulldozer_special
-        ),
-		--145+ throwback, 3 tasers+1 heavy swat in staircase escape
-		restoration:gen_dummy(
-            400026,
-            "taser_escape_1",
-            Vector3(6050, -2351, -135.691),
-            Rotation(0, 0, -0),
-            optsTaser
-        ),
-		restoration:gen_dummy(
-            400027,
-            "taser_escape_2",
-            Vector3(5887, -2347, -135.691),
-            Rotation(0, 0, -0),
-            optsTaser
-        ),
-		restoration:gen_dummy(
-            400028,
-            "taser_escape_3",
-            Vector3(5553, -2367, -135.691),
-            Rotation(-90, 0, -0),
-            optsTaser
-        ),
-		restoration:gen_dummy(
-            400029,
-            "swat_escape_1",
-            Vector3(5553, -2502, -135.691),
-            Rotation(-90, 0, -0),
-            optsSWAT_Heavy
-        ),
-		--3 cloakers coming down the vent+elevator
-		restoration:gen_dummy(
-            400030,
-            "cloaker_rush_1",
-            Vector3(483, 352, 475.020),
-            Rotation(0, 0, -0),
-            optsCloaker_rush_1
-        ),
-		restoration:gen_dummy(
-            400031,
-            "cloaker_rush_2",
-            Vector3(677, 57, 475.020),
-            Rotation(90, -0, -0),
-            optsCloaker_rush_2
-        ),
-		restoration:gen_dummy(
-            400032,
-            "cloaker_rush_3",
-            Vector3(677, 12, 475.020),
-            Rotation(90, -0, -0),
-            optsCloaker_rush_2
-        ),
-		restoration:gen_so(
-            400033,
-            "special_sniper_so_2",
-            Vector3(-1175, -1375, 475),
-            Rotation(0, 0, 0),
-            optsSniper_SO
-        ),
-		restoration:gen_so(
-            400034,
-            "special_sniper_so_3",
-            Vector3(-1000, -1375, 475),
-            Rotation(0, 0, 0),
-            optsSniper_SO
-        ),
-		restoration:gen_dummy(
-            400035,
-            "dozer_ambush_elevator_1",
-            Vector3(5879, -3035, 464.309),
-            Rotation(90, -0, -0),
-            optsDozerAmbush
-        ),
-		restoration:gen_dummy(
-            400036,
-            "dozer_ambush_elevator_2",
-            Vector3(5879, -3252, 464.309),
-            Rotation(90, -0, -0),
-            optsDozerAmbush
-        ),
-		restoration:gen_dummy(
-            400037,
-            "taser_special_1",
-            Vector3(-777, -1616, 475),
-            Rotation(0, 0, -0),
-            optsTaser_special
-        ),
-		restoration:gen_dummy(
-            400038,
-            "taser_special_2",
-            Vector3(-861, -1616, 475),
-            Rotation(0, 0, -0),
-            optsTaser_special
-        ),
-		restoration:gen_so(
-            400039,
-            "shield_defend_so_1",
-            Vector3(3307, 700, -15),
-            Rotation(90, -0, -0),
-            optsShieldDefend_SO
-        ),
-		restoration:gen_so(
-            400040,
-            "shield_defend_so_2",
-            Vector3(3307, 1800, -15),
-            Rotation(90, -0, -0),
-            optsShieldDefend_SO
-        ),
-		restoration:gen_dummy(
-            400041,
-            "shield_defend_1",
-            Vector3(3963, 1836, -42.895),
-            Rotation(90, -0, -0),
-            optsShield_Defend_1
-        ),
-        restoration:gen_dummy(
-            400042,
-            "shield_defend_2",
-            Vector3(3959, 721, -43.895),
-            Rotation(90, -0, -0),
-            optsShield_Defend_2
-        ),
-		restoration:gen_toggleelement(
-            400043,
-            "enable_lobby_shields",
-            enable_shields
-        ),
-		restoration:gen_toggleelement(
-            400044,
-            "disable_lobby_shields",
-            disable_shields
-        ),
-		restoration:gen_toggleelement(
-            400045,
-            "enable_OverdrillPONR",
-            enable_OverdrillPONR
-        ),
-		restoration:gen_toggleelement(
-            400046,
-            "disable_RegularPONR",
-            disable_RegularPONR
-        ),
-		restoration:gen_pointofnoreturn(
-            400047,
-            "Regular_PONR",
-            Vector3(-2657, -3569, -90),
-            Rotation(90, -0, -0),
-            optsRegularPONR
-        ),
-		restoration:gen_pointofnoreturn(
-            400048,
-            "Overdrill_PONR",
-            Vector3(-2657, -3569, -90),
-            Rotation(90, -0, -0),
-            optsOverdrillPONR
-        ),
-		restoration:gen_toggleelement(
-            400049,
-            "disable_OverdrillPONR",
-            disable_OverdrillPONR
-        ),
-		restoration:gen_dialogue(
-            400050,
-            "they_sending_tasers",
-            Bain_sendtasers
-        ),
-		restoration:gen_dialogue(
-            400051,
-            "they_sending_cloakers",
-            Bain_sendcloakers
-        ),
-		restoration:gen_dialogue(
-            400052,
-            "they_sending_dozers",
-            Bain_senddozers
-        ),
-		restoration:gen_dynamicfilter(
-            400053,
-            "black_tank_elevator_ambush_for_3_and_above_players",
+			400023,
+			"dozer_hunt_so",
 			Vector3(-2657, -3569, -90),
-            Rotation(90, -0, -0),
-            optsBlackTankAmbushFilter
-        ),
+			Rotation(90, -0, -0),
+			optsBulldozer_SO
+		),
+		-- Two PJ dozers when leaving the vault
 		restoration:gen_dummy(
-            400054,
-            "surprise_tank",
-            Vector3(4657, -1100, -735.693),
-            Rotation(-180, 0, -0),
-            optsDozerAmbush_2
-        ),
+			400024,
+			"projob_tank_exit_vault_1",
+			Vector3(3359, 1790, -15),
+			Rotation(-90, 0, -0),
+			optsBulldozer_special
+		),
+		restoration:gen_dummy(
+			400025,
+			"projob_tank_exit_vault_2",
+			Vector3(3359, 713, -15),
+			Rotation(-90, 0, -0),
+			optsBulldozer_special
+		),
+		-- 145+ throwback, 3 tasers+1 heavy swat in staircase escape
+		restoration:gen_dummy(
+			400026,
+			"taser_escape_1",
+			Vector3(6050, -2351, -135.691),
+			Rotation(0, 0, -0),
+			optsTaser
+		),
+		restoration:gen_dummy(
+			400027,
+			"taser_escape_2",
+			Vector3(5887, -2347, -135.691),
+			Rotation(0, 0, -0),
+			optsTaser
+		),
+		restoration:gen_dummy(
+			400028,
+			"taser_escape_3",
+			Vector3(5553, -2367, -135.691),
+			Rotation(-90, 0, -0),
+			optsTaser
+		),
+		restoration:gen_dummy(
+			400029,
+			"swat_escape_1",
+			Vector3(5553, -2502, -135.691),
+			Rotation(-90, 0, -0),
+			optsSWAT_Heavy
+		),
+		-- 3 cloakers coming down the vent+elevator
+		restoration:gen_dummy(
+			400030,
+			"cloaker_rush_1",
+			Vector3(483, 352, 475.020),
+			Rotation(0, 0, -0),
+			optsCloaker_rush_1
+		),
+		restoration:gen_dummy(
+			400031,
+			"cloaker_rush_2",
+			Vector3(677, 57, 475.020),
+			Rotation(90, -0, -0),
+			optsCloaker_rush_2
+		),
+		restoration:gen_dummy(
+			400032,
+			"cloaker_rush_3",
+			Vector3(677, 12, 475.020),
+			Rotation(90, -0, -0),
+			optsCloaker_rush_2
+		),
+		restoration:gen_so(
+			400033,
+			"special_sniper_so_2",
+			Vector3(-1175, -1375, 475),
+			Rotation(0, 0, 0),
+			optsSniper_SO
+		),
+		restoration:gen_so(
+			400034,
+			"special_sniper_so_3",
+			Vector3(-1000, -1375, 475),
+			Rotation(0, 0, 0),
+			optsSniper_SO
+		),
+		restoration:gen_dummy(
+			400035,
+			"dozer_ambush_elevator_1",
+			Vector3(5879, -3035, 464.309),
+			Rotation(90, -0, -0),
+			optsDozerAmbush
+		),
+		restoration:gen_dummy(
+			400036,
+			"dozer_ambush_elevator_2",
+			Vector3(5879, -3252, 464.309),
+			Rotation(90, -0, -0),
+			optsDozerAmbush
+		),
+		restoration:gen_dummy(
+			400037,
+			"taser_special_1",
+			Vector3(-777, -1616, 475),
+			Rotation(0, 0, -0),
+			optsTaser_special
+		),
+		restoration:gen_dummy(
+			400038,
+			"taser_special_2",
+			Vector3(-861, -1616, 475),
+			Rotation(0, 0, -0),
+			optsTaser_special
+		),
+		restoration:gen_so(
+			400039,
+			"shield_defend_so_1",
+			Vector3(3307, 700, -15),
+			Rotation(90, -0, -0),
+			optsShieldDefend_SO
+		),
+		restoration:gen_so(
+			400040,
+			"shield_defend_so_2",
+			Vector3(3307, 1800, -15),
+			Rotation(90, -0, -0),
+			optsShieldDefend_SO
+		),
+		restoration:gen_dummy(
+			400041,
+			"shield_defend_1",
+			Vector3(3963, 1836, -42.895),
+			Rotation(90, -0, -0),
+			optsShield_Defend_1
+		),
+		restoration:gen_dummy(
+			400042,
+			"shield_defend_2",
+			Vector3(3959, 721, -43.895),
+			Rotation(90, -0, -0),
+			optsShield_Defend_2
+		),
+		restoration:gen_toggleelement(
+			400043,
+			"enable_lobby_shields",
+			enable_shields
+		),
+		restoration:gen_toggleelement(
+			400044,
+			"disable_lobby_shields",
+			disable_shields
+		),
+		restoration:gen_toggleelement(
+			400045,
+			"enable_OverdrillPONR",
+			enable_OverdrillPONR
+		),
+		restoration:gen_toggleelement(
+			400046,
+			"disable_RegularPONR",
+			disable_RegularPONR
+		),
+		restoration:gen_pointofnoreturn(
+			400047,
+			"Regular_PONR",
+			Vector3(-2657, -3569, -90),
+			Rotation(90, -0, -0),
+			optsRegularPONR
+		),
+		restoration:gen_pointofnoreturn(
+			400048,
+			"Overdrill_PONR",
+			Vector3(-2657, -3569, -90),
+			Rotation(90, -0, -0),
+			optsOverdrillPONR
+		),
+		restoration:gen_toggleelement(
+			400049,
+			"disable_OverdrillPONR",
+			disable_OverdrillPONR
+		),
+		restoration:gen_dialogue(
+			400050,
+			"they_sending_tasers",
+			Bain_sendtasers
+		),
+		restoration:gen_dialogue(
+			400051,
+			"they_sending_cloakers",
+			Bain_sendcloakers
+		),
+		restoration:gen_dialogue(
+			400052,
+			"they_sending_dozers",
+			Bain_senddozers
+		),
+		restoration:gen_dynamicfilter(
+			400053,
+			"black_tank_elevator_ambush_for_3_and_above_players",
+			Vector3(-2657, -3569, -90),
+			Rotation(90, -0, -0),
+			optsBlackTankAmbushFilter
+		),
+		restoration:gen_dummy(
+			400054,
+			"surprise_tank",
+			Vector3(4657, -1100, -735.693),
+			Rotation(-180, 0, -0),
+			optsDozerAmbush_2
+		),
 		restoration:gen_missionscript(
-            400055,
-            "spawn_the_surprise_tank",
-            spawn_the_surprise_tank
-        ),
+			400055,
+			"spawn_the_surprise_tank",
+			spawn_the_surprise_tank
+		),
 		restoration:gen_toggleelement(
-            400056,
-            "enable_the_surpise_tank",
-            enable_thetank
-        ),
+			400056,
+			"enable_the_surpise_tank",
+			enable_thetank
+		),
 		restoration:gen_toggleelement(
-            400057,
-            "disable_the_surpise_tank",
-            disable_thetank
-        )
-    }
+			400057,
+			"disable_the_surpise_tank",
+			disable_thetank
+		),
+	},
 }


### PR DESCRIPTION
Green Bridge and Undercover already had PONR elements, but now they're set up to be editable in Lua if needed
Unsure if/when Heat Street will be reverted to vanilla, untouched
Diamond Heist has no PONR, untouched
Rantman's No Mercy edit is already set up properly for anti-grief (not reliant on auto-detect), untouched