### PR TITLE
More sights + some fixes

### DIFF
--- a/lua/sc/loc/loc.lua
+++ b/lua/sc/loc/loc.lua
@@ -1317,14 +1317,16 @@ Hooks:Add("LocalizationManagerPostInit", "SC_Localization_Eng", function(loc)
 		["bm_wp_upg_a_piercing_heavy_desc_per_pellet"] = "Fires #{skill_color}#12## #{skill_color}#armor piercing## flechettes.\n#{skill_color}#Headshot damage is increased by 100% and there is no reduction to enemy headshot multipliers.##",
 
 		--Generic Optic Zoom Descriptions--
-		["bm_wp_upg_o_1_1"] = "Red Dot sight.\n#{risk}#1.1x magnification.##",
-		["bm_wp_upg_o_1_1_health"] = "Red Dot sight that #{skill_color}#displays the health of enemies## while aiming at them.\n#{risk}#1.1x magnification.##",
+		["bm_wp_upg_o_1_1"] = "Red dot sight.\n#{risk}#1.1x magnification.##",
+		["bm_wp_upg_o_1_1_health"] = "Red dot sight that #{skill_color}#displays the health of enemies## while aiming at them.\n#{risk}#1.1x magnification.##",
+		["bm_wp_upg_o_1_1_ammo"] = "Red dot sight that #{skill_color}#displays the weapon's current ammo count##.\n#{risk}#1.1x magnification.##",
 		["bm_wp_upg_o_1_1_generic"] = "#{risk}#1.1x magnification.##",
 		["bm_wp_upg_o_1_2"] = "Red dot sight.\n#{risk}#1.2x magnification.##",
 		["bm_wp_upg_o_1_5"] = "Holographic sight.\n#{risk}#1.5x magnification.##",
 		["bm_wp_upg_o_1_5_pris"] = "Prismatic sight.\n#{risk}#1.5x magnification.##",
 		["bm_wp_upg_o_1_5_scope"] = "Low-powered scope.\n#{risk}#1.5x magnification.##",
 		["bm_wp_upg_o_1_8"] = "Red dot sight.\n#{risk}#1.8x magnification.##",
+		["bm_wp_upg_o_1_8_laser"] = "Red dot sight with a built-in laser sight.\n#{risk}#1.8x magnification.##\n\nToggle the laser on/off by pressing #{skill_color}#$BTN_GADGET.##",
 		--["bm_wp_upg_o_1_8_irons"] = "Red dot sight with back-up iron sights.\n#{risk}#1-1.8x magnification.##\n\nPress #{skill_color}#$BTN_GADGET## while aiming to switch between sights.",
 		["bm_wp_upg_o_2"] = "Low-powered scope.\n#{risk}#2x magnification.##",
 		["bm_wp_upg_o_2_szholot"] = "Thermal holographic sight.\n#{risk}#2x magnification.##\n#{skill_color}#Automatically marks## guards, elites and special enemies when you aim at them.\n\n#{risk}#NOTE: Guards can only be marked during stealth.##",
@@ -1348,6 +1350,7 @@ Hooks:Add("LocalizationManagerPostInit", "SC_Localization_Eng", function(loc)
 		["bm_wp_upg_o_5_vari"] = "Variable zoom scope.\n#{risk}#5-8x magnification.##\n\nPress #{skill_color}#$BTN_GADGET## while aiming to switch between zoom levels.",
 		["bm_wp_upg_o_6"] = "Long-range scope.\n#{risk}#6x magnification.##",
 		["bm_wp_upg_o_6_range"] = "Long-range scope with a built-in #{skill_color}#rangefinder.##\n#{risk}#6x magnification.##",
+		["bm_wp_upg_o_6_rds_mount"] = "Long-range scope with a top-mounted red-dot sight.\n#{risk}#1.1-6x magnification.##",
 		["bm_wp_upg_o_8"] = "Long-range scope.\n#{risk}#8x magnification.##",
 		["bm_wp_upg_o_8_range"] = "Long-range scope with a built-in #{skill_color}#rangefinder.##\n#{risk}#8x magnification.##",
 

--- a/lua/sc/tweak_data/weaponfactorytweakdata.lua
+++ b/lua/sc/tweak_data/weaponfactorytweakdata.lua
@@ -25088,6 +25088,96 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 					value = 3,
 					zoom = 1
 				}		
+				self.parts.wpn_fps_upg_o_romeo3_pis.supported = true		
+				self.parts.wpn_fps_upg_o_romeo3_pis.desc_id = "bm_wp_upg_o_1_1"
+				self.parts.wpn_fps_upg_o_romeo3_pis.stats = {
+					value = 3,
+					zoom = 1
+				}
+			end	
+
+			if self.parts.wpn_fps_upg_o_su230_mdrs then
+				self.parts.wpn_fps_upg_o_su230_mdrs.supported = true	
+				self.parts.wpn_fps_upg_o_su230_mdrs.desc_id = "bm_wp_upg_o_4_rds"
+				self.parts.wpn_fps_upg_o_su230_mdrs.perks = {"scope"}	
+				self.parts.wpn_fps_upg_o_su230_mdrs.stats = {
+					value = 8,
+					zoom = 30
+				}
+				self.parts.wpn_fps_upg_o_su230_mdrs_switch.stats = {
+					value = 1,
+					gadget_zoom = 2
+				}
+			end		
+			
+			if self.parts.wpn_fps_upg_o_acog_rmr then
+				self.parts.wpn_fps_upg_o_acog_rmr.supported = true	
+				self.parts.wpn_fps_upg_o_acog_rmr.desc_id = "bm_wp_upg_o_4_rds"
+				self.parts.wpn_fps_upg_o_acog_rmr.perks = {"scope"}	
+				self.parts.wpn_fps_upg_o_acog_rmr.stats = {
+					value = 8,
+					zoom = 30
+				}	
+				self.parts.wpn_fps_upg_o_acog_rmr_switch.stats = {
+					value = 1,
+					gadget_zoom = 2
+				}
+			end		
+			
+			if self.parts.wpn_fps_upg_o_ta648rmr then
+				self.parts.wpn_fps_upg_o_ta648rmr.supported = true	
+				self.parts.wpn_fps_upg_o_ta648rmr.desc_id = "bm_wp_upg_o_6_rds_mount"
+				self.parts.wpn_fps_upg_o_ta648rmr.perks = {"scope"}	
+				self.parts.wpn_fps_upg_o_ta648rmr.stats = {
+					value = 8,
+					zoom = 50
+				}	
+				self.parts.wpn_fps_upg_o_ta648rmr_switch.stats = {
+					value = 1,
+					gadget_zoom = 2
+				}
+			end
+
+			if self.parts.wpn_fps_upg_o_susat then
+				self.parts.wpn_fps_upg_o_susat.supported = true	
+				self.parts.wpn_fps_upg_o_susat.desc_id = "bm_wp_upg_o_4_irons"
+				self.parts.wpn_fps_upg_o_susat.perks = {"scope"}	
+				self.parts.wpn_fps_upg_o_susat.stats = {
+					value = 8,
+					zoom = 30
+				}	
+				self.parts.wpn_fps_upg_o_susat_steelsight.stats = {
+					value = 1,
+					gadget_zoom = 1
+				}
+			end
+
+			if self.parts.wpn_fps_upg_o_horzine then
+				self.parts.wpn_fps_upg_o_horzine.supported = true
+				self.parts.wpn_fps_upg_o_horzine.desc_id = "bm_wp_upg_o_1_1_ammo"
+				self.parts.wpn_fps_upg_o_horzine.stats = {
+					value = 8,
+					zoom = 1
+				}		
+			end
+			
+			if self.parts.wpn_fps_upg_o_pk01_vi then
+				self.parts.wpn_fps_upg_o_pk01_vi.supported = true
+				self.parts.wpn_fps_upg_o_pk01_vi.desc_id = "bm_wp_upg_o_1_8_laser"
+				self.parts.wpn_fps_upg_o_pk01_vi.perks = {"scope", "gadget"}	
+				self.parts.wpn_fps_upg_o_pk01_vi.stats = {
+					value = 8,
+					zoom = 1
+				}		
+			end
+
+			if self.parts.wpn_fps_upg_o_mro then
+				self.parts.wpn_fps_upg_o_mro.supported = true
+				self.parts.wpn_fps_upg_o_mro.desc_id = "bm_wp_upg_o_1_2"
+				self.parts.wpn_fps_upg_o_mro.stats = {
+					value = 3,
+					zoom = 2
+				}
 			end	
 			
 			if self.parts.wpn_fps_upg_fl_anpeq2 then
@@ -36556,6 +36646,10 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 			self.parts.wpn_fps_ass_kurisumasu_gb_windham.supported = true
 			self.parts.wpn_fps_ass_kurisumasu_gb_windham.stats = { value = 0 }
 			self.parts.wpn_fps_ass_kurisumasu_gb_windham.custom_stats = nil
+			
+			self.parts.wpn_fps_ass_kurisumasu_ro_buis.supported = true
+			self.parts.wpn_fps_ass_kurisumasu_ro_buis.stats = { value = 0 }
+			self.parts.wpn_fps_ass_kurisumasu_ro_buis.custom_stats = nil
 
 			self.wpn_fps_ass_kurisumasu.override = self.wpn_fps_ass_kurisumasu.override or {}
 			self.wpn_fps_ass_kurisumasu.override.wpn_fps_upg_m4_s_standard = {

--- a/lua/sc/tweak_data/weapontweakdata.lua
+++ b/lua/sc/tweak_data/weapontweakdata.lua
@@ -21917,6 +21917,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 				self.swhiskey.damage_type = "handcannon"
 				self.swhiskey.fire_mode_data.fire_rate = 0.4195804
 				self.swhiskey.muzzleflash = "effects/payday2/particles/weapons/big_51b_auto_fps"
+				self.swhiskey.desc_id = "bm_ap_weapon_sc_desc"
 				self.swhiskey.AMMO_MAX = 20
 				self.swhiskey.CLIP_AMMO_MAX = 5
 				self.swhiskey.kick = self.stat_info.kick_tables.vertical_kick
@@ -24304,6 +24305,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 				self.bk500.damage_type = "handcannon"
 				self.bk500.fire_mode_data.fire_rate = 0.5454
 				self.bk500.muzzleflash = "effects/payday2/particles/weapons/big_51b_auto_fps"
+				self.bk500.desc_id = "bm_ap_weapon_sc_desc"
 				self.bk500.AMMO_MAX = 20
 				self.bk500.CLIP_AMMO_MAX = 5
 				self.bk500.kick = self.stat_info.kick_tables.vertical_kick


### PR DESCRIPTION
- Added support for the Horzine Tech Sight, SpecterDR MDRS, TA31F-RMR, TA648-RMR, SUSAT, Trijicon MRO and BelOMO PK-01
- Fixed the custom .500's not having a description of their AP capabilities.
- Removed "unsupported" description from the M4 Grenadier's Backup Irons attachment.