### PR TITLE
Small tweaks

### DIFF
--- a/lua/sc/tweak_data/playertweakdata.lua
+++ b/lua/sc/tweak_data/playertweakdata.lua
@@ -472,7 +472,7 @@ function PlayerTweakData:_init_mp7()
 	pivot_shoulder_translation = Vector3(10.6576, 18.2065, -5.75727)
 	pivot_shoulder_rotation = Rotation(0.106663, -0.0849503, 0.628575)
 	pivot_head_translation = Vector3(-0.02, 14, -0.1)
-	pivot_head_rotation = Rotation(0, 0, 0)
+	pivot_head_rotation = Rotation(0, 0.5, 0)
 	self.stances.mp7.steelsight.shoulders.translation = pivot_head_translation - pivot_shoulder_translation:rotate_with(pivot_shoulder_rotation:inverse()):rotate_with(pivot_head_rotation)
 	self.stances.mp7.steelsight.shoulders.rotation = pivot_head_rotation * pivot_shoulder_rotation:inverse()
 end

--- a/lua/sc/tweak_data/weaponfactorytweakdata.lua
+++ b/lua/sc/tweak_data/weaponfactorytweakdata.lua
@@ -19028,7 +19028,8 @@ end)
 						translation = Vector3(-0.005, 1.6, -3.028)
 					}
 					self.parts.wpn_fps_upg_o_specter.stance_mod.wpn_fps_smg_mp7 = {
-						translation = Vector3(0.02, 7.5, -2.72)
+						translation = Vector3(0.02, 7.5, -2.72),
+						rotation = Rotation(0, -0.5, 0)
 					}
 				
 					self.parts.wpn_fps_upg_o_specter.stance_mod.wpn_fps_smg_mp9 = {

--- a/lua/sc/tweak_data/weapontweakdata.lua
+++ b/lua/sc/tweak_data/weapontweakdata.lua
@@ -16467,7 +16467,9 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 				}
 				self.czevo.stats_modifiers = nil
 				self.czevo.panic_suppression_chance = 0.05
-				self.czevo.timers = deep_clone(self.shepheard.timers)
+				self.czevo.timers.reload_empty = 2.7
+				self.czevo.timers.reload_exit_empty = 0.5
+				self.czevo.timers.reload_exit_not_empty = 0.6
 				self.x_czevo.use_data.selection_index = 5 
 			end
 


### PR DESCRIPTION
- Scorpion EVO : tweaked reload timers (it doesn't reuse the MPX's anims anymore)
- MP7 : centered iron sights (couldn't do it through PVM)