### PR TITLE
XM8 stuff

### DIFF
--- a/lua/sc/tweak_data/weaponfactorytweakdata.lua
+++ b/lua/sc/tweak_data/weaponfactorytweakdata.lua
@@ -25278,19 +25278,37 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 				self.parts.wpn_fps_upg_xm8_handguard_compact.stats = deep_clone(barrels.short_b2_stats)
 				self.parts.wpn_fps_upg_xm8_handguard_compact.custom_stats = deep_clone(barrels.short_b2_stats)
 					
-				self.parts.wpn_fps_ass_xm8_insight_ismv.supported = false
+				self.parts.wpn_fps_ass_xm8_insight_ismv.supported = true
+				self.parts.wpn_fps_ass_xm8_insight_ismv.desc_id = "bm_wp_upg_o_1_1"
+				self.parts.wpn_fps_ass_xm8_insight_ismv.stats = {
+					value = 3,
+					zoom = 1
+				}	
 					
 				self.parts.wpn_fps_upg_xm8_cmag.supported = true
+				self.parts.wpn_fps_upg_xm8_cmag.has_description = false
 				self.parts.wpn_fps_upg_xm8_cmag.stats = deep_clone(self.parts.wpn_fps_upg_m4_m_drum.stats)
 				self.parts.wpn_fps_upg_xm8_cmag.custom_stats = deep_clone(self.parts.wpn_fps_upg_m4_m_drum.custom_stats)
 					
 				self.parts.wpn_fps_upg_xm8_mag_magpul.supported = true
+				self.parts.wpn_fps_upg_xm8_mag_magpul.has_description = false
 				self.parts.wpn_fps_upg_xm8_mag_magpul.stats = deep_clone(self.parts.wpn_fps_m4_upg_m_quick.stats)
 				self.parts.wpn_fps_upg_xm8_mag_magpul.custom_stats = nil
 					
 				self.parts.wpn_fps_upg_xm8_stock_collapsed.supported = true
 				self.parts.wpn_fps_upg_xm8_stock_collapsed.stats = deep_clone(stocks.adj_to_fold_stats)
 				self.parts.wpn_fps_upg_xm8_stock_collapsed.custom_stats = deep_clone(stocks.adj_to_fold_stats)	
+
+				table.insert(self.wpn_fps_ass_xm8.uses_parts, "wpn_fps_upg_i_m8a1")
+				for k, used_part_id in ipairs(self.wpn_fps_ass_xm8.uses_parts) do
+					if self.parts[used_part_id] and self.parts[used_part_id].type then
+						if self.parts[used_part_id].type == "magazine" then
+							if self.parts[used_part_id].stats and self.parts[used_part_id].stats.extra_ammo then
+								table.insert(self.parts.wpn_fps_upg_i_m8a1.forbids, used_part_id)
+							end
+						end
+					end
+				end
 			end				
 		
 			if self.parts.wpn_fps_upg_o_okp7_dove then --Pawcio's Russian Sight Pack 

--- a/lua/sc/tweak_data/weapontweakdata.lua
+++ b/lua/sc/tweak_data/weapontweakdata.lua
@@ -18182,8 +18182,6 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 				self.xm8.damage_type = "assault_rifle"
 				self.xm8.tactical_reload = 1
 				self.xm8.nato = true
-				self.xm8.BURST_FIRE = 3
-				self.xm8.ADAPTIVE_BURST_SIZE = false																	
 				self.xm8.auto.fire_rate = 0.08
 				self.xm8.fire_mode_data.fire_rate = 0.08
 				self.xm8.AMMO_MAX = 150
@@ -20234,6 +20232,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 				self.vp70.lock_slide = true
 				self.vp70.fire_mode_data.fire_rate = 0.1
 				self.vp70.no_auto_anims = true
+				self.vp70.BURST_FIRE = nil
 				self.vp70.tactical_reload = 1
 				self.vp70.FIRE_MODE = "single"
 				self.vp70.CAN_TOGGLE_FIREMODE = false

--- a/lua/sc/tweak_data/weapontweakdata.lua
+++ b/lua/sc/tweak_data/weapontweakdata.lua
@@ -18199,7 +18199,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 				self.xm8.damage_falloff = {
 					start_dist = 2100,
 					end_dist = 6000,
-					min_mult = 0.4166
+					min_mult = 0.5
 				}
 				self.xm8.stats = {
 					damage = 24,


### PR DESCRIPTION
- Updated the default sight to be properly supported.
- Removed burst capabilities (not part of the weapon, and crashed anyway). Added the M8A1 burst attachment to compensate.
- Buffed minimum range so it isn't a straight downgrade from the custom G36K.
- Properly removed burst capabilities from the base VP70. Functionality is still present when attaching the stock.