### PR TITLE
More PONR stuff

### DIFF
--- a/Core.lua
+++ b/Core.lua
@@ -1315,6 +1315,27 @@ function restoration:gen_instance_input(id, name, pos, rot, opts)
 	}
 end
 
+function restoration:gen_counter(id, name, pos, rot, opts)
+	opts = opts or {}
+	return {
+		id = id,
+		editor_name = name,
+		class = "ElementCounter",
+		module = "CoreElementCounter",
+		values = {
+			execute_on_startup = false,
+			trigger_times = opts.trigger_times or 0,
+			on_executed = opts.on_executed or {},
+			base_delay = opts.base_delay or 0,
+			position = pos,
+			rotation = rot,
+			enabled = opts.enabled or false,
+			counter_target = opts.counter_target or 0,
+			digital_gui_unit_ids = opts.digital_gui_unit_ids or {},
+		},
+	}
+end
+
 function restoration:log(...)
 	if self.logging then
 		log("[StreamlinedHeistingAI] " .. table.concat({...}, " "))

--- a/Core.lua
+++ b/Core.lua
@@ -39,7 +39,7 @@ function restoration:Init()
 	}
 		--Defines what captains spawn on what heists.
 	restoration.captain_spawns = {
-	    --Winters
+		--Winters
 		arena = restoration.captain_types.winter, --Alesso
 		welcome_to_the_jungle_1 = restoration.captain_types.winter, --Big Oil Day 1
 		stage_1 = restoration.captain_types.winter, --Big Oil Day 1 EDIT
@@ -274,7 +274,7 @@ function restoration:Init()
 		"constantine_resort_lvl", --Scarlett Resort (Constantine Scores)
 		"constantine_murkyairport_lvl", --Murky Airport (Constantine Scores)
 		"Security_Avenue", --GenSec HQ Day 1
-        "arena_club30" -- Arena Orange
+		"arena_club30" -- Arena Orange
 	}
 	--Slightly reduced spawns, generally use for heists with lengthy sections where players typically hold out in one smallish position, or 'early game' heists.
 	restoration.tiny_levels = {
@@ -827,7 +827,7 @@ function restoration:send_sync_environment(to)
 	end
 end
 
-	restoration.loaded_elements = false
+restoration.loaded_elements = false
 
 --Stealing this from SH cause it's way better
 function restoration:require(file)
@@ -848,469 +848,469 @@ end
 
 --Mission script but it can touch instances
 function restoration:instance_script_patches()
-		if self._instance_script_patches == nil then
-			local level_id = Global.game_settings and Global.game_settings.level_id
+	if self._instance_script_patches == nil then
+		local level_id = Global.game_settings and Global.game_settings.level_id
 
-			if level_id then
-				self._instance_script_patches = self:require("instance_script/" .. level_id:gsub('_skip1$', ''):gsub('_skip2$', ''):gsub("_night$", ""):gsub("_day$", "")) or false
-			end
+		if level_id then
+			self._instance_script_patches = self:require("instance_script/" .. level_id:gsub('_skip1$', ''):gsub('_skip2$', ''):gsub("_night$", ""):gsub("_day$", "")) or false
 		end
-
-		return self._instance_script_patches
 	end
+
+	return self._instance_script_patches
+end
 
 
 --Mission script but it can add new functions to heists
 function restoration:mission_script_add()
-		restoration.loaded_elements = false
-		if self._mission_script_add == nil then
-			local level_id = Global.game_settings and Global.game_settings.level_id
-			if level_id then
-				self._mission_script_add = self:require("mission_script_add/" .. level_id:gsub('_skip1$', ''):gsub('_skip2$', ''):gsub("_night$", ""):gsub("_day$", "")) or false
-			end
-		end
-		return self._mission_script_add
-	end
-
-	function restoration:gen_dummy(id, name, pos, rot, opts)
-		opts = opts or {}
-		return {
-			id = id,
-			editor_name = name,
-			class = "ElementSpawnEnemyDummy",
-			values = {
-				execute_on_startup = opts.execute_on_startup or false,
-				participate_to_group_ai = opts.participate_to_group_ai or false,
-				position = pos,
-				force_pickup = opts.force_pickup or "none",
-				voice = opts.voice or 0,
-				enemy = opts.enemy or "units/payday2/characters/ene_swat_1/ene_swat_1",
-				enemy_table = opts.enemy_table or nil, --possible enemy tables to prevent crashing
-				trigger_times = opts.trigger_times or 0,
-				spawn_action = opts.spawn_action or "none",
-				accessibility = opts.accessibility or "any",
-				on_executed = opts.on_executed or {},
-				rotation = rot,
-				team = opts.team or "default",
-				base_delay = opts.base_delay or 0,
-				enabled = opts.enabled or false,
-				amount = opts.amount or 0,
-				interval = opts.interval or 5,
-			},
-		}
-	end
-
-	function restoration:gen_spawngroup(id, name, elements, interval)
-		return {
-			id = id,
-			editor_name = name,
-			class = "ElementSpawnEnemyGroup",
-			values = {
-				on_executed = {},
-				trigger_times = 0,
-				base_delay = 0,
-				ignore_disabled = false,
-				amount = 0,
-				spawn_type = "ordered",
-				team = "default",
-				execute_on_startup = false,
-				enabled = true,
-				preferred_spawn_groups = {
-					"tac_shield_wall_charge",
-					"FBI_spoocs",
-					"tac_tazer_charge",
-					"tac_tazer_flanking",
-					"tac_shield_wall",
-					"tac_swat_rifle_flank",
-					"tac_shield_wall_ranged",
-					"tac_bull_rush",
-				},
-				elements = elements,
-				interval = interval or 0,
-			},
-		}
-	end
-
-	function restoration:gen_so(id, name, pos, rot, opts)
-		opts = opts or {}
-		return {
-			id = id,
-			editor_name = name,
-			class = "ElementSpecialObjective",
-			values = {
-				path_style = opts.path_style or "destination",
-				align_position = opts.align_position or false,
-				ai_group = "enemies",
-				is_navigation_link = false,
-				position = pos,
-				scan = opts.scan or false,
-				needs_pos_rsrv = opts.needs_pos_rsrv or false,
-				enabled = true,
-				execute_on_startup = false,
-				rotation = rot,
-				base_delay = 0,
-				action_duration_min = 0,
-				search_position = pos,
-				use_instigator = true,
-				trigger_times = 0,
-				trigger_on = "none",
-				search_distance = 0,
-				so_action = opts.so_action or "none",
-				path_stance = opts.path_stance or "hos",
-				path_haste = "run",
-				repeatable = false,
-				attitude = "engage",
-				interval = opts.interval or -1,
-				action_duration_max = 0,
-				align_rotation = opts.align_rotation or false,
-				pose = opts.pose or "none",
-				forced = opts.forced or false,
-				base_chance = 1,
-				interaction_voice = "none",
-				SO_access = opts.SO_access or "512", -- default to sniper
-				chance_inc = 0,
-				interrupt_dmg = opts.interrupt_dmg or 1,
-				interrupt_objective = false,
-				on_executed = opts.on_executed or {},
-				interrupt_dis = opts.interrupt_dis or 1,
-				patrol_path = "none",
-			},
-		}
-	end
-
-	function restoration:gen_areatrigger(id, name, pos, rot, opts)
-		opts = opts or {}
-		return {
-			id = id,
-			editor_name = name,
-			class = "ElementAreaTrigger",
-			module = "CoreElementArea",
-			values = {
-				execute_on_startup = false,
-				trigger_times = opts.trigger_times or 1,
-				on_executed = opts.on_executed or {},
-				base_delay = opts.base_delay or 0,
-				position = pos,
-				rotation = rot,
-				enabled = true,
-				interval = 0.1,
-				trigger_on = "on_enter",
-				instigator = "player",
-				shape_type = opts.shape_type or "box",
-				width = opts.width or 500,
-				depth = opts.depth or 500,
-				height = opts.height or 500,
-				radius = opts.radius or 250,
-				spawn_unit_elements = {},
-				amount = opts.amount or "1",
-				instigator_name = "",
-				use_disabled_shapes = false,
-				substitute_object = "",
-			},
-		}
-	end
-
-	function restoration:gen_dummytrigger(id, name, pos, rot, opts)
-		opts = opts or {}
-		return {
-			id = id,
-			editor_name = name,
-			class = "ElementEnemyDummyTrigger",
-			values = {
-				execute_on_startup = false,
-				trigger_times = opts.trigger_times or 0,
-				elements = opts.elements or {},
-				on_executed = opts.on_executed or {},
-				base_delay = opts.base_delay or 0,
-				position = pos,
-				rotation = rot,
-				enabled = true,
-				event = opts.event or "spawn"
-			},
-		}
-	end
-
-	function restoration:gen_missionscript(id, name, opts)
-		opts = opts or {}
-		return {
-			id = id,
-			editor_name = name,
-			class = "MissionScriptElement",
-			module = "CoreMissionScriptElement",
-			values = {
-				execute_on_startup = false,
-				trigger_times = opts.trigger_times or 0,
-				on_executed = opts.on_executed or {},
-				base_delay = opts.base_delay or 0,
-				enabled = opts.enabled or false
-			},
-		}
-	end
-
-	function restoration:gen_toggleelement(id, name, opts)
-		opts = opts or {}
-		return {
-			id = id,
-			editor_name = name,
-			class = "ElementToggle",
-			module = "CoreElementToggle",
-			values = {
-				execute_on_startup = false,
-				trigger_times = opts.trigger_times or 0,
-				set_trigger_times = opts.set_trigger_times or -1,
-				elements = opts.elements or {},
-				on_executed = opts.on_executed or {},
-				base_delay = opts.base_delay or 0,
-				enabled = opts.enabled or false,
-				toggle = opts.toggle or "on"
-			},
-		}
-	end
-
-	function restoration:gen_pointofnoreturn(id, name, pos, rot, opts)
-		opts = opts or {}
-		return {
-			id = id,
-			editor_name = name,
-			class = "ElementPointOfNoReturn",
-			values = {
-				execute_on_startup = false,
-				trigger_times = opts.trigger_times or 1,
-				elements = opts.elements or {},
-				elements_in_instances = opts.elements_in_instances or nil,
-				on_executed = opts.on_executed or {},
-				base_delay = opts.base_delay or 0,
-				tweak_id = "noreturn",
-				time_balance_mul = opts.time_balance_mul or nil,
-				time_easy = opts.time_easy or 0,
-				time_normal = opts.time_normal or 0,
-				time_hard = opts.time_hard or 0,
-				time_overkill = opts.time_overkill or 0,
-				time_overkill_145 = opts.time_overkill_145 or 0,
-				time_easy_wish = opts.time_easy_wish or 0,
-				time_overkill_290 = opts.time_overkill_290 or 0,
-				time_sm_wish = opts.time_sm_wish or 0,
-				position = pos,
-				rotation = rot,
-				enabled = opts.enabled or false
-			},
-		}
-	end
-
-	function restoration:gen_dialogue(id, name, opts)
-		opts = opts or {}
-		return {
-			id = id,
-			editor_name = name,
-			class = "ElementDialogue",
-			values = {
-				execute_on_startup = false,
-				trigger_times = opts.trigger_times or 0,
-				on_executed = opts.on_executed or {},
-				base_delay = opts.base_delay or 0,
-				dialogue = opts.dialogue or "none",
-				enabled = true,
-				can_not_be_muted = opts.can_not_be_muted or false,
-				execute_on_executed_when_done = opts.execute_on_executed_when_done or false,
-				play_on_player_instigator_only = opts.play_on_player_instigator_only or false,
-				use_instigator = opts.use_instigator or false,
-				use_position = opts.use_position or false
-			},
-		}
-	end
-
-	function restoration:gen_preferedadd(id, name, opts)
-		opts = opts or {}
-		return {
-			id = id,
-			editor_name = name,
-			class = "ElementEnemyPreferedAdd",
-			values = {
-				execute_on_startup = false,
-				base_delay = opts.base_delay or 0,
-				trigger_times = opts.trigger_times or 0,
-				spawn_groups = opts.spawn_groups or {},
-				on_executed = opts.on_executed or {},
-				enabled = true
-			},
-		}
-	end
-
-	function restoration:gen_smokeandnades(id, name, pos, rot, opts)
-		opts = opts or {}
-		return {
-			id = id,
-			editor_name = name,
-			class = "ElementSmokeGrenade",
-			values = {
-				execute_on_startup = false,
-				position = pos,
-				rotation = rot,
-				enabled = true,
-				base_delay = opts.base_delay or 0,
-				duration = opts.duration or 0,
-				effect_type = opts.effect_type or "smoke",
-				ignore_control = true,
-				immediate = true,
-				on_executed = opts.on_executed or {},
-				trigger_times = opts.trigger_times or 0
-			},
-		}
-	end
-
-	function restoration:gen_dynamicfilter(id, name, pos, rot, opts)
-		opts = opts or {}
-		return {
-			id = id,
-			editor_name = name,
-			class = "ElementFilter",
-			values = {
-				execute_on_startup = false,
-				trigger_times = opts.trigger_times or 0,
-				on_executed = opts.on_executed or {},
-				base_delay = opts.base_delay or 0,
-				mode_assault = true,
-				mode_control = true,
-				difficulty_easy = opts.difficulty_easy or false,
-				difficulty_normal = opts.difficulty_normal or false,
-				difficulty_hard = opts.difficulty_hard or false,
-				difficulty_overkill = opts.difficulty_overkill or false,
-				difficulty_overkill_145 = opts.difficulty_overkill_145 or false,
-				difficulty_easy_wish = opts.difficulty_easy_wish or false,
-				difficulty_overkill_290 = opts.difficulty_overkill_290 or false,
-				difficulty_sm_wish = opts.difficulty_sm_wish or false,
-				player_1 = opts.player_1 or false,
-				player_2 = opts.player_2 or false,
-				player_3 = opts.player_3 or false,
-				player_4 = opts.player_4 or false,
-				platform_pc_only = false,
-				platform_win32 = true,
-				--resmod for consoles when?
-				platform_ps3 = false,
-				platform_ps4_only = false,
-				platform_xb1_only = false,
-				position = pos,
-				rotation = rot,
-				enabled = opts.enabled or false
-			},
-		}
-	end
-
-	function restoration:gen_sotrigger(id, name, pos, rot, opts)
-		opts = opts or {}
-		return {
-			id = id,
-			editor_name = name,
-			class = "ElementSpecialObjectiveTrigger",
-			values = {
-				execute_on_startup = false,
-				trigger_times = opts.trigger_times or 0,
-				elements = opts.elements or {},
-				on_executed = opts.on_executed or {},
-				base_delay = opts.base_delay or 0,
-				position = pos,
-				rotation = rot,
-				enabled = true,
-				event = opts.event or "complete"
-			},
-		}
-	end
-
-	function restoration:objecteditor(id, name, pos, rot, opts)
-		opts = opts or {}
-		return {
-			id = id,
-			editor_name = name,
-			class = "ElementUnitSequence",
-			module = "CoreElementUnitSequence",
-			values = {
-				execute_on_startup = false,
-				trigger_times = opts.trigger_times or 0,
-				trigger_list = opts.trigger_list or {},
-				on_executed = opts.on_executed or {},
-				base_delay = opts.base_delay or 0,
-				position = pos,
-				rotation = rot,
-				enabled = true
-			},
-		}
-	end
-
-	function restoration:gen_operator(id, name, pos, rot, opts)
-		opts = opts or {}
-		return {
-			id = id,
-			editor_name = name,
-			class = "ElementOperator",
-			module = "CoreElementOperator",
-			values = {
-				execute_on_startup = false,
-				trigger_times = opts.trigger_times or 0,
-				on_executed = opts.on_executed or {},
-				base_delay = opts.base_delay or 0,
-				position = pos,
-				rotation = rot,
-				enabled = opts.enabled or false,
-				operation = opts.operation or "add",
-				elements = opts.elements or {},
-			},
-		}
-	end
-
-	function restoration:gen_instance_input_event(id, name, pos, rot, opts)
-		opts = opts or {}
-		return {
-			id = id,
-			editor_name = name,
-			class = "ElementInstanceInputEvent",
-			module = "CoreElementInstance",
-			values = {
-				execute_on_startup = false,
-				trigger_times = opts.trigger_times or 0,
-				on_executed = opts.on_executed or {},
-				base_delay = opts.base_delay or 0,
-				position = pos,
-				rotation = rot,
-				enabled = opts.enabled or false,
-				instance = nil,  -- string (prefer event_list)
-				event = nil,  -- string (prefer event_list)
-				event_list = opts.event_list or {},
-			},
-		}
-	end
-
-	function restoration:gen_instance_input(id, name, pos, rot, opts)
-		opts = opts or {}
-		return {
-			id = id,
-			editor_name = name,
-			class = "ElementInstanceInput",
-			module = "CoreElementInstance",
-			values = {
-				execute_on_startup = false,
-				trigger_times = opts.trigger_times or 0,
-				on_executed = opts.on_executed or {},
-				base_delay = opts.base_delay or 0,
-				position = pos,
-				rotation = rot,
-				enabled = opts.enabled or false,
-				instance_name = opts.instance_name or "",
-				event = opts.event or "",
-			},
-		}
-	end
-
-	function restoration:log(...)
-		if self.logging then
-			log("[StreamlinedHeistingAI] " .. table.concat({...}, " "))
+	restoration.loaded_elements = false
+	if self._mission_script_add == nil then
+		local level_id = Global.game_settings and Global.game_settings.level_id
+		if level_id then
+			self._mission_script_add = self:require("mission_script_add/" .. level_id:gsub('_skip1$', ''):gsub('_skip2$', ''):gsub("_night$", ""):gsub("_day$", "")) or false
 		end
 	end
+	return self._mission_script_add
+end
 
-	function restoration:warn(...)
-		log("[StreamlinedHeistingAI][Warning] " .. table.concat({...}, " "))
-	end
+function restoration:gen_dummy(id, name, pos, rot, opts)
+	opts = opts or {}
+	return {
+		id = id,
+		editor_name = name,
+		class = "ElementSpawnEnemyDummy",
+		values = {
+			execute_on_startup = opts.execute_on_startup or false,
+			participate_to_group_ai = opts.participate_to_group_ai or false,
+			position = pos,
+			force_pickup = opts.force_pickup or "none",
+			voice = opts.voice or 0,
+			enemy = opts.enemy or "units/payday2/characters/ene_swat_1/ene_swat_1",
+			enemy_table = opts.enemy_table or nil, --possible enemy tables to prevent crashing
+			trigger_times = opts.trigger_times or 0,
+			spawn_action = opts.spawn_action or "none",
+			accessibility = opts.accessibility or "any",
+			on_executed = opts.on_executed or {},
+			rotation = rot,
+			team = opts.team or "default",
+			base_delay = opts.base_delay or 0,
+			enabled = opts.enabled or false,
+			amount = opts.amount or 0,
+			interval = opts.interval or 5,
+		},
+	}
+end
 
-	function restoration:error(...)
-		log("[StreamlinedHeistingAI][Error] " .. table.concat({...}, " "))
+function restoration:gen_spawngroup(id, name, elements, interval)
+	return {
+		id = id,
+		editor_name = name,
+		class = "ElementSpawnEnemyGroup",
+		values = {
+			on_executed = {},
+			trigger_times = 0,
+			base_delay = 0,
+			ignore_disabled = false,
+			amount = 0,
+			spawn_type = "ordered",
+			team = "default",
+			execute_on_startup = false,
+			enabled = true,
+			preferred_spawn_groups = {
+				"tac_shield_wall_charge",
+				"FBI_spoocs",
+				"tac_tazer_charge",
+				"tac_tazer_flanking",
+				"tac_shield_wall",
+				"tac_swat_rifle_flank",
+				"tac_shield_wall_ranged",
+				"tac_bull_rush",
+			},
+			elements = elements,
+			interval = interval or 0,
+		},
+	}
+end
+
+function restoration:gen_so(id, name, pos, rot, opts)
+	opts = opts or {}
+	return {
+		id = id,
+		editor_name = name,
+		class = "ElementSpecialObjective",
+		values = {
+			path_style = opts.path_style or "destination",
+			align_position = opts.align_position or false,
+			ai_group = "enemies",
+			is_navigation_link = false,
+			position = pos,
+			scan = opts.scan or false,
+			needs_pos_rsrv = opts.needs_pos_rsrv or false,
+			enabled = true,
+			execute_on_startup = false,
+			rotation = rot,
+			base_delay = 0,
+			action_duration_min = 0,
+			search_position = pos,
+			use_instigator = true,
+			trigger_times = 0,
+			trigger_on = "none",
+			search_distance = 0,
+			so_action = opts.so_action or "none",
+			path_stance = opts.path_stance or "hos",
+			path_haste = "run",
+			repeatable = false,
+			attitude = "engage",
+			interval = opts.interval or -1,
+			action_duration_max = 0,
+			align_rotation = opts.align_rotation or false,
+			pose = opts.pose or "none",
+			forced = opts.forced or false,
+			base_chance = 1,
+			interaction_voice = "none",
+			SO_access = opts.SO_access or "512", -- default to sniper
+			chance_inc = 0,
+			interrupt_dmg = opts.interrupt_dmg or 1,
+			interrupt_objective = false,
+			on_executed = opts.on_executed or {},
+			interrupt_dis = opts.interrupt_dis or 1,
+			patrol_path = "none",
+		},
+	}
+end
+
+function restoration:gen_areatrigger(id, name, pos, rot, opts)
+	opts = opts or {}
+	return {
+		id = id,
+		editor_name = name,
+		class = "ElementAreaTrigger",
+		module = "CoreElementArea",
+		values = {
+			execute_on_startup = false,
+			trigger_times = opts.trigger_times or 1,
+			on_executed = opts.on_executed or {},
+			base_delay = opts.base_delay or 0,
+			position = pos,
+			rotation = rot,
+			enabled = true,
+			interval = 0.1,
+			trigger_on = "on_enter",
+			instigator = "player",
+			shape_type = opts.shape_type or "box",
+			width = opts.width or 500,
+			depth = opts.depth or 500,
+			height = opts.height or 500,
+			radius = opts.radius or 250,
+			spawn_unit_elements = {},
+			amount = opts.amount or "1",
+			instigator_name = "",
+			use_disabled_shapes = false,
+			substitute_object = "",
+		},
+	}
+end
+
+function restoration:gen_dummytrigger(id, name, pos, rot, opts)
+	opts = opts or {}
+	return {
+		id = id,
+		editor_name = name,
+		class = "ElementEnemyDummyTrigger",
+		values = {
+			execute_on_startup = false,
+			trigger_times = opts.trigger_times or 0,
+			elements = opts.elements or {},
+			on_executed = opts.on_executed or {},
+			base_delay = opts.base_delay or 0,
+			position = pos,
+			rotation = rot,
+			enabled = true,
+			event = opts.event or "spawn"
+		},
+	}
+end
+
+function restoration:gen_missionscript(id, name, opts)
+	opts = opts or {}
+	return {
+		id = id,
+		editor_name = name,
+		class = "MissionScriptElement",
+		module = "CoreMissionScriptElement",
+		values = {
+			execute_on_startup = false,
+			trigger_times = opts.trigger_times or 0,
+			on_executed = opts.on_executed or {},
+			base_delay = opts.base_delay or 0,
+			enabled = opts.enabled or false
+		},
+	}
+end
+
+function restoration:gen_toggleelement(id, name, opts)
+	opts = opts or {}
+	return {
+		id = id,
+		editor_name = name,
+		class = "ElementToggle",
+		module = "CoreElementToggle",
+		values = {
+			execute_on_startup = false,
+			trigger_times = opts.trigger_times or 0,
+			set_trigger_times = opts.set_trigger_times or -1,
+			elements = opts.elements or {},
+			on_executed = opts.on_executed or {},
+			base_delay = opts.base_delay or 0,
+			enabled = opts.enabled or false,
+			toggle = opts.toggle or "on"
+		},
+	}
+end
+
+function restoration:gen_pointofnoreturn(id, name, pos, rot, opts)
+	opts = opts or {}
+	return {
+		id = id,
+		editor_name = name,
+		class = "ElementPointOfNoReturn",
+		values = {
+			execute_on_startup = false,
+			trigger_times = opts.trigger_times or 1,
+			elements = opts.elements or {},
+			elements_in_instances = opts.elements_in_instances or nil,
+			on_executed = opts.on_executed or {},
+			base_delay = opts.base_delay or 0,
+			tweak_id = "noreturn",
+			time_balance_mul = opts.time_balance_mul or nil,
+			time_easy = opts.time_easy or 0,
+			time_normal = opts.time_normal or 0,
+			time_hard = opts.time_hard or 0,
+			time_overkill = opts.time_overkill or 0,
+			time_overkill_145 = opts.time_overkill_145 or 0,
+			time_easy_wish = opts.time_easy_wish or 0,
+			time_overkill_290 = opts.time_overkill_290 or 0,
+			time_sm_wish = opts.time_sm_wish or 0,
+			position = pos,
+			rotation = rot,
+			enabled = opts.enabled or false
+		},
+	}
+end
+
+function restoration:gen_dialogue(id, name, opts)
+	opts = opts or {}
+	return {
+		id = id,
+		editor_name = name,
+		class = "ElementDialogue",
+		values = {
+			execute_on_startup = false,
+			trigger_times = opts.trigger_times or 0,
+			on_executed = opts.on_executed or {},
+			base_delay = opts.base_delay or 0,
+			dialogue = opts.dialogue or "none",
+			enabled = true,
+			can_not_be_muted = opts.can_not_be_muted or false,
+			execute_on_executed_when_done = opts.execute_on_executed_when_done or false,
+			play_on_player_instigator_only = opts.play_on_player_instigator_only or false,
+			use_instigator = opts.use_instigator or false,
+			use_position = opts.use_position or false
+		},
+	}
+end
+
+function restoration:gen_preferedadd(id, name, opts)
+	opts = opts or {}
+	return {
+		id = id,
+		editor_name = name,
+		class = "ElementEnemyPreferedAdd",
+		values = {
+			execute_on_startup = false,
+			base_delay = opts.base_delay or 0,
+			trigger_times = opts.trigger_times or 0,
+			spawn_groups = opts.spawn_groups or {},
+			on_executed = opts.on_executed or {},
+			enabled = true
+		},
+	}
+end
+
+function restoration:gen_smokeandnades(id, name, pos, rot, opts)
+	opts = opts or {}
+	return {
+		id = id,
+		editor_name = name,
+		class = "ElementSmokeGrenade",
+		values = {
+			execute_on_startup = false,
+			position = pos,
+			rotation = rot,
+			enabled = true,
+			base_delay = opts.base_delay or 0,
+			duration = opts.duration or 0,
+			effect_type = opts.effect_type or "smoke",
+			ignore_control = true,
+			immediate = true,
+			on_executed = opts.on_executed or {},
+			trigger_times = opts.trigger_times or 0
+		},
+	}
+end
+
+function restoration:gen_dynamicfilter(id, name, pos, rot, opts)
+	opts = opts or {}
+	return {
+		id = id,
+		editor_name = name,
+		class = "ElementFilter",
+		values = {
+			execute_on_startup = false,
+			trigger_times = opts.trigger_times or 0,
+			on_executed = opts.on_executed or {},
+			base_delay = opts.base_delay or 0,
+			mode_assault = true,
+			mode_control = true,
+			difficulty_easy = opts.difficulty_easy or false,
+			difficulty_normal = opts.difficulty_normal or false,
+			difficulty_hard = opts.difficulty_hard or false,
+			difficulty_overkill = opts.difficulty_overkill or false,
+			difficulty_overkill_145 = opts.difficulty_overkill_145 or false,
+			difficulty_easy_wish = opts.difficulty_easy_wish or false,
+			difficulty_overkill_290 = opts.difficulty_overkill_290 or false,
+			difficulty_sm_wish = opts.difficulty_sm_wish or false,
+			player_1 = opts.player_1 or false,
+			player_2 = opts.player_2 or false,
+			player_3 = opts.player_3 or false,
+			player_4 = opts.player_4 or false,
+			platform_pc_only = false,
+			platform_win32 = true,
+			--resmod for consoles when?
+			platform_ps3 = false,
+			platform_ps4_only = false,
+			platform_xb1_only = false,
+			position = pos,
+			rotation = rot,
+			enabled = opts.enabled or false
+		},
+	}
+end
+
+function restoration:gen_sotrigger(id, name, pos, rot, opts)
+	opts = opts or {}
+	return {
+		id = id,
+		editor_name = name,
+		class = "ElementSpecialObjectiveTrigger",
+		values = {
+			execute_on_startup = false,
+			trigger_times = opts.trigger_times or 0,
+			elements = opts.elements or {},
+			on_executed = opts.on_executed or {},
+			base_delay = opts.base_delay or 0,
+			position = pos,
+			rotation = rot,
+			enabled = true,
+			event = opts.event or "complete"
+		},
+	}
+end
+
+function restoration:objecteditor(id, name, pos, rot, opts)
+	opts = opts or {}
+	return {
+		id = id,
+		editor_name = name,
+		class = "ElementUnitSequence",
+		module = "CoreElementUnitSequence",
+		values = {
+			execute_on_startup = false,
+			trigger_times = opts.trigger_times or 0,
+			trigger_list = opts.trigger_list or {},
+			on_executed = opts.on_executed or {},
+			base_delay = opts.base_delay or 0,
+			position = pos,
+			rotation = rot,
+			enabled = true
+		},
+	}
+end
+
+function restoration:gen_operator(id, name, pos, rot, opts)
+	opts = opts or {}
+	return {
+		id = id,
+		editor_name = name,
+		class = "ElementOperator",
+		module = "CoreElementOperator",
+		values = {
+			execute_on_startup = false,
+			trigger_times = opts.trigger_times or 0,
+			on_executed = opts.on_executed or {},
+			base_delay = opts.base_delay or 0,
+			position = pos,
+			rotation = rot,
+			enabled = opts.enabled or false,
+			operation = opts.operation or "add",
+			elements = opts.elements or {},
+		},
+	}
+end
+
+function restoration:gen_instance_input_event(id, name, pos, rot, opts)
+	opts = opts or {}
+	return {
+		id = id,
+		editor_name = name,
+		class = "ElementInstanceInputEvent",
+		module = "CoreElementInstance",
+		values = {
+			execute_on_startup = false,
+			trigger_times = opts.trigger_times or 0,
+			on_executed = opts.on_executed or {},
+			base_delay = opts.base_delay or 0,
+			position = pos,
+			rotation = rot,
+			enabled = opts.enabled or false,
+			instance = nil,  -- string (prefer event_list)
+			event = nil,  -- string (prefer event_list)
+			event_list = opts.event_list or {},
+		},
+	}
+end
+
+function restoration:gen_instance_input(id, name, pos, rot, opts)
+	opts = opts or {}
+	return {
+		id = id,
+		editor_name = name,
+		class = "ElementInstanceInput",
+		module = "CoreElementInstance",
+		values = {
+			execute_on_startup = false,
+			trigger_times = opts.trigger_times or 0,
+			on_executed = opts.on_executed or {},
+			base_delay = opts.base_delay or 0,
+			position = pos,
+			rotation = rot,
+			enabled = opts.enabled or false,
+			instance_name = opts.instance_name or "",
+			event = opts.event or "",
+		},
+	}
+end
+
+function restoration:log(...)
+	if self.logging then
+		log("[StreamlinedHeistingAI] " .. table.concat({...}, " "))
 	end
+end
+
+function restoration:warn(...)
+	log("[StreamlinedHeistingAI][Warning] " .. table.concat({...}, " "))
+end
+
+function restoration:error(...)
+	log("[StreamlinedHeistingAI][Error] " .. table.concat({...}, " "))
+end
 

--- a/Core.lua
+++ b/Core.lua
@@ -828,6 +828,23 @@ function restoration:send_sync_environment(to)
 end
 
 restoration.loaded_elements = false
+restoration.enable_mission_script_patches_in_editor = true
+restoration.enable_mission_script_patches_on_spawner_maps = true
+
+function restoration:disable_mission_script_patches()
+	if not self.enable_mission_script_patches_in_editor then
+		if Global.editor_mode then
+			return true
+		end
+	end
+
+	if not self.enable_mission_script_patches_on_spawner_maps then
+		local level_id = Global.game_settings and Global.game_settings.level_id
+		if level_id == "modders_devmap" or level_id == "Enemy_Spawner" then
+			return true
+		end
+	end
+end
 
 --Stealing this from SH cause it's way better
 function restoration:require(file)
@@ -850,12 +867,10 @@ end
 function restoration:instance_script_patches()
 	if self._instance_script_patches == nil then
 		local level_id = Global.game_settings and Global.game_settings.level_id
-
 		if level_id then
 			self._instance_script_patches = self:require("instance_script/" .. level_id:gsub('_skip1$', ''):gsub('_skip2$', ''):gsub("_night$", ""):gsub("_day$", "")) or false
 		end
 	end
-
 	return self._instance_script_patches
 end
 

--- a/Core.lua
+++ b/Core.lua
@@ -831,7 +831,7 @@ restoration.loaded_elements = false
 
 --Stealing this from SH cause it's way better
 function restoration:require(file)
-	local path = ModPath .. "req/" .. file .. ".lua"
+	local path = self:GetPath() .. "req/" .. file .. ".lua"
 	return io.file_is_readable(path) and blt.vm.dofile(path)
 end
 

--- a/lua/sc/core/coreworldinstancemanager.lua
+++ b/lua/sc/core/coreworldinstancemanager.lua
@@ -323,6 +323,9 @@ function CoreWorldInstanceManager:_get_instance_mission_data(path)
 	return result
 end
 
+if restoration:disable_mission_script_patches() then
+	return
+end
 
 local instance_script_patches = restoration:instance_script_patches()
 if not instance_script_patches then

--- a/lua/sc/managers/mission/elementpointofnoreturn.lua
+++ b/lua/sc/managers/mission/elementpointofnoreturn.lua
@@ -1,13 +1,11 @@
 local difficulty = Global.game_settings and Global.game_settings.difficulty or "normal"
 local to_replace_key = "time_" .. difficulty
 
-Hooks:PostHook(ElementPointOfNoReturn, "init", "res_init", function(self)
-	self._values.original_time = self._values[to_replace_key] or self._values.time_hard
-end)
-
 Hooks:PreHook(ElementPointOfNoReturn, "operation_add", "res_operation_add", function(self)
+	self._values.original_time = self._values[to_replace_key] or self._values.time_hard
+	self._values.time_balance_mul = self._values.time_balance_mul or { 1, 1, 1, 1, }
 	if self._values.original_time then
-		local balance_mul = self._values.time_balance_mul or { 1, 1, 1, 1, }
+		local balance_mul = self._values.time_balance_mul
 		local final_mul = managers.groupai:state():_get_balancing_multiplier(balance_mul) or balance_mul[#balance_mul] or 1
 		self._values[to_replace_key] = self._values.original_time * final_mul
 	end

--- a/lua/sc/managers/missionmanager.lua
+++ b/lua/sc/managers/missionmanager.lua
@@ -1,148 +1,328 @@
---[[
-local level_id = Global.game_settings and Global.game_settings.level_id
-if Global.editor_mode then
+if restoration:disable_mission_script_patches() then
 	return
 end
-]]--
--- Add custom mission script changes and triggers for specific levels
--- Execution of mission scripts can trigger reinforce locations (trigger that has just a name disables previously enabled reinforcement with that id)
--- Mission script elements can be disabled or enabled
--- From Streamlined Heisting
 
-local mission_script_elements = restoration:mission_script_patches()
 local mission_add = restoration:mission_script_add()
-if not mission_script_elements then
-	return
-end
-
-
 if mission_add then
 	-- Load the elements from the file
-	Hooks:PreHook(MissionScript, "init", "eclipse_missionmanager_init", function(self, data)
+	Hooks:PreHook(MissionScript, "init", "res_init", function(self, data)
 		if not restoration.loaded_elements and data.name == "default" then
-			for _,element in ipairs(mission_add.elements) do
-                table.insert(data.elements, element)
-            end
 			restoration.loaded_elements = true
+			for _, element in ipairs(mission_add.elements) do
+				table.insert(data.elements, element)
+			end
 		end
 	end)
 end
 
-Hooks:PreHook(MissionManager, "_activate_mission", "sh__activate_mission", function (self)
-	for element_id, data in pairs(mission_script_elements) do
-		local element = self:get_element_by_id(element_id)
-		if not element then
-		else
-			-- Check if this element is supposed to trigger reinforce points
-			if data.reinforce then
-				Hooks:PostHook(element, "on_executed", "sh_on_executed_reinforce_" .. element_id, function ()
-					for _, v in pairs(data.reinforce) do
-						managers.groupai:state():set_area_min_police_force(v.name, v.force, v.position)
-					end
-				end)
-			end
+local is_pro_job = Global.game_settings and Global.game_settings.one_down
+local function try_insert(v, e)
+	if not table.contains(v, e) then
+		table.insert(v, e)
+	end
+end
 
-			-- Check if this element is supposed to trigger a difficulty change
-			if data.difficulty then
-				Hooks:PostHook(element, "on_executed", "sh_on_executed_difficulty_" .. element_id, function ()
-					managers.groupai:state():set_difficulty(data.difficulty)
-				end)
-			end
+-- Add custom mission script changes and triggers for specific levels
+-- Mission script elements can be disabled or enabled
+-- From Streamlined Heisting
+-- Add custom mission script changes and triggers for specific levels
+MissionManager.mission_script_patch_funcs = {}
 
-			-- Check if this element has custom values set
-			if data.values then
-				for k, v in pairs(data.values) do
-					element._values[k] = v
-					
-					--making sure that changing chance values work
-					if k == "chance" and element.chance_operation_set_chance then
-						element:chance_operation_set_chance(v)
-					end
-					--making sure that changing spawn_action values work (thanks miki)
-					if k == "spawn_action" then
-						local spawn_action = table.index_of(CopActionAct._act_redirects.enemy_spawn, v)
+-- Replace specified values on this element
+function MissionManager.mission_script_patch_funcs.values(self, element, data)
+	for k, v in pairs(data) do
+		element._values[k] = v
+		restoration:log("%s value \"%s\" has been set to \"%s\"", element:editor_name(), k, tostring(v))
+	end
 
-						element._values.spawn_action = spawn_action ~= -1 and spawn_action or nil
-					end
-					--Either use enemy table or self value so randomized enemies can be possible (thanks miki once again)
-					if k == "enemy" and type(v) == "table" then
-						element._enemy_table = v
-						element._values.enemy = nil
-					end
+	-- Making sure that changing spawn_action values work (thanks Miki)
+	if data.spawn_action then
+		local spawn_action = table.index_of(CopActionAct._act_redirects.enemy_spawn, v)
+		element._values.spawn_action = spawn_action ~= -1 and spawn_action or nil
+	end
+
+	-- Handle enemy tables (Idstring'ing a table is not ideal)
+	if type(data.enemy) == "table" then
+		element._enemy_table = v
+		element._values.enemy = nil
+	end
+
+	-- Below from ASS
+	if data.chance and element._chance then
+		element._chance = data.chance
+	end
+
+	-- We love spawn group elements
+	local group_data = element._group_data
+	if group_data then
+		group_data.amount = data.amount or group_data.amount
+		group_data.spawn_type = data.spawn_type or group_data.spawn_type
+		if data.ignore_disabled ~= nil then
+			group_data.ignore_disabled = data.ignore_disabled
+		end
+	end
+end
+
+-- Modify the element's on executed
+-- Can add new on executed elements, modify delays of existing on executed elements, or remove them
+function MissionManager.mission_script_patch_funcs.on_executed(self, element, data)
+	for _, v in pairs(data) do
+		local new_element = self:get_element_by_id(v.id)
+		if new_element then
+			local val, i = table.find_value(element._values.on_executed, function(val) return val.id == v.id end)
+			if v.remove then
+				if val then
+					table.remove(element._values.on_executed, i)
+					restoration:log("Removed element %s from on_executed of %s", new_element:editor_name(), element:editor_name())
 				end
+			elseif val then
+				val.delay = v.delay or 0
+				val.delay_rand = v.delay_rand or 0
+				restoration:log("Modified element %s in on_executed of %s", new_element:editor_name(), element:editor_name())
+			else
+				table.insert(element._values.on_executed, v)
+				restoration:log("Added element %s to on_executed of %s", new_element:editor_name(), element:editor_name())
 			end
-			
-			
-		--check if this element is supposed to trigger endless assault
-		if data.hunt then
-			Hooks:PostHook(element, "on_executed", "sh_on_executed_hunt_" .. element_id, function ()
-				managers.groupai:state():set_wave_mode(data.hunt and "hunt" or "besiege")
-			end)
-		end	
-			
-		--Check if this element is supposed to call in Bravos
-		if data.spawn_bravos then
-			if restoration then
-				restoration.always_bravos = true
+		else
+			restoration:error("Mission script element %u could not be found", v.id)
+		end
+	end
+
+	-- Below from ASS, handles ElementRandom elements
+	if element._original_on_executed then
+		element._original_on_executed = clone(element._values.on_executed)
+	end
+end
+
+-- Add a prehook to this specific element's on executed
+function MissionManager.mission_script_patch_funcs.pre_func(self, element, data)
+	Hooks:PreHook(element, "on_executed", "res_on_executed_pre_func_" .. element:id(), data)
+	restoration:log("%s hooked as pre function call trigger", element:editor_name())
+end
+
+-- Add a posthook to this specific element's on executed
+function MissionManager.mission_script_patch_funcs.func(self, element, data)
+	Hooks:PostHook(element, "on_executed", "res_on_executed_func_" .. element:id(), data)
+	restoration:log("%s hooked as function call trigger", element:editor_name())
+end
+
+-- Execution of mission script elements can trigger reinforce locations
+-- Trigger that has just a name disables previously enabled reinforcement with that id
+function MissionManager.mission_script_patch_funcs.reinforce(self, element, data)
+	if Network:is_client() then
+		return
+	end
+	Hooks:PostHook(element, "on_executed", "res_on_executed_reinforce_" .. element:id(), function()
+		restoration:log("%s executed, toggled %u reinforce point(s)", element:editor_name(), #data)
+		for _, v in pairs(data) do
+			managers.groupai:state():set_area_min_police_force(v.name, v.force, v.position)
+		end
+	end)
+	restoration:log("%s hooked as reinforce trigger for %u area(s)", element:editor_name(), #data)
+end
+
+-- Set GroupAI difficulty when this element is executed
+-- Likely not needed since Res uses its own GroupAI difficulty progression that mostly ignores mission scripting (including this patch function)
+function MissionManager.mission_script_patch_funcs.difficulty(self, element, data)
+	if Network:is_client() then
+		return
+	end
+	Hooks:PostHook(element, "on_executed", "res_on_executed_difficulty_" .. element:id(), function()
+		restoration:log("%s executed, set difficulty to %.2g", element:editor_name(), data)
+		managers.groupai:state():set_difficulty(data)
+	end)
+	restoration:log("%s hooked as difficulty change trigger", element:editor_name())
+end
+
+-- Set flashlights on or off when this element is executed
+function MissionManager.mission_script_patch_funcs.flashlight(self, element, data)
+	local function set_flashlights()
+		managers.game_play_central:set_flashlights_on(data.flashlight)
+	end
+	Hooks:PostHook(element, "on_executed", "res_on_executed_flashlight_" .. element_id, set_flashlights)
+	Hooks:PostHook(element, "client_on_executed", "res_client_on_executed_flashlight_" .. element_id, set_flashlights)
+	restoration:log("%s hooked as flashlight state trigger", element:editor_name())
+end
+
+-- Modify the preferred groups of spawn group elements
+function MissionManager.mission_script_patch_funcs.groups(self, element, data)
+	if Network:is_client() then
+		return
+	end
+	local new_groups = table.list_to_set(element._values.preferred_spawn_groups)
+	for group_name, enabled in pairs(data) do
+		new_groups[group_name] = enabled or nil
+	end
+	element._values.preferred_spawn_groups = table.map_keys(new_groups)
+	restoration:log("Changed %u preferred group(s) of %s", table.size(data), element:editor_name())
+end
+
+function MissionManager.mission_script_patch_funcs.ai_area(self, element, data)
+	Hooks:PostHook(element, "on_executed", "res_on_executed_ai_area_" .. element:id(), function()
+		restoration:log("%s executed, creating %d AI area(s)", element:editor_name(), #data)
+		for _, nav_segs in ipairs(data) do
+			local area_pos = Vector3()
+			for _, nav_seg_id in ipairs(nav_segs) do
+				local nav_seg = managers.navigation._nav_segments[nav_seg_id]
+				if not nav_seg then
+					restoration:error("Nav segment %u could not be found", nav_seg_id)
+					return
+				end
+				mvector3.add_scaled(area_pos, nav_seg.pos, 1 / #nav_segs)
+			end
+			self._ai_area_id = (self._ai_area_id or 10000) + 1
+			managers.groupai:state():add_area(self._ai_area_id, nav_segs, area_pos)
+		end
+	end)
+	restoration:log("%s hooked as AI area trigger", element:editor_name())
+end
+
+-- Turn Bravos on or off outside of point of no returns
+-- Includes handling for Bravos mutator if active
+function MissionManager.mission_script_patch_funcs.spawn_bravos(self, element, data)
+	Hooks:PostHook(element, "on_executed", "res_on_executed_spawn_bravos_" .. element:id(), function()
+		if not data then
+			local bravos_mutator = managers.mutators:get_active_mutator(MutatorBravosOnly)
+			local bravo_replacement = bravos_mutator and bravos_mutator.get_bravo_replacement and bravos_mutator:get_bravo_replacement()
+			if bravo_replacement == "all" then
+				return
 			end
 		end
-			
-		-- Check if this element is supposed to trigger a point of no return
-		local is_pro_job = Global.game_settings and Global.game_settings.one_down
-		if is_pro_job then
-			if data.ponr then
-				local function set_ponr()
-					local ponr_timer_balance_mul = data.ponr_player_mul and managers.groupai:state():_get_balancing_multiplier(data.ponr_player_mul) or 1
-					managers.groupai:state():set_point_of_no_return_timer(data.ponr * ponr_timer_balance_mul, 0)
-				end
-				
-				Hooks:PostHook(element, "on_executed", "sh_on_executed_ponr_" .. element_id, set_ponr)
-				Hooks:PostHook(element, "client_on_executed", "sh_client_on_executed_ponr_" .. element_id, set_ponr)
-			end
-			
-			if data.ponr_end then
-					Hooks:PostHook(element, "on_executed", "eclipse_on_executed_ponr_end_" .. element_id, function()
-						managers.groupai:state():remove_point_of_no_return_timer(0)
-					end)
-					Hooks:PostHook(element, "client_on_executed", "eclipse_client_on_executed_ponr_end_" .. element_id, function()
-						managers.groupai:state():remove_point_of_no_return_timer(0)
-					end)
-				end
-			end	
+		restoration.always_bravos = data
+	end)
+	restoration:log("%s hooked as spawn Bravos trigger", element:editor_name())
+end
 
-			if data.flashlight ~= nil then
-				local function set_flashlights()
-					managers.game_play_central:set_flashlights_on(data.flashlight)
-				end
-				Hooks:PostHook(element, "on_executed", "sh_on_executed_flashlight_" .. element_id, set_flashlights)
-				Hooks:PostHook(element, "client_on_executed", "sh_client_on_executed_flashlight_" .. element_id, set_flashlights)
-			end
-			
-			if data.on_executed then
-				for _, v in pairs(data.on_executed) do
-					local new_element = self:get_element_by_id(v.id)
-					if new_element then
-						local val, i = table.find_value(element._values.on_executed, function (val) return val.id == v.id end)
-						if v.remove then
-							if val then
-								table.remove(element._values.on_executed, i)
-							end
-						elseif val then
-							val.delay = v.delay or 0
-							val.delay_rand = v.delay_rand or 0
-						else
-							table.insert(element._values.on_executed, v)
-						end
-					end
-				end
-			end
+-- Start a point of no return when this element is executed on Pro Jobs
+-- Prefer using actual point of no return elements in mission script add
+function MissionManager.mission_script_patch_funcs.ponr(self, element, data)
+	if not is_pro_job then
+		return
+	end
 
-			if data.func then
-				Hooks:PostHook(element, "on_executed", "sh_on_executed_func_" .. element_id, data.func)
+	local function set_ponr()
+		local balance_mul = data.player_mul or { 1, 1, 1, 1, }
+		local final_mul = managers.groupai:state():_get_balancing_multiplier(balance_mul) or balance_mul[#balance_mul] or 1
+		managers.groupai:state():set_point_of_no_return_timer(data.length * final_mul, 0)
+	end
+	Hooks:PostHook(element, "on_executed", "res_on_executed_ponr_" .. element:id(), set_ponr)
+	Hooks:PostHook(element, "client_on_executed", "res_client_on_executed_ponr_" .. element:id(), set_ponr)
+end
+
+-- End mission script patch point of no return if active when this element is executed on Pro Jobs
+-- Prefer using actual operator elements in mission script add
+function MissionManager.mission_script_patch_funcs.ponr_end(self, element, data)
+	if not is_pro_job then
+		return
+	end
+
+	local function end_ponr()
+		managers.groupai:state():remove_point_of_no_return_timer(0)
+	end
+	Hooks:PostHook(element, "on_executed", "res_on_executed_ponr_end_" .. element:id(), end_ponr)
+	Hooks:PostHook(element, "client_on_executed", "res_client_on_executed_ponr_end_" .. element:id(), end_ponr)
+end
+
+-- From ASS
+-- Used for elements with lists in their values not containing tables
+function MissionManager.mission_script_patch_funcs.modify_list_value(self, element, data)
+	for k, v in pairs(data) do
+		if type(element._values[k]) ~= "table" then
+			restoration:warn("Invalid modify list value name \"%s\" on %s", k, element:editor_name())
+		else
+			for id, enabled in pairs(v) do
+				if enabled then
+					try_insert(element._values[k], id)
+				else
+					table.delete(element._values[k], id)
+				end
 			end
-			
-			if data.pre_func then
-				Hooks:PreHook( element, "on_executed", "sh_pre_func_" .. element_id, data.pre_func )
+		end
+	end
+end
+
+-- From ASS
+-- Used for ElementInstanceInputEvent, core\lib\managers\mission\coreelementinstance
+function MissionManager.mission_script_patch_funcs.event_list(self, element, data)
+	local event_list = element._values.event_list
+	if not event_list then
+		restoration:warn("%s has no event list", element:editor_name())
+		return
+	end
+
+	for instance, event in pairs(data) do
+		local val, i = table.find_value(event_list, function(val) return val.instance == instance end)
+		if event then
+			if val then
+				val.event = event
+			else
+				table.insert(event_list, { instance = instance, event = event, })
+			end
+		elseif val then
+			table.remove(event_list, i)
+		end
+	end
+	restoration:log("Changed %u event(s) in event list of %s", table.size(data), element:editor_name())
+end
+
+-- From ASS
+-- Used for ElementSpecialObjective, lib\managers\mission\elementspecialobjective
+function MissionManager.mission_script_patch_funcs.so_access_filter(self, element, data)
+	element._values.SO_access_original = element._values.SO_access
+	element._values.SO_access = managers.navigation:convert_access_filter_to_number(data)
+	restoration:log("Replaced SO access filter of element %s", element:editor_name())
+end
+
+-- From ASS
+-- Referenced from ElementAiGlobalEvent, lib\managers\mission\elementaiglobalevent
+function MissionManager.mission_script_patch_funcs.hunt(self, element, data)
+	Hooks:PostHook(element, "on_executed", "res_on_executed_hunt_" .. element:id(), function()
+		local groupai_state = managers.groupai:state()
+		local hunt_mode = groupai_state._hunt_mode
+		local flag = (data and not hunt_mode and "hunt") or (hunt_mode and not data and "besiege") or nil
+		if flag then
+			restoration:log("%s executed, setting wave mode to %s", element:editor_name(), flag)
+			if groupai_state:enemy_weapons_hot() then
+				groupai_state:set_wave_mode(flag)
+			else
+				local key = "res_script_patch_hunt_" .. element:id()
+				local events = { "enemy_weapons_hot", }
+				local function clbk()
+					groupai_state:set_wave_mode(flag)
+					groupai_state:remove_listener(key)
+				end
+				groupai_state:add_listener(key, events, clbk)
+			end
+		end
+	end)
+end
+
+Hooks:PreHook(MissionManager, "_activate_mission", "res__activate_mission", function(self)
+	local mission_script_elements = restoration:mission_script_patches()
+	if not mission_script_elements then
+		return
+	end
+
+	for element_id, data in pairs(mission_script_elements) do
+		-- Handle outdated mission script patch PONRs
+		if type(data.ponr) == "number" then
+			data.ponr = {
+				length = data.ponr,
+				player_mul = data.ponr_player_mul,
+			}
+		end
+		data.ponr_player_mul = nil
+
+		local element = self:get_element_by_id(element_id)
+		if not element then
+			restoration:error("Mission script element %u could not be found", element_id)
+		else
+			for patch_name, patch_data in pairs(data) do
+				if self.mission_script_patch_funcs[patch_name] then
+					self.mission_script_patch_funcs[patch_name](self, element, patch_data)
+				else
+					restoration:warn("MissionManager.mission_script_patch_funcs.%s does not exist", patch_name)
+				end
 			end
 		end
 	end

--- a/lua/sc/managers/mutatorsmanager.lua
+++ b/lua/sc/managers/mutatorsmanager.lua
@@ -159,3 +159,10 @@ function MutatorsManager:ProfileSave()
 	file:write(json.encode(Global.mutators.mutator_values))
 	file:close()
 end
+
+-- Get a mutator if it exists and is currently active
+function MutatorsManager:get_active_mutator(mutator_class)
+	if mutator_class and self:is_mutator_active(mutator_class) then
+		return self:get_mutator(mutator_class)
+	end
+end

--- a/req/mission_script/branchbank.lua
+++ b/req/mission_script/branchbank.lua
@@ -12,7 +12,7 @@ local woman_spooc = ((pro_job and difficulty == 8) and "units/pd2_dlc_vip/charac
 
 local ponr = {
 	on_executed = {
-		{ id = 400020, delay = 0, },
+		{ id = 400021, delay = 0, },
 	},
 }
 local spooc = {
@@ -23,16 +23,17 @@ local spooc = {
 }
 
 return {
-	--Pro Job PONR, triggers when the van loot secure is on, should probably trigger when the vault opens instead
-	[104452] = ponr,
-	[104715] = ponr,
-	[104716] = ponr,
+	-- Pro Job PONR
+	-- Triggers once both A) whisper state is off (on alarm), and B) a player has entered the vault
+	[105384] = ponr,
+	[101321] = ponr,
 	-- Special ambush chance increase
 	[103072] = {
 		values = {
 			chance = 75,
 		},
 	},
+	-- Allow special ambush with only 1 player
 	[105563] = {
 		values = {
 			player_1 = true,
@@ -49,17 +50,17 @@ return {
 			amount = 2,
 		},
 	},
-	--Restores unused cloaker ambush spawns+Titan Cloaker on DSPJ
+	-- Restores unused Cloaker ambush spawns + Titan Cloaker on DSPJ
 	[105571] = spooc,
 	[105584] = spooc,
 	[105607] = spooc,
-	--More cop cars arrive on DW+ (similiar to Firestarter Day 3)
+	-- More cop cars arrive on DW+ (similar to Firestarter day 3)
 	[103879] = {
 		values = {
 			amount = copcars,
 		},
 	},
-	--more snipers on high diffs
+	-- More snipers on high difficulties
 	[101200] = {
 		values = {
 			amount = snipers,
@@ -93,7 +94,7 @@ return {
 			{ id = 100364, delay = 0, },
 		},
 	},
-	--Don't repeat the same dialog with chopper deploying units and/or telling about the tear gas
+	-- Don't repeat the chopper incoming dialog
 	[105362] = {
 		values = {
 			trigger_times = 1,
@@ -104,25 +105,25 @@ return {
 			trigger_times = 1,
 		},
 	},
-	--Made Tear Gas heli have loopable spawn
-	--set this to 100% so it will always trigger the chance of tear gas heli squad
-	[105496] = { 
+	-- Always trigger the tear gas heli
+	[105496] = {
 		values = {
 			chance = 100,
 		},
 	},
+	-- Make the tear gas heli loop
 	[100631] = {
 		on_executed = {
 			{ id = 101747, delay = 150, delay_rand = 120, },
 		},
 	},
-	--the heli1 spawn's trigger_times is set to 1 for some reason, switching to 0 to make the chopper still spawn after once
+	-- The heli1 spawn's trigger_times is set to 1, set to 0 so it can loop
 	[101424] = {
 		values = {
 			trigger_times = 0,
 		},
 	},
-	--kill chopper spawns once heli squad deploys tear gas
+	-- Kill chopper spawns once heli squad deploys tear gas
 	[102297] = {
 		func = function(self)
 			local turn_this_shit_off = self:get_mission_element(105610)
@@ -132,7 +133,7 @@ return {
 			end
 		end,
 	},
-	--The vault door is always locked on DS
+	-- The vault door is always locked on DS
 	[100195] = {
 		values = {
 			chance = vaultdoor,
@@ -143,8 +144,8 @@ return {
 			chance = vaultdoor,
 		},
 	},
-	--Pro Job Stuff
-	--2 tear gas choppers instead of 1
+	-- Pro Job stuff
+	-- 2 tear gas choppers instead of 1
 	[105610] = {
 		values = {
 			amount = teargaschopper,
@@ -153,7 +154,7 @@ return {
 			{ id = 105496, delay = 15, },
 		},
 	},
-	--More rooms filled with tear gas
+	-- More rooms filled with tear gas
 	[102195] = {
 		values = {
 			amount = teargas,
@@ -164,7 +165,7 @@ return {
 			amount = teargasmayhem,
 		},
 	},
-	--Heli spawns
+	-- Heli spawns
 	[101785] = {
 		values = {
 			enemy = bulldozer,

--- a/req/mission_script/cage.lua
+++ b/req/mission_script/cage.lua
@@ -1,14 +1,16 @@
 return {
-	--Increase PONR timers
+	-- Increase PONR timers
 	[105040] = {
 		values = {
+			elements = { 105093, },
+			time_easy = 420,
 			time_normal = 390,
 			time_hard = 360,
 			time_overkill = 330,
 			time_overkill_145 = 300,
 			time_easy_wish = 270,
 			time_overkill_290 = 240,
-			time_sm_wish = 210
-		}
-	}
+			time_sm_wish = 210,
+		},
+	},
 }

--- a/req/mission_script/dark.lua
+++ b/req/mission_script/dark.lua
@@ -1,21 +1,24 @@
 local murky_bravos_table = {
-"units/pd2_mod_sharks/characters/ene_murky_elite_guard_1/ene_murky_elite_guard_1",
-"units/pd2_mod_sharks/characters/ene_murky_elite_guard_2/ene_murky_elite_guard_2",
-"units/pd2_mod_sharks/characters/ene_murky_elite_guard_1/ene_murky_elite_guard_1",
-"units/pd2_mod_sharks/characters/ene_murky_elite_guard_2/ene_murky_elite_guard_2",
-"units/pd2_mod_sharks/characters/ene_murky_elite_guard_1/ene_murky_elite_guard_1",
-"units/pd2_mod_sharks/characters/ene_murky_elite_guard_2/ene_murky_elite_guard_2",
-"units/pd2_mod_sharks/characters/ene_murky_elite_guard_3/ene_murky_elite_guard_3",
+	"units/pd2_mod_sharks/characters/ene_murky_elite_guard_1/ene_murky_elite_guard_1",
+	"units/pd2_mod_sharks/characters/ene_murky_elite_guard_2/ene_murky_elite_guard_2",
+	"units/pd2_mod_sharks/characters/ene_murky_elite_guard_1/ene_murky_elite_guard_1",
+	"units/pd2_mod_sharks/characters/ene_murky_elite_guard_2/ene_murky_elite_guard_2",
+	"units/pd2_mod_sharks/characters/ene_murky_elite_guard_1/ene_murky_elite_guard_1",
+	"units/pd2_mod_sharks/characters/ene_murky_elite_guard_2/ene_murky_elite_guard_2",
+	"units/pd2_mod_sharks/characters/ene_murky_elite_guard_3/ene_murky_elite_guard_3",
 }
 local bravo_guards = {
 	values = {
-        enemy = murky_bravos_table
-	}
+		enemy = murky_bravos_table,
+	},
 }
+
 return {
-	--Increase PONR timers
+	-- Increase PONR timers
 	[102120] = {
 		values = {
+			elements = { 106030, 106033, },
+			time_easy = 60,
 			time_normal = 60,
 			time_hard = 60,
 			time_overkill = 60,
@@ -23,10 +26,10 @@ return {
 			time_easy_wish = 60,
 			time_overkill_290 = 60,
 			time_sm_wish = 60,
-		}
+		},
 	},
-	--Murky Elite Guards
-	--https://www.youtube.com/watch?v=cNuluqg3GfQ
+	-- Murky Elite Guards
+	-- https://www.youtube.com/watch?v=cNuluqg3GfQ
 	[101189] = bravo_guards,
 	[102077] = bravo_guards,
 	[102078] = bravo_guards,
@@ -57,5 +60,5 @@ return {
 	[100123] = bravo_guards,
 	[100124] = bravo_guards,
 	[101525] = bravo_guards,
-	[101528] = bravo_guards
+	[101528] = bravo_guards,
 }

--- a/req/mission_script/fish.lua
+++ b/req/mission_script/fish.lua
@@ -8,10 +8,7 @@ return {
 	-- Toggle on the escape area trigger when it should be available, in addition to the escape logic link
 	[100711] = {
 		values = {
-			elements = {
-				100710,
-				100723,
-			},
+			elements = { 100710, 100723, },
 		},
 	},
 	-- Increase PONR timers

--- a/req/mission_script/fish.lua
+++ b/req/mission_script/fish.lua
@@ -1,47 +1,31 @@
-local difficulty = tweak_data:difficulty_to_index(Global.game_settings and Global.game_settings.difficulty or "normal")
-local ponr_value = (difficulty <= 5 and 800 or (difficulty == 6 or difficulty == 7) and 700) or 600
-	
-local ponr_timer_player_mul = {
-		1,
-		0.85,
-		0.7,
-		0.65,
-		0.65,
-		0.65,
-		0.65,
-		0.65,
-		0.65,
-		0.65,
-		0.65,
-		0.65,
-		0.65,
-		0.65,
-		0.65,
-		0.65,
-		0.65,
-		0.65,
-		0.65,
-		0.65,
-		0.65,
-		0.65
-}
-
 return {
-	--Pro Job PONR when someone hacks the laptop for the first time
-	[100036] = {
-		ponr_player_mul = ponr_timer_player_mul,
-		ponr = ponr_value
+	-- Escape area trigger starts disabled
+	[100710] = {
+		values = {
+			enabled = false,
+		},
 	},
-	--Increase PONR timers
+	-- Toggle on the escape area trigger when it should be available, in addition to the escape logic link
+	[100711] = {
+		values = {
+			elements = {
+				100710,
+				100723,
+			},
+		},
+	},
+	-- Increase PONR timers
 	[100720] = {
 		values = {
+			elements = { 100710, },
+			time_easy = 60,
 			time_normal = 60,
 			time_hard = 60,
 			time_overkill = 60,
 			time_overkill_145 = 60,
 			time_easy_wish = 60,
 			time_overkill_290 = 60,
-			time_sm_wish = 60
-		}
-	}
+			time_sm_wish = 60,
+		},
+	},
 }

--- a/req/mission_script/tag.lua
+++ b/req/mission_script/tag.lua
@@ -1,14 +1,16 @@
 return {
-	--Increase PONR timers
+	-- Increase PONR timers
 	[100021] = {
 		values = {
+			elements = { 101343, 101712, 101713, 101714, },
+			time_easy = 60,
 			time_normal = 60,
 			time_hard = 60,
 			time_overkill = 60,
 			time_overkill_145 = 60,
 			time_easy_wish = 60,
 			time_overkill_290 = 60,
-			time_sm_wish = 60
-		}
-	}
+			time_sm_wish = 60,
+		},
+	},
 }

--- a/req/mission_script_add/branchbank.lua
+++ b/req/mission_script_add/branchbank.lua
@@ -10,7 +10,7 @@ local ponr_timer_player_mul = {
 
 local opts_pro_job_ponr = {
 	elements = { 104722, 104723, 100512, },
-	trigger_times = 0,
+	trigger_times = 1,
 	time_balance_mul = ponr_timer_player_mul,
 	time_easy = ponr_value,
 	time_normal = ponr_value,
@@ -23,6 +23,14 @@ local opts_pro_job_ponr = {
 	enabled = pro_job,
 }
 
+local opts_pro_job_ponr_counter = {
+	enabled = true,
+	counter_target = 2,
+	on_executed = {
+		{ id = 400020, delay = 0, },
+	},
+}
+
 return {
 	elements = {
 		restoration:gen_pointofnoreturn(
@@ -31,6 +39,13 @@ return {
 			Vector3(0, 0, 0),
 			Rotation(0, 0, 0),
 			opts_pro_job_ponr
+		),
+		restoration:gen_counter(
+			400021,
+			"pro_job_ponr_counter",
+			Vector3(0, 0, 0),
+			Rotation(0, 0, 0),
+			opts_pro_job_ponr_counter
 		),
 	},
 }


### PR DESCRIPTION
Updated many stealth-only heists to specify area triggers for anti-grief, and remove stealth PONR from Yacht Heist (only the PONR when the alarm goes remains)
More testing on the updated missionmanager implementation is always appreciated