### PR TITLE
Primarily Watchdogs day 2

### DIFF
--- a/Core.lua
+++ b/Core.lua
@@ -858,7 +858,7 @@ function restoration:mission_script_patches()
 	if self._mission_script_patches == nil then
 		local level_id = Global.game_settings and Global.game_settings.level_id
 		if level_id then
-			self._mission_script_patches = self:require("mission_script/" .. level_id:gsub('_skip1$', ''):gsub('_skip2$', ''):gsub("_night$", ""):gsub("_day$", "")) or false
+			self._mission_script_patches = self:require("mission_script/" .. level_id:gsub("_skip1$", ""):gsub("_skip2$", ""):gsub("_night$", ""):gsub("_day$", "")) or false
 		end
 	end
 	return self._mission_script_patches
@@ -871,7 +871,7 @@ function restoration:instance_script_patches()
 	if self._instance_script_patches == nil then
 		local level_id = Global.game_settings and Global.game_settings.level_id
 		if level_id then
-			self._instance_script_patches = self:require("instance_script/" .. level_id:gsub('_skip1$', ''):gsub('_skip2$', ''):gsub("_night$", ""):gsub("_day$", "")) or false
+			self._instance_script_patches = self:require("instance_script/" .. level_id:gsub("_skip1$", ""):gsub("_skip2$", ""):gsub("_night$", ""):gsub("_day$", "")) or false
 		end
 	end
 	return self._instance_script_patches
@@ -885,7 +885,7 @@ function restoration:mission_script_add()
 	if self._mission_script_add == nil then
 		local level_id = Global.game_settings and Global.game_settings.level_id
 		if level_id then
-			self._mission_script_add = self:require("mission_script_add/" .. level_id:gsub('_skip1$', ''):gsub('_skip2$', ''):gsub("_night$", ""):gsub("_day$", "")) or false
+			self._mission_script_add = self:require("mission_script_add/" .. level_id:gsub("_skip1$", ""):gsub("_skip2$", ""):gsub("_night$", ""):gsub("_day$", "")) or false
 		end
 	end
 	return self._mission_script_add
@@ -919,33 +919,45 @@ function restoration:gen_dummy(id, name, pos, rot, opts)
 	}
 end
 
-function restoration:gen_spawngroup(id, name, elements, interval)
+function restoration:gen_spawngroup(id, name, elements, interval, opts)
+	opts = opts or {}
+	-- preferred_spawn_groups = false means this element isn't for GroupAI group spawns
+	local ignore_replace_preferred
+	local preferred_spawn_groups = opts.preferred_spawn_groups
+	if preferred_spawn_groups then
+		ignore_replace_preferred = true
+	elseif preferred_spawn_groups == false then
+		preferred_spawn_groups = nil
+	elseif not preferred_spawn_groups then
+		preferred_spawn_groups = {
+			"tac_shield_wall_charge",
+			"FBI_spoocs",
+			"tac_tazer_charge",
+			"tac_tazer_flanking",
+			"tac_shield_wall",
+			"tac_swat_rifle_flank",
+			"tac_shield_wall_ranged",
+			"tac_bull_rush",
+		}
+	end
 	return {
 		id = id,
 		editor_name = name,
 		class = "ElementSpawnEnemyGroup",
 		values = {
-			on_executed = {},
-			trigger_times = 0,
-			base_delay = 0,
-			ignore_disabled = false,
-			amount = 0,
-			spawn_type = "ordered",
-			team = "default",
-			execute_on_startup = false,
-			enabled = true,
-			preferred_spawn_groups = {
-				"tac_shield_wall_charge",
-				"FBI_spoocs",
-				"tac_tazer_charge",
-				"tac_tazer_flanking",
-				"tac_shield_wall",
-				"tac_swat_rifle_flank",
-				"tac_shield_wall_ranged",
-				"tac_bull_rush",
-			},
-			elements = elements,
-			interval = interval or 0,
+			on_executed = opts.on_executed or {},
+			trigger_times = opts.trigger_times or 0,
+			base_delay = opts.base_delay or 0,
+			ignore_disabled = opts.ignore_disabled or false,
+			amount = opts.amount or 0,
+			spawn_type = opts.spawn_type or "ordered",
+			team = opts.team or "default",
+			execute_on_startup = opts.execute_on_startup or false,
+			enabled = opts.enabled or false,
+			preferred_spawn_groups = preferred_spawn_groups,
+			ignore_replace_preferred = ignore_replace_preferred,
+			elements = elements or opts.elements or {},
+			interval = interval or opts.interval or 0,
 		},
 	}
 end
@@ -959,40 +971,40 @@ function restoration:gen_so(id, name, pos, rot, opts)
 		values = {
 			path_style = opts.path_style or "destination",
 			align_position = opts.align_position or false,
-			ai_group = "enemies",
-			is_navigation_link = false,
+			ai_group = opts.ai_group or "enemies",
+			is_navigation_link = opts.is_navigation_link or false,
 			position = pos,
 			scan = opts.scan or false,
 			needs_pos_rsrv = opts.needs_pos_rsrv or false,
-			enabled = true,
-			execute_on_startup = false,
+			enabled = opts.enabled ~= false,
+			execute_on_startup = opts.execute_on_startup or false,
 			rotation = rot,
-			base_delay = 0,
-			action_duration_min = 0,
+			base_delay = opts.base_delay or 0,
+			action_duration_min = opts.action_duration_min or 0,
 			search_position = pos,
-			use_instigator = true,
-			trigger_times = 0,
-			trigger_on = "none",
-			search_distance = 0,
+			use_instigator = opts.use_instigator ~= false,
+			trigger_times = opts.trigger_times or 0,
+			trigger_on = opts.trigger_on or "none",
+			search_distance = opts.search_distance or 0,
 			so_action = opts.so_action or "none",
 			path_stance = opts.path_stance or "hos",
-			path_haste = "run",
-			repeatable = false,
-			attitude = "engage",
+			path_haste = opts.path_haste or "run",
+			repeatable = opts.repeatable or false,
+			attitude = opts.attitude or "engage",
 			interval = opts.interval or -1,
-			action_duration_max = 0,
+			action_duration_max = opts.action_duration_max or 0,
 			align_rotation = opts.align_rotation or false,
 			pose = opts.pose or "none",
 			forced = opts.forced or false,
-			base_chance = 1,
-			interaction_voice = "none",
-			SO_access = opts.SO_access or "512", -- default to sniper
-			chance_inc = 0,
+			base_chance = opts.base_chance or 1,
+			interaction_voice = opts.interaction_voice or "none",
+			SO_access = opts.SO_access or "512",  -- Default to sniper
+			chance_inc = opts.chance_inc or 0,
 			interrupt_dmg = opts.interrupt_dmg or 1,
-			interrupt_objective = false,
+			interrupt_objective = opts.interrupt_objective or false,
 			on_executed = opts.on_executed or {},
 			interrupt_dis = opts.interrupt_dis or 1,
-			patrol_path = "none",
+			patrol_path = opts.patrol_path or "none",
 		},
 	}
 end
@@ -1005,26 +1017,26 @@ function restoration:gen_areatrigger(id, name, pos, rot, opts)
 		class = "ElementAreaTrigger",
 		module = "CoreElementArea",
 		values = {
-			execute_on_startup = false,
+			execute_on_startup = opts.execute_on_startup or false,
 			trigger_times = opts.trigger_times or 1,
 			on_executed = opts.on_executed or {},
 			base_delay = opts.base_delay or 0,
 			position = pos,
 			rotation = rot,
-			enabled = true,
-			interval = 0.1,
-			trigger_on = "on_enter",
-			instigator = "player",
+			enabled = opts.enabled ~= false,
+			interval = opts.interval or 0.1,
+			trigger_on = opts.trigger_on or "on_enter",
+			instigator = opts.instigator or "player",
 			shape_type = opts.shape_type or "box",
 			width = opts.width or 500,
 			depth = opts.depth or 500,
 			height = opts.height or 500,
 			radius = opts.radius or 250,
-			spawn_unit_elements = {},
+			spawn_unit_elements = opts.spawn_unit_elements or {},
 			amount = opts.amount or "1",
-			instigator_name = "",
-			use_disabled_shapes = false,
-			substitute_object = "",
+			instigator_name = opts.instigator_name or "",
+			use_disabled_shapes = opts.use_disabled_shapes or false,
+			substitute_object = opts.substitute_objects or "",
 		},
 	}
 end
@@ -1036,15 +1048,15 @@ function restoration:gen_dummytrigger(id, name, pos, rot, opts)
 		editor_name = name,
 		class = "ElementEnemyDummyTrigger",
 		values = {
-			execute_on_startup = false,
+			execute_on_startup = opts.execute_on_startup or false,
 			trigger_times = opts.trigger_times or 0,
 			elements = opts.elements or {},
 			on_executed = opts.on_executed or {},
 			base_delay = opts.base_delay or 0,
 			position = pos,
 			rotation = rot,
-			enabled = true,
-			event = opts.event or "spawn"
+			enabled = opts.enabled ~= false,
+			event = opts.event or "spawn",
 		},
 	}
 end
@@ -1057,11 +1069,11 @@ function restoration:gen_missionscript(id, name, opts)
 		class = "MissionScriptElement",
 		module = "CoreMissionScriptElement",
 		values = {
-			execute_on_startup = false,
+			execute_on_startup = opts.execute_on_startup or false,
 			trigger_times = opts.trigger_times or 0,
 			on_executed = opts.on_executed or {},
 			base_delay = opts.base_delay or 0,
-			enabled = opts.enabled or false
+			enabled = opts.enabled or false,
 		},
 	}
 end
@@ -1074,14 +1086,14 @@ function restoration:gen_toggleelement(id, name, opts)
 		class = "ElementToggle",
 		module = "CoreElementToggle",
 		values = {
-			execute_on_startup = false,
+			execute_on_startup = opts.execute_on_startup or false,
 			trigger_times = opts.trigger_times or 0,
 			set_trigger_times = opts.set_trigger_times or -1,
 			elements = opts.elements or {},
 			on_executed = opts.on_executed or {},
 			base_delay = opts.base_delay or 0,
 			enabled = opts.enabled or false,
-			toggle = opts.toggle or "on"
+			toggle = opts.toggle or "on",
 		},
 	}
 end
@@ -1093,7 +1105,7 @@ function restoration:gen_pointofnoreturn(id, name, pos, rot, opts)
 		editor_name = name,
 		class = "ElementPointOfNoReturn",
 		values = {
-			execute_on_startup = false,
+			execute_on_startup = opts.execute_on_startup or false,
 			trigger_times = opts.trigger_times or 1,
 			elements = opts.elements or {},
 			elements_in_instances = opts.elements_in_instances or nil,
@@ -1112,7 +1124,7 @@ function restoration:gen_pointofnoreturn(id, name, pos, rot, opts)
 			time_sm_wish = opts.time_sm_wish or 0,
 			position = pos,
 			rotation = rot,
-			enabled = opts.enabled or false
+			enabled = opts.enabled or false,
 		},
 	}
 end
@@ -1124,17 +1136,17 @@ function restoration:gen_dialogue(id, name, opts)
 		editor_name = name,
 		class = "ElementDialogue",
 		values = {
-			execute_on_startup = false,
+			execute_on_startup = opts.execute_on_startup or false,
 			trigger_times = opts.trigger_times or 0,
 			on_executed = opts.on_executed or {},
 			base_delay = opts.base_delay or 0,
 			dialogue = opts.dialogue or "none",
-			enabled = true,
+			enabled = opts.enabled ~= false,
 			can_not_be_muted = opts.can_not_be_muted or false,
 			execute_on_executed_when_done = opts.execute_on_executed_when_done or false,
 			play_on_player_instigator_only = opts.play_on_player_instigator_only or false,
 			use_instigator = opts.use_instigator or false,
-			use_position = opts.use_position or false
+			use_position = opts.use_position or false,
 		},
 	}
 end
@@ -1146,12 +1158,12 @@ function restoration:gen_preferedadd(id, name, opts)
 		editor_name = name,
 		class = "ElementEnemyPreferedAdd",
 		values = {
-			execute_on_startup = false,
+			execute_on_startup = opts.execute_on_startup or false,
 			base_delay = opts.base_delay or 0,
 			trigger_times = opts.trigger_times or 0,
 			spawn_groups = opts.spawn_groups or {},
 			on_executed = opts.on_executed or {},
-			enabled = true
+			enabled = opts.enabled ~= false,
 		},
 	}
 end
@@ -1163,17 +1175,17 @@ function restoration:gen_smokeandnades(id, name, pos, rot, opts)
 		editor_name = name,
 		class = "ElementSmokeGrenade",
 		values = {
-			execute_on_startup = false,
+			execute_on_startup = opts.execute_on_startup or false,
 			position = pos,
 			rotation = rot,
-			enabled = true,
+			enabled = opts.enabled ~= false,
 			base_delay = opts.base_delay or 0,
 			duration = opts.duration or 0,
 			effect_type = opts.effect_type or "smoke",
-			ignore_control = true,
-			immediate = true,
+			ignore_control = opts.ignore_control ~= false,
+			immediate = opts.immediate ~= false,
 			on_executed = opts.on_executed or {},
-			trigger_times = opts.trigger_times or 0
+			trigger_times = opts.trigger_times or 0,
 		},
 	}
 end
@@ -1185,12 +1197,12 @@ function restoration:gen_dynamicfilter(id, name, pos, rot, opts)
 		editor_name = name,
 		class = "ElementFilter",
 		values = {
-			execute_on_startup = false,
+			execute_on_startup = opts.execute_on_startup or false,
 			trigger_times = opts.trigger_times or 0,
 			on_executed = opts.on_executed or {},
 			base_delay = opts.base_delay or 0,
-			mode_assault = true,
-			mode_control = true,
+			mode_assault = opts.mode_assault ~= false,
+			mode_control = opts.mode_control ~= false,
 			difficulty_easy = opts.difficulty_easy or false,
 			difficulty_normal = opts.difficulty_normal or false,
 			difficulty_hard = opts.difficulty_hard or false,
@@ -1211,7 +1223,7 @@ function restoration:gen_dynamicfilter(id, name, pos, rot, opts)
 			platform_xb1_only = false,
 			position = pos,
 			rotation = rot,
-			enabled = opts.enabled or false
+			enabled = opts.enabled or false,
 		},
 	}
 end
@@ -1223,15 +1235,15 @@ function restoration:gen_sotrigger(id, name, pos, rot, opts)
 		editor_name = name,
 		class = "ElementSpecialObjectiveTrigger",
 		values = {
-			execute_on_startup = false,
+			execute_on_startup = opts.execute_on_startup or false,
 			trigger_times = opts.trigger_times or 0,
 			elements = opts.elements or {},
 			on_executed = opts.on_executed or {},
 			base_delay = opts.base_delay or 0,
 			position = pos,
 			rotation = rot,
-			enabled = true,
-			event = opts.event or "complete"
+			enabled = opts.enabled ~= false,
+			event = opts.event or "complete",
 		},
 	}
 end
@@ -1244,14 +1256,14 @@ function restoration:objecteditor(id, name, pos, rot, opts)
 		class = "ElementUnitSequence",
 		module = "CoreElementUnitSequence",
 		values = {
-			execute_on_startup = false,
+			execute_on_startup = opts.execute_on_startup or false,
 			trigger_times = opts.trigger_times or 0,
 			trigger_list = opts.trigger_list or {},
 			on_executed = opts.on_executed or {},
 			base_delay = opts.base_delay or 0,
 			position = pos,
 			rotation = rot,
-			enabled = true
+			enabled = opts.enabled ~= false,
 		},
 	}
 end
@@ -1264,7 +1276,7 @@ function restoration:gen_operator(id, name, pos, rot, opts)
 		class = "ElementOperator",
 		module = "CoreElementOperator",
 		values = {
-			execute_on_startup = false,
+			execute_on_startup = opts.execute_on_startup or false,
 			trigger_times = opts.trigger_times or 0,
 			on_executed = opts.on_executed or {},
 			base_delay = opts.base_delay or 0,
@@ -1285,7 +1297,7 @@ function restoration:gen_instance_input_event(id, name, pos, rot, opts)
 		class = "ElementInstanceInputEvent",
 		module = "CoreElementInstance",
 		values = {
-			execute_on_startup = false,
+			execute_on_startup = opts.execute_on_startup or false,
 			trigger_times = opts.trigger_times or 0,
 			on_executed = opts.on_executed or {},
 			base_delay = opts.base_delay or 0,
@@ -1307,7 +1319,7 @@ function restoration:gen_instance_input(id, name, pos, rot, opts)
 		class = "ElementInstanceInput",
 		module = "CoreElementInstance",
 		values = {
-			execute_on_startup = false,
+			execute_on_startup = opts.execute_on_startup or false,
 			trigger_times = opts.trigger_times or 0,
 			on_executed = opts.on_executed or {},
 			base_delay = opts.base_delay or 0,
@@ -1328,7 +1340,7 @@ function restoration:gen_counter(id, name, pos, rot, opts)
 		class = "ElementCounter",
 		module = "CoreElementCounter",
 		values = {
-			execute_on_startup = false,
+			execute_on_startup = opts.execute_on_startup or false,
 			trigger_times = opts.trigger_times or 0,
 			on_executed = opts.on_executed or {},
 			base_delay = opts.base_delay or 0,
@@ -1349,14 +1361,14 @@ function restoration:gen_element_random(id, name, opts)
 		module = "CoreElementRandom",
 		class = "ElementRandom",
 		values = {
-			execute_on_startup = false,
+			execute_on_startup = opts.execute_on_startup or false,
 			ignore_disabled = opts.ignore_disabled or false,
 			trigger_times = opts.trigger_times or 0,
 			amount = opts.amount or 0,
 			amount_random = opts.amount_random or 0,
 			on_executed = opts.on_executed or {},
 			base_delay = opts.base_delay or 0,
-			enabled = true,
+			enabled = opts.enabled ~= false,
 		},
 	}
 end

--- a/Core.lua
+++ b/Core.lua
@@ -1,5 +1,5 @@
 if not ModCore then
-	restoration.log_shit("[ERROR] Unable to find ModCore from BeardLib! Is BeardLib installed correctly?")
+	log("[RestorationMod][Error] Unable to find ModCore from BeardLib! Is BeardLib installed correctly?")
 	return
 end
 
@@ -846,13 +846,14 @@ function restoration:disable_mission_script_patches()
 	end
 end
 
---Stealing this from SH cause it's way better
+-- Load and execute a file from the req/ folder
 function restoration:require(file)
 	local path = self:GetPath() .. "req/" .. file .. ".lua"
 	return io.file_is_readable(path) and blt.vm.dofile(path)
 end
 
---Mission Script
+-- Get mission script patches used to tweak values of existing mission script elements
+-- Tweaks elements post-init
 function restoration:mission_script_patches()
 	if self._mission_script_patches == nil then
 		local level_id = Global.game_settings and Global.game_settings.level_id
@@ -863,7 +864,9 @@ function restoration:mission_script_patches()
 	return self._mission_script_patches
 end
 
---Mission script but it can touch instances
+-- Get instance script patches used to tweak mission script element definitions in instance
+-- Instances used multiple times on the same level will all have the same changes applied
+-- Tweaks element definitions pre-init
 function restoration:instance_script_patches()
 	if self._instance_script_patches == nil then
 		local level_id = Global.game_settings and Global.game_settings.level_id
@@ -875,7 +878,8 @@ function restoration:instance_script_patches()
 end
 
 
---Mission script but it can add new functions to heists
+-- Get new mission script elements to add to the default mission script
+-- Adds elements pre-init
 function restoration:mission_script_add()
 	restoration.loaded_elements = false
 	if self._mission_script_add == nil then
@@ -1354,19 +1358,20 @@ function restoration:gen_element_random(id, name, opts)
 			enabled = true,
 		},
 	}
-end	
+end
 
-function restoration:log(...)
+restoration.logging = io.file_is_readable("mods/developer.txt")
+function restoration:log(str, ...)
 	if self.logging then
-		log("[StreamlinedHeistingAI] " .. table.concat({...}, " "))
+		log("[RestorationMod] " .. str:format(...))
 	end
 end
 
-function restoration:warn(...)
-	log("[StreamlinedHeistingAI][Warning] " .. table.concat({...}, " "))
+function restoration:warn(str, ...)
+	log("[RestorationMod][Warning] " .. str:format(...))
 end
 
-function restoration:error(...)
-	log("[StreamlinedHeistingAI][Error] " .. table.concat({...}, " "))
+function restoration:error(str, ...)
+	log("[RestorationMod][Error] " .. str:format(...))
 end
 

--- a/Core.lua
+++ b/Core.lua
@@ -1100,6 +1100,7 @@ function restoration:gen_pointofnoreturn(id, name, pos, rot, opts)
 			on_executed = opts.on_executed or {},
 			base_delay = opts.base_delay or 0,
 			tweak_id = "noreturn",
+			time_balance_mul_include_team_ai = opts.time_balance_mul_include_team_ai,
 			time_balance_mul = opts.time_balance_mul or nil,
 			time_easy = opts.time_easy or 0,
 			time_normal = opts.time_normal or 0,

--- a/lua/sc/managers/groupaistatebase.lua
+++ b/lua/sc/managers/groupaistatebase.lua
@@ -522,21 +522,25 @@ function GroupAIStateBase:_radio_chatter_clbk()
 	managers.enemy:add_delayed_clbk("_radio_chatter_clbk", self._radio_clbk, Application:time() + 30 + math.random(0, 20))
 end	
 
-function GroupAIStateBase:_get_balancing_multiplier(balance_multipliers)
+function GroupAIStateBase:_get_balancing_multiplier(balance_multipliers, include_team_ai)
+	-- If stealth - count only amount of players
+	if include_team_ai == nil then
+		include_team_ai = not self:whisper_mode()
+	end
+
 	local nr_players = 0
-	--If stealth - count only amount of players
-	if self:whisper_mode() then
-		nr_players = managers.network:session():amount_of_alive_players() 
+	if not include_team_ai then
+		nr_players = managers.network:session():amount_of_alive_players()
 	else
-	--If loud - count players + bots
-	for u_key, u_data in pairs(self:all_criminals()) do
-		if not u_data.status then
-			nr_players = nr_players + 1
+		-- If loud - count players + bots
+		for u_key, u_data in pairs(self:all_criminals()) do
+			if not u_data.status then
+				nr_players = nr_players + 1
+			end
 		end
+		nr_players = math.clamp(nr_players, 1, 22)
 	end
-		nr_players = math.clamp(nr_players, 1, 22)	
-	end
-	--log("SC: Balance set for player count of = " .. tostring(nr_players))
+	-- log("SC: Balance set for player count of = " .. tostring(nr_players))
 	return balance_multipliers[nr_players]
 end
 

--- a/lua/sc/managers/mission/elementpointofnoreturn.lua
+++ b/lua/sc/managers/mission/elementpointofnoreturn.lua
@@ -5,8 +5,8 @@ Hooks:PreHook(ElementPointOfNoReturn, "operation_add", "res_operation_add", func
 	self._values.original_time = self._values[to_replace_key] or self._values.time_hard
 	self._values.time_balance_mul = self._values.time_balance_mul or { 1, 1, 1, 1, }
 	if self._values.original_time then
-		local balance_mul = self._values.time_balance_mul
-		local final_mul = managers.groupai:state():_get_balancing_multiplier(balance_mul) or balance_mul[#balance_mul] or 1
+		local balance_mul, include_team_ai = self._values.time_balance_mul, self._values.time_balance_mul_include_team_ai
+		local final_mul = managers.groupai:state():_get_balancing_multiplier(balance_mul, include_team_ai) or balance_mul[#balance_mul] or 1
 		self._values[to_replace_key] = self._values.original_time * final_mul
 	end
 end)

--- a/lua/sc/managers/mission/elementspawnenemydummy.lua
+++ b/lua/sc/managers/mission/elementspawnenemydummy.lua
@@ -2898,10 +2898,9 @@ else
 	difficulty = Global.game_settings and Global.game_settings.difficulty or "normal"
 end
 
-Hooks:PostHook(ElementSpawnEnemyDummy, "init", "sh_init", function (self)
+Hooks:PostHook(ElementSpawnEnemyDummy, "init", "res_init", function (self)
 	local enemy_mapping = self.enemy_mapping
-	local faction_mapping = self.faction_mapping[tweak_data.levels:get_ai_group_type()]
-	faction_mapping = faction_mapping and faction_mapping[difficulty]
+	local faction_mapping = self:get_faction_mapping()
 
 	local mapped_name = enemy_mapping[self._enemy_name:key()]
 	local mapped_unit = faction_mapping and faction_mapping[mapped_name]
@@ -2941,3 +2940,10 @@ Hooks:PreHook(ElementSpawnEnemyDummy, "produce", "sh_produce", function (self, p
 		self._enemy_name = Idstring(table.random(self._enemy_table))
 	end
 end)
+
+-- Primarily for mission script patches to pull units from without needing to be updated if the used faction is changed
+function ElementSpawnEnemyDummy:get_faction_mapping(ai_group_type, diff)
+	ai_group_type = ai_group_type or tweak_data.levels:get_ai_group_type()
+	diff = diff or difficulty
+	return self.faction_mapping[ai_group_type] and self.faction_mapping[ai_group_type][diff]
+end

--- a/lua/sc/managers/mission/elementspawnenemygroup.lua
+++ b/lua/sc/managers/mission/elementspawnenemygroup.lua
@@ -4601,15 +4601,15 @@ local exclude_spawngroups = {
 }
 
 Hooks:PostHook(ElementSpawnEnemyGroup, "_finalize_values", "revert_spawnpoint_delays_finalize_values", function(self)
-	local level = Global.level_data and Global.level_data.level_id or ''
-	level = level:gsub('_skip1$', ''):gsub('_skip2$', ''):gsub('_night$', ''):gsub('_day$', '') -- bugger off please
+	local level = Global.level_data and Global.level_data.level_id or ""
+	level = level:gsub("_skip1$", ""):gsub("_skip2$", ""):gsub("_night$", ""):gsub("_day$", "") -- bugger off please
 
-	if level == 'branchbank' or level == 'branchbank_cash' or level == 'branchbank_deposit' or level == 'branchbank_gold' or level == 'branchbank_gold_prof' or level == 'branchbank_prof' then
+	if level == "branchbank" or level == "branchbank_cash" or level == "branchbank_deposit" or level == "branchbank_gold" or level == "branchbank_gold_prof" or level == "branchbank_prof" then
 		level = "firestarter_3"
 	elseif level == "gallery" then
 		level = "framing_frame_1"
 	elseif level == "rat" then
-		level = "alex_1"	
+		level = "alex_1"
 	end
 
 	local groups = self._values.preferred_spawn_groups
@@ -4617,7 +4617,7 @@ Hooks:PostHook(ElementSpawnEnemyGroup, "_finalize_values", "revert_spawnpoint_de
 	if element then
 		self._values.interval = element.interval
 		self._values.preferred_spawn_groups = element.preferred_spawn_groups
-	elseif groups and #groups > 0 and not table.contains_all(exclude_spawngroups, groups) then
+	elseif not self._values.ignore_replace_preferred and groups and #groups > 0 and not table.contains_all(exclude_spawngroups, groups) then
 		self._values.preferred_spawn_groups = {}
 
 		for name in pairs(tweak_data.group_ai.enemy_spawn_groups) do

--- a/lua/sc/managers/missionmanager.lua
+++ b/lua/sc/managers/missionmanager.lua
@@ -137,7 +137,7 @@ end
 -- Set flashlights on or off when this element is executed
 function MissionManager.mission_script_patch_funcs.flashlight(self, element, data)
 	local function set_flashlights()
-		managers.game_play_central:set_flashlights_on(data.flashlight)
+		managers.game_play_central:set_flashlights_on(data)
 	end
 	Hooks:PostHook(element, "on_executed", "res_on_executed_flashlight_" .. element:id(), set_flashlights)
 	Hooks:PostHook(element, "client_on_executed", "res_client_on_executed_flashlight_" .. element:id(), set_flashlights)

--- a/req/mission_script/watchdogs_2.lua
+++ b/req/mission_script/watchdogs_2.lua
@@ -1,6 +1,6 @@
 local difficulty = tweak_data:difficulty_to_index(Global.game_settings and Global.game_settings.difficulty or "normal")
 local pro_job = Global.game_settings and Global.game_settings.one_down
-local chance_close_warehouse = (difficulty < 3 and 0.01 or difficulty < 5 and 0.02 or difficulty < 7 and 0.04 or 0.08) + (pro_job and 0.04 or 0)
+local chance_close_warehouse = (difficulty < 3 and 0.05 or difficulty < 5 and 0.1 or difficulty < 7 and 0.15 or 0.2) + (pro_job and 0.05 or 0)
 local close_warehouse = math.random() < chance_close_warehouse
 local warehouse_filter = {
 	values = {
@@ -58,9 +58,13 @@ return {
 	-- Rework closing the warehouse to be chance-based
 	-- Warehouse starts with some doors closed but inside logic enabled
 	-- 104001 handles fully closing the warehouse
+	-- 104013 handles the outside power switch
 	-- 104003 handles fully opening the warehouse
-	[104001] = warehouse_filter_2,
-	[104003] = warehouse_filter,
+	-- 104012 handles the inside power switch
+	[104001] = warehouse_filter,
+	[104013] = warehouse_filter,
+	[104003] = warehouse_filter_2,
+	[104012] = warehouse_filter_2,
 	-- Enable unused reinforce points
 	[101954] = enable,
 	[101955] = enable,
@@ -72,7 +76,7 @@ return {
 	-- Prevent removal of reinforce when the boat arrives
 	[100210] = disable,
 	-- Add new Cloaker group and enable random spawn points on first assault starting
-	[103399] = {
+	[103999] = {
 		on_executed = {
 			{ id = 400076, delay = 0, },
 			{ id = 400067, delay = 0, },
@@ -90,14 +94,14 @@ return {
 			{ id = 100511, delay = 90, },
 		},
 	},
-	-- Spawn FBI Ready Teams after 15-20s
-	-- Spawn a scripted dozer after 150-210s
-	-- Spawn Ground Snipers after 180-270s
+	-- Spawn FBI Ready Teams
+	-- Spawn a scripted dozer
+	-- Spawn Ground Snipers
 	[100486] = {
 		on_executed = {
 			{ id = 400055, delay = 15, delay_rand = 5, },
 			{ id = 400058, delay = 150, delay_rand = 60, },
-			{ id = 400056, delay = 180, delay_rand = 90, },
+			{ id = 400062, delay = 180, delay_rand = 90, },
 		},
 	},
 	-- Spawn Snipers on the ships

--- a/req/mission_script/watchdogs_2.lua
+++ b/req/mission_script/watchdogs_2.lua
@@ -1,37 +1,103 @@
-local enabled = {
+local difficulty = tweak_data:difficulty_to_index(Global.game_settings and Global.game_settings.difficulty or "normal")
+local pro_job = Global.game_settings and Global.game_settings.one_down
+local chance_close_warehouse = (difficulty < 3 and 0.01 or difficulty < 5 and 0.02 or difficulty < 7 and 0.04 or 0.08) + (pro_job and 0.04 or 0)
+local close_warehouse = math.random() < chance_close_warehouse
+local warehouse_filter = {
+	values = {
+		difficulty_easy = close_warehouse,
+		difficulty_normal = close_warehouse,
+		difficulty_hard = close_warehouse,
+		difficulty_overkill = close_warehouse,
+		difficulty_overkill_145 = close_warehouse,
+		difficulty_easy_wish = close_warehouse,
+		difficulty_overkill_290 = close_warehouse,
+		difficulty_sm_wish = close_warehouse,
+	},
+}
+local warehouse_filter_2 = {
+	values = {
+		difficulty_easy = not close_warehouse,
+		difficulty_normal = not close_warehouse,
+		difficulty_hard = not close_warehouse,
+		difficulty_overkill = not close_warehouse,
+		difficulty_overkill_145 = not close_warehouse,
+		difficulty_easy_wish = not close_warehouse,
+		difficulty_overkill_290 = not close_warehouse,
+		difficulty_sm_wish = not close_warehouse,
+	},
+}
+local enable = {
 	values = {
 		enabled = true,
 	},
 }
+local disable = {
+	values = {
+		enabled = false,
+	},
+}
+local disable_cheat_spawns_fix = {
+	values = {
+		amount = "all",
+		width = 7000,
+	},
+}
+local enable_cheat_spawns_fix = {
+	values = {
+		width = 7000,
+	},
+}
 
 return {
-	-- Pro Job PONR
+	-- Pro Job PONR when the escape heli arrives
 	[100324] = {
 		on_executed = {
 			{ id = 400061, delay = 0, },
 		},
 	},
+	-- Rework closing the warehouse to be chance-based
+	-- Warehouse starts with some doors closed but inside logic enabled
+	-- 104001 handles fully closing the warehouse
+	-- 104003 handles fully opening the warehouse
+	[104001] = warehouse_filter_2,
+	[104003] = warehouse_filter,
 	-- Enable unused reinforce points
-	[101954] = enabled,
-	[101955] = enabled,
-	[101984] = enabled,
-	[101987] = enabled,
-	[102123] = enabled,
-	[102125] = enabled,
-	[102126] = enabled,
-	[100210] = {
-		values = {
-			enabled = false,
+	[101954] = enable,
+	[101955] = enable,
+	[101984] = enable,
+	[101987] = enable,
+	[102123] = enable,
+	[102125] = enable,
+	[102126] = enable,
+	-- Prevent removal of reinforce when the boat arrives
+	[100210] = disable,
+	-- Add new Cloaker group and enable random spawn points on first assault starting
+	[103399] = {
+		on_executed = {
+			{ id = 400076, delay = 0, },
+			{ id = 400067, delay = 0, },
 		},
 	},
-	-- Spawn FBI Ready Teams
-	-- Spawn a scripted dozer after 150 seconds
-	-- Spawn Ground Snipers after 3 minutes
+	-- Keep enabling random Cloaker spawn points at the end of each assault
+	[103636] = {
+		on_executed = {
+			{ id = 400067, delay = 0, },
+		},
+	},
+	-- Delay the initial assault (vanilla delay on this is 15s)
+	[101115] = {
+		on_executed = {
+			{ id = 100511, delay = 90, },
+		},
+	},
+	-- Spawn FBI Ready Teams after 15-20s
+	-- Spawn a scripted dozer after 150-210s
+	-- Spawn Ground Snipers after 180-270s
 	[100486] = {
 		on_executed = {
-			{ id = 400054, delay = 25, },
-			{ id = 400058, delay = 150, },
-			{ id = 400056, delay = 180, },
+			{ id = 400055, delay = 15, delay_rand = 5, },
+			{ id = 400058, delay = 150, delay_rand = 60, },
+			{ id = 400056, delay = 180, delay_rand = 90, },
 		},
 	},
 	-- Spawn Snipers on the ships
@@ -50,4 +116,20 @@ return {
 			{ id = 400015, delay = 20, },
 		},
 	},
+	-- Fix cheat spawn area triggers not being wide enough and reenabling spawns too soon
+	[101013] = disable_cheat_spawns_fix,
+	[101235] = disable_cheat_spawns_fix,
+	[101010] = enable_cheat_spawns_fix,
+	[101220] = enable_cheat_spawns_fix,
+	-- Dock Cloakers start disabled
+	[103961] = disable,
+	[103963] = disable,
+	[103965] = disable,
+	[103967] = disable,
+	[103969] = disable,
+	[103971] = disable,
+	[103973] = disable,
+	[103975] = disable,
+	[103977] = disable,
+	[103979] = disable,
 }

--- a/req/mission_script/watchdogs_2.lua
+++ b/req/mission_script/watchdogs_2.lua
@@ -1,44 +1,17 @@
-local difficulty = tweak_data:difficulty_to_index(Global.game_settings and Global.game_settings.difficulty or "normal")	
-local ponr_value = (difficulty <= 5 and 1080 or (difficulty == 6 or difficulty == 7) and 1050) or 1020	
-	
-	local ponr_timer_player_mul = {
-		1,
-		0.85,
-		0.7,
-		0.65,
-		0.65,
-		0.65,
-		0.65,
-		0.65,
-		0.65,
-		0.65,
-		0.65,
-		0.65,
-		0.65,
-		0.65,
-		0.65,
-		0.65,
-		0.65,
-		0.65,
-		0.65,
-		0.65,
-		0.65,
-		0.65
-}
-
 local enabled = {
 	values = {
-        enabled = true
-	}
-}
-return {
-	--Pro Job PONR 
-	[100324] = {
-		ponr_player_mul = ponr_timer_player_mul,
-		ponr = ponr_value
+		enabled = true,
 	},
-	--Enable unused Reinforce spots
-	--didn't knew that day 2 had reinforce spots to begin with
+}
+
+return {
+	-- Pro Job PONR
+	[100324] = {
+		on_executed = {
+			{ id = 400061, delay = 0, },
+		},
+	},
+	-- Enable unused reinforce points
 	[101954] = enabled,
 	[101955] = enabled,
 	[101984] = enabled,
@@ -48,33 +21,33 @@ return {
 	[102126] = enabled,
 	[100210] = {
 		values = {
-			enabled = false
-		}
+			enabled = false,
+		},
 	},
-	--Spawn FBI Ready Teams
-	--Spawn Ground Snipers after 3 minutes
-	--Spawn a scripted dozer after 150 seconds
-	--[[[100486] = {
+	-- Spawn FBI Ready Teams
+	-- Spawn a scripted dozer after 150 seconds
+	-- Spawn Ground Snipers after 3 minutes
+	[100486] = {
 		on_executed = {
-			{ id = 400054, delay = 25 },
-			{ id = 400058, delay = 150 },
-			{ id = 400056, delay = 180 }
-		}
+			{ id = 400054, delay = 25, },
+			{ id = 400058, delay = 150, },
+			{ id = 400056, delay = 180, },
+		},
 	},
-	--Spawn Snipers on the ships
+	-- Spawn Snipers on the ships
 	[102182] = {
 		on_executed = {
-			{ id = 400013, delay = 20 }
-		}
+			{ id = 400013, delay = 20, },
+		},
 	},
 	[102388] = {
 		on_executed = {
-			{ id = 400014, delay = 20 }
-		}
+			{ id = 400014, delay = 20, },
+		},
 	},
 	[102335] = {
 		on_executed = {
-			{ id = 400015, delay = 20 }
-		}
-	} ]]--
+			{ id = 400015, delay = 20, },
+		},
+	},
 }

--- a/req/mission_script_add/watchdogs_2.lua
+++ b/req/mission_script_add/watchdogs_2.lua
@@ -1,5 +1,5 @@
 --TODO: MAKE FBI READY TEAMS LESS SPAMMY
---[[local difficulty = tweak_data:difficulty_to_index(Global.game_settings and Global.game_settings.difficulty or "normal")
+local difficulty = tweak_data:difficulty_to_index(Global.game_settings and Global.game_settings.difficulty or "normal")
 local pro_job = Global.game_settings and Global.game_settings.one_down
 local sniper = "units/payday2/characters/ene_sniper_1/ene_sniper_1"
 local fbi_ready_team_1 = "units/payday2/characters/ene_hoxton_breakout_responder_1/ene_hoxton_breakout_responder_1"
@@ -7,76 +7,102 @@ local fbi_ready_team_2 = "units/payday2/characters/ene_hoxton_breakout_responder
 local fbi_ready_team_dozer = "units/pd2_mod_lapd/characters/ene_bulldozer_3/ene_bulldozer_3"
 local tank = "units/payday2/characters/ene_bulldozer_1/ene_bulldozer_1"
 local deathwish_above = difficulty >= 7
+local ponr_value = (difficulty <= 5 and 1080 or (difficulty == 6 or difficulty == 7) and 1050) or 1020
+local ponr_timer_player_mul = {
+	1,
+	0.85,
+	0.7,
+	0.65,
+	0.65,  -- 5+ players
+}
 
 local optsSniper_1 = {
 	enemy = sniper,
-	on_executed = { { id = 400007, delay = 0 } },
-	enabled = true
+	on_executed = {
+		{ id = 400007, delay = 0, },
+	},
+	enabled = true,
 }
 local optsSniper_2 = {
 	enemy = sniper,
-	on_executed = { { id = 400008, delay = 0 } },
-	enabled = true
+	on_executed = {
+		{ id = 400008, delay = 0, },
+	},
+	enabled = true,
 }
 local optsSniper_3 = {
 	enemy = sniper,
-	on_executed = { { id = 400009, delay = 0 } },
-	enabled = true
+	on_executed = {
+		{ id = 400009, delay = 0, },
+	},
+	enabled = true,
 }
 local optsSniper_4 = {
 	enemy = sniper,
-	on_executed = { { id = 400010, delay = 0 } },
-	enabled = true
+	on_executed = {
+		{ id = 400010, delay = 0, },
+	},
+	enabled = true,
 }
 local optsSniper_5 = {
 	enemy = sniper,
-	on_executed = { { id = 400011, delay = 0 } },
-	enabled = true
+	on_executed = {
+		{ id = 400011, delay = 0, },
+	},
+	enabled = true,
 }
 local optsSniper_6 = {
 	enemy = sniper,
-	on_executed = { { id = 400012, delay = 0 } },
-	enabled = true
+	on_executed = {
+		{ id = 400012, delay = 0, },
+	},
+	enabled = true,
 }
 local optsGroundSniper_1 = {
 	enemy = sniper,
-	on_executed = { { id = 400025, delay = 0 } },
-	enabled = true
+	on_executed = {
+		{ id = 400025, delay = 0, },
+	},
+	enabled = true,
 }
 local optsGroundSniper_2 = {
 	enemy = sniper,
-	on_executed = { { id = 400029, delay = 0 } },
-	enabled = true
+	on_executed = {
+		{ id = 400029, delay = 0, },
+	},
+	enabled = true,
 }
 local optsFBIAgent_1 = {
 	enemy = fbi_ready_team_1,
 	participate_to_group_ai = true,
-	on_executed = { { id = 400057, delay = 0 } },
-	enabled = true
+	on_executed = {
+		{ id = 400057, delay = 0, },
+	},
+	enabled = true,
 }
 local optsFBIAgent_2 = {
 	enemy = fbi_ready_team_2,
 	participate_to_group_ai = true,
-	on_executed = { { id = 400057, delay = 0 } },
-	enabled = true
+	on_executed = {
+		{ id = 400057, delay = 0, },
+	},
+	enabled = true,
 }
 local optsFBIAgent_3 = {
 	enemy = fbi_ready_team_dozer,
 	trigger_times = 1,
 	participate_to_group_ai = true,
-	on_executed = { 
-		{ id = 400057, delay = 0 },
-		{ id = 400060, delay = 0 }
+	on_executed = {
+		{ id = 400057, delay = 0, },
 	},
-	enabled = deathwish_above
+	enabled = deathwish_above,
 }
 local optsDozer = {
 	enemy = tank,
-	on_executed = { 
-		{ id = 400060, delay = 0 },
-		{ id = 400057, delay = 3 }
+	on_executed = {
+		{ id = 400057, delay = 3, },
 	},
-	enabled = true
+	enabled = true,
 }
 local optsSniper_SO = {
 	scan = true,
@@ -84,13 +110,13 @@ local optsSniper_SO = {
 	needs_pos_rsrv = true,
 	align_rotation = true,
 	interval = 2,
-	so_action = "AI_sniper"
+	so_action = "AI_sniper",
 }
 local optsHunt_SO = {
 	scan = true,
-	SO_access = tostring(128+4096),
+	SO_access = tostring(128 + 4096),
 	interval = 2,
-	so_action = "AI_hunt"
+	so_action = "AI_hunt",
 }
 local optsgroundSniper_SO_1_1 = {
 	scan = true,
@@ -99,9 +125,9 @@ local optsgroundSniper_SO_1_1 = {
 	align_rotation = true,
 	interval = 2,
 	so_action = "AI_sniper",
-	on_executed = { 
-		{ id = 400026, delay = 15 }
-	}
+	on_executed = {
+		{ id = 400026, delay = 15, },
+	},
 }
 local optsgroundSniper_SO_1_2 = {
 	scan = true,
@@ -109,10 +135,10 @@ local optsgroundSniper_SO_1_2 = {
 	needs_pos_rsrv = true,
 	align_rotation = true,
 	interval = 2,
-    so_action = "AI_sniper",
-	on_executed = { 
-		{ id = 400027, delay = 15 }
-	}
+	so_action = "AI_sniper",
+	on_executed = {
+		{ id = 400027, delay = 15, },
+	},
 }
 local optsgroundSniper_SO_1_3 = {
 	scan = true,
@@ -121,9 +147,9 @@ local optsgroundSniper_SO_1_3 = {
 	align_rotation = true,
 	interval = 2,
 	so_action = "AI_sniper",
-	on_executed = { 
-		{ id = 400028, delay = 15 }
-	}
+	on_executed = {
+		{ id = 400028, delay = 15, },
+	},
 }
 local optsgroundSniper_SO_1_4 = {
 	scan = true,
@@ -132,9 +158,9 @@ local optsgroundSniper_SO_1_4 = {
 	align_rotation = true,
 	interval = 2,
 	so_action = "AI_sniper",
-	on_executed = { 
-		{ id = 400025, delay = 15 }
-	}
+	on_executed = {
+		{ id = 400025, delay = 15, },
+	},
 }
 local optsgroundSniper_SO_2_1 = {
 	scan = true,
@@ -143,9 +169,9 @@ local optsgroundSniper_SO_2_1 = {
 	align_rotation = true,
 	interval = 2,
 	so_action = "AI_sniper",
-	on_executed = { 
-		{ id = 400030, delay = 15 }
-	}
+	on_executed = {
+		{ id = 400030, delay = 15, },
+	},
 }
 local optsgroundSniper_SO_2_2 = {
 	scan = true,
@@ -153,10 +179,10 @@ local optsgroundSniper_SO_2_2 = {
 	needs_pos_rsrv = true,
 	align_rotation = true,
 	interval = 2,
-    so_action = "AI_sniper",
-	on_executed = { 
-		{ id = 400031, delay = 15 }
-	}
+	so_action = "AI_sniper",
+	on_executed = {
+		{ id = 400031, delay = 15, },
+	},
 }
 local optsgroundSniper_SO_2_3 = {
 	scan = true,
@@ -165,9 +191,9 @@ local optsgroundSniper_SO_2_3 = {
 	align_rotation = true,
 	interval = 2,
 	so_action = "AI_sniper",
-	on_executed = { 
-		{ id = 400032, delay = 15 }
-	}
+	on_executed = {
+		{ id = 400032, delay = 15, },
+	},
 }
 local optsgroundSniper_SO_2_4 = {
 	scan = true,
@@ -176,568 +202,252 @@ local optsgroundSniper_SO_2_4 = {
 	align_rotation = true,
 	interval = 2,
 	so_action = "AI_sniper",
-	on_executed = { 
-		{ id = 400029, delay = 15 }
-	}
+	on_executed = {
+		{ id = 400029, delay = 15, },
+	},
 }
 local spawnSnipers_1 = {
 	enabled = true,
 	trigger_times = 1,
-	on_executed = { 
-		{ id = 400001, delay = 4 },
-		{ id = 400002, delay = 4 },
-		{ id = 400022, delay = 0 }
-	}
+	on_executed = {
+		{ id = 400001, delay = 4, },
+		{ id = 400002, delay = 4, },
+		{ id = 400022, delay = 0, },
+	},
 }
 local spawnSnipers_2 = {
 	enabled = true,
 	trigger_times = 1,
-	on_executed = { 
-		{ id = 400003, delay = 4 },
-		{ id = 400004, delay = 4 },
-		{ id = 400022, delay = 0 }
-	}
+	on_executed = {
+		{ id = 400003, delay = 4, },
+		{ id = 400004, delay = 4, },
+		{ id = 400022, delay = 0, },
+	},
 }
 local spawnSnipers_3 = {
 	enabled = true,
 	trigger_times = 1,
-	on_executed = { 
-		{ id = 400005, delay = 4 },
-		{ id = 400006, delay = 4 },
-		{ id = 400022, delay = 0 }
-	}
+	on_executed = {
+		{ id = 400005, delay = 4, },
+		{ id = 400006, delay = 4, },
+		{ id = 400022, delay = 0, },
+	},
 }
 local spawnGroundSnipers = {
 	enabled = true,
-	on_executed = { 
-		{ id = 400023, delay = 0 },
-		{ id = 400024, delay = 0 }
-	}
+	on_executed = {
+		{ id = 400023, delay = 0, },
+		{ id = 400024, delay = 0, },
+	},
 }
 local spawnFBI_Agents = {
 	enabled = true,
 	trigger_times = 3,
-	on_executed = { 
-		{ id = 400035, delay = 0 },
-		{ id = 400036, delay = 0 },
-		{ id = 400037, delay = 0 },
-		{ id = 400038, delay = 0 },
-		{ id = 400039, delay = 0 },
-		{ id = 400040, delay = 0 },
-		{ id = 400041, delay = 0 },
-		{ id = 400042, delay = 0 },
-		{ id = 400043, delay = 0 },
-		{ id = 400044, delay = 0 },
-		{ id = 400045, delay = 0 },
-		{ id = 400046, delay = 0 },
-		{ id = 400047, delay = 0 },
-		{ id = 400048, delay = 0 },
-		{ id = 400049, delay = 0 },
-		{ id = 400050, delay = 0 },
-		{ id = 400051, delay = 0 },
-		{ id = 400052, delay = 0 },
-		{ id = 400053, delay = 0 },
-		{ id = 400055, delay = 0 }
-	}
+	on_executed = {
+		{ id = 400035, delay = 0, },
+		{ id = 400036, delay = 0, },
+		{ id = 400037, delay = 0, },
+		{ id = 400038, delay = 0, },
+		{ id = 400039, delay = 0, },
+		{ id = 400040, delay = 0, },
+		{ id = 400041, delay = 0, },
+		{ id = 400042, delay = 0, },
+		{ id = 400043, delay = 0, },
+		{ id = 400044, delay = 0, },
+		{ id = 400045, delay = 0, },
+		{ id = 400046, delay = 0, },
+		{ id = 400047, delay = 0, },
+		{ id = 400048, delay = 0, },
+		{ id = 400049, delay = 0, },
+		{ id = 400050, delay = 0, },
+		{ id = 400051, delay = 0, },
+		{ id = 400052, delay = 0, },
+		{ id = 400053, delay = 0, },
+		{ id = 400055, delay = 0, },
+	},
 }
 local loopFBIAgents = {
 	enabled = true,
-	on_executed = { 
-		{ id = 400054, delay = 80 }
-	}
+	on_executed = {
+		{ id = 400054, delay = 80, },
+	},
 }
 local Bain_sendsnipers = {
 	dialogue = "play_pln_gen_snip_01",
 	trigger_times = 1,
-	can_not_be_muted = true
+	can_not_be_muted = true,
 }
 local optsrespawn_sniper_1 = {
-	on_executed = { 
-		{ id = 400001, delay = 30 }
+	on_executed = {
+		{ id = 400001, delay = 30, },
 	},
-	elements = { 
-		400001
+	elements = {
+		400001,
 	},
-	event = "death"
+	event = "death",
 }
 local optsrespawn_sniper_2 = {
-	on_executed = { 
-		{ id = 400002, delay = 30 }
+	on_executed = {
+		{ id = 400002, delay = 30, },
 	},
-	elements = { 
-		400002
+	elements = {
+		400002,
 	},
-    event = "death"
+	event = "death",
 }
 local optsrespawn_sniper_3 = {
-	on_executed = { 
-		{ id = 400003, delay = 30 }
+	on_executed = {
+		{ id = 400003, delay = 30, },
 	},
-	elements = { 
-		400003
+	elements = {
+		400003,
 	},
-	event = "death"
+	event = "death",
 }
 local optsrespawn_sniper_4 = {
-	on_executed = { 
-		{ id = 400004, delay = 30 }
+	on_executed = {
+		{ id = 400004, delay = 30, },
 	},
-	elements = { 
-		400004
+	elements = {
+		400004,
 	},
-	event = "death"
+	event = "death",
 }
 local optsrespawn_sniper_5 = {
-	on_executed = { 
-		{ id = 400005, delay = 30 }
+	on_executed = {
+		{ id = 400005, delay = 30, },
 	},
-	elements = { 
-		400005
+	elements = {
+		400005,
 	},
-	event = "death"
+	event = "death",
 }
 local optsrespawn_sniper_6 = {
-	on_executed = { 
-		{ id = 400006, delay = 30 }
+	on_executed = {
+		{ id = 400006, delay = 30, },
 	},
-	elements = { 
-		400006
+	elements = {
+		400006,
 	},
-	event = "death"
+	event = "death",
 }
 local optsrespawn_ground_sniper_1 = {
-	on_executed = { 
-		{ id = 400023, delay = 30 }
+	on_executed = {
+		{ id = 400023, delay = 30, },
 	},
-	elements = { 
-		400023
+	elements = {
+		400023,
 	},
-	event = "death"
+	event = "death",
 }
 local optsrespawn_ground_sniper_2 = {
-	on_executed = { 
-		{ id = 400024, delay = 30 }
+	on_executed = {
+		{ id = 400024, delay = 30, },
 	},
-	elements = { 
-		400024
+	elements = {
+		400024,
 	},
-	event = "death"
+	event = "death",
 }
 local optsrespawn_tank = {
-	on_executed = { 
-		{ id = 400058, delay = 150 }
+	on_executed = {
+		{ id = 400058, delay = 150, },
 	},
-	elements = { 
-		400058
+	elements = {
+		400058,
 	},
-	event = "death"
+	event = "death",
+}
+local opts_pro_job_ponr = {
+	elements = { 100989, 103322, 103323, 103324, },
+	trigger_times = 1,
+	time_balance_mul_include_team_ai = true,
+	time_balance_mul = ponr_timer_player_mul,
+	time_easy = ponr_value,
+	time_normal = ponr_value,
+	time_hard = ponr_value,
+	time_overkill = ponr_value,
+	time_overkill_145 = ponr_value,
+	time_easy_wish = ponr_value,
+	time_overkill_290 = ponr_value,
+	time_sm_wish = ponr_value,
+	enabled = pro_job,
+}
+local opts_pro_job_ponr_counter = {
+	enabled = true,
+	counter_target = 1,
+	on_executed = {
+		{ id = 400060, delay = 0, },
+	},
 }
 
 return {
-    elements = {
-        --Snipers
-		restoration:gen_dummy(
-            400001,
-            "sniper_1",
-            Vector3(3385, -3308, 540.404),
-            Rotation(-90, 0, -0),
-            optsSniper_1
-        ),
-		restoration:gen_dummy(
-            400002,
-            "sniper_2",
-            Vector3(3285, -3308, 540.404),
-            Rotation(-90, 0, -0),
-            optsSniper_2
-        ),
-		restoration:gen_dummy(
-            400003,
-            "sniper_3",
-            Vector3(4202, 4376, 540.404),
-            Rotation(90, -0, -0),
-            optsSniper_3
-        ),
-		restoration:gen_dummy(
-            400004,
-            "sniper_4",
-            Vector3(4133, 4368, 540.404),
-            Rotation(90, -0, -0),
-            optsSniper_4
-        ),
-		restoration:gen_dummy(
-            400005,
-            "sniper_5",
-            Vector3(5936, 405, 540.404),
-            Rotation(0, 0, -0),
-            optsSniper_5
-        ),
-		restoration:gen_dummy(
-            400006,
-            "sniper_6",
-            Vector3(5936, 500, 540.404),
-            Rotation(0, 0, -0),
-            optsSniper_6
-        ),
-		restoration:gen_so(
-            400007,
-            "sniper_so_1",
-            Vector3(3974, -2994, 540.404),
-            Rotation(0, 0, -0),
-            optsSniper_SO
-        ),
-		restoration:gen_so(
-            400008,
-            "sniper_so_2",
-            Vector3(4132, -2997, 540.404),
-            Rotation(0, 0, -0),
-            optsSniper_SO
-        ),
-		restoration:gen_so(
-            400009,
-            "sniper_so_3",
-            Vector3(3509, 4051, 540.404),
-            Rotation(-180, 0, -0),
-            optsSniper_SO
-        ),
-		restoration:gen_so(
-            400010,
-            "sniper_so_4",
-            Vector3(3701, 4051, 540.404),
-            Rotation(-180, 0, -0),
-            optsSniper_SO
-        ),
-		restoration:gen_so(
-            400011,
-            "sniper_so_5",
-            Vector3(5643, 1060, 540.404),
-            Rotation(90, -0, -0),
-            optsSniper_SO
-        ),
-		restoration:gen_so(
-            400012,
-            "sniper_so_6",
-            Vector3(5643, 929, 540.404),
-            Rotation(90, -0, -0),
-            optsSniper_SO
-        ),
-		--Mission Scripts
-		restoration:gen_missionscript(
-            400013,
-            "spawn_snipers_1",
-            spawnSnipers_1
-        ),
-		restoration:gen_missionscript(
-            400014,
-            "spawn_snipers_2",
-            spawnSnipers_2
-        ),
-		restoration:gen_missionscript(
-            400015,
-            "spawn_snipers_3",
-            spawnSnipers_3
-        ),
-		restoration:gen_dummytrigger(
-            400016,
-            "respawn_sniper_1",
-            Vector3(-2400, -3677, 375),
-            Rotation(90, -0, -0),
-            optsrespawn_sniper_1
-        ),
-		restoration:gen_dummytrigger(
-            400017,
-            "respawn_sniper_2",
-            Vector3(-2400, -3577, 375),
-            Rotation(90, -0, -0),
-            optsrespawn_sniper_2
-        ),
-		restoration:gen_dummytrigger(
-            400018,
-            "respawn_sniper_3",
-            Vector3(-2400, -3677, 375),
-            Rotation(90, -0, -0),
-            optsrespawn_sniper_3
-        ),
-		restoration:gen_dummytrigger(
-            400019,
-            "respawn_sniper_4",
-            Vector3(-2400, -3577, 375),
-            Rotation(90, -0, -0),
-            optsrespawn_sniper_4
-        ),
-		restoration:gen_dummytrigger(
-            400020,
-            "respawn_sniper_5",
-            Vector3(-2400, -3677, 375),
-            Rotation(90, -0, -0),
-            optsrespawn_sniper_5
-        ),
-		restoration:gen_dummytrigger(
-            400021,
-            "respawn_sniper_6",
-            Vector3(-2400, -3577, 375),
-            Rotation(90, -0, -0),
-            optsrespawn_sniper_6
-        ),
-		restoration:gen_dialogue(
-            400022,
-            "they_sending_snipers",
-            Bain_sendsnipers
-        ),
-		--Ground Snipers
-		restoration:gen_dummy(
-            400023,
-            "ground_sniper_1",
-            Vector3(-2983, 193, 0),
-            Rotation(0, 0, -0),
-            optsGroundSniper_1
-        ),
-		restoration:gen_dummy(
-            400024,
-            "ground_sniper_2",
-            Vector3(-2559, -2495, 0),
-            Rotation(-90, 0, -0),
-            optsGroundSniper_2
-        ),
-		restoration:gen_so(
-            400025,
-            "ground_sniper_loop_1_1",
-            Vector3(-2189, 1500, -0),
-            Rotation(-90, 0, -0),
-            optsgroundSniper_SO_1_1
-        ),
-		restoration:gen_so(
-            400026,
-            "ground_sniper_loop_1_2",
-            Vector3(-1024.726, 3595.228, 0),
-            Rotation(-130, 0, -0),
-            optsgroundSniper_SO_1_2
-        ),
-		restoration:gen_so(
-            400027,
-            "ground_sniper_loop_1_3",
-            Vector3(617, 1198, 0),
-            Rotation(-80, 0, -0),
-            optsgroundSniper_SO_1_3
-        ),
-		restoration:gen_so(
-            400028,
-            "ground_sniper_loop_1_4",
-            Vector3(-186, -1162, 0),
-            Rotation(-90, 0, -0),
-            optsgroundSniper_SO_1_4
-        ),
-		restoration:gen_so(
-            400029,
-            "ground_sniper_loop_2_1",
-            Vector3(413, -1575, 0),
-            Rotation(-90, 0, -0),
-            optsgroundSniper_SO_2_1
-        ),
-		restoration:gen_so(
-            400030,
-            "ground_sniper_loop_2_2",
-            Vector3(1096, -1170, 0),
-            Rotation(-104, 0, -0),
-            optsgroundSniper_SO_2_2
-        ),
-		restoration:gen_so(
-            400031,
-            "ground_sniper_loop_2_3",
-            Vector3(1476, 656, -0),
-            Rotation(-55, 0, -0),
-            optsgroundSniper_SO_2_3
-        ),
-		restoration:gen_so(
-            400032,
-            "ground_sniper_loop_2_4",
-            Vector3(-465, 1287, -0),
-            Rotation(-90, 0, -0),
-            optsgroundSniper_SO_2_4
-        ),
-		restoration:gen_dummytrigger(
-            400033,
-            "respawn_ground_sniper_1",
-            Vector3(-2400, -3677, 375),
-            Rotation(90, -0, -0),
-            optsrespawn_ground_sniper_1
-        ),
-		restoration:gen_dummytrigger(
-            400034,
-            "respawn_ground_sniper_2",
-            Vector3(-2400, -3577, 375),
-            Rotation(90, -0, -0),
-            optsrespawn_ground_sniper_2
-        ),
-		--FBI Ready Team
-		restoration:gen_dummy(
-            400035,
-            "fbi_team_1",
-            Vector3(-2974, 6585, 0),
-            Rotation(180, 0, -0),
-            optsFBIAgent_1
-        ),
-		restoration:gen_dummy(
-            400036,
-            "fbi_team_2",
-            Vector3(-2973.040, 6639.992, 0),
-            Rotation(180, 0, -0),
-            optsFBIAgent_2
-        ),
-		restoration:gen_dummy(
-            400037,
-            "fbi_team_3",
-            Vector3(-2971.906, 6704.982, 0),
-            Rotation(180, 0, -0),
-            optsFBIAgent_2
-        ),
-		restoration:gen_dummy(
-            400038,
-            "fbi_team_4",
-            Vector3(-2970.963, 6758.974, 0),
-            Rotation(180, 0, -0),
-            optsFBIAgent_1
-        ),
-		restoration:gen_dummy(
-            400039,
-            "fbi_team_5",
-            Vector3(-2970.021, 6812.965, 0),
-            Rotation(180, 0, -0),
-            optsFBIAgent_1
-        ),
-		restoration:gen_dummy(
-            400040,
-            "fbi_team_6",
-            Vector3(-2969.235, 6857.958, 0),
-            Rotation(180, 0, -0),
-            optsFBIAgent_2
-        ),
-		restoration:gen_dummy(
-            400041,
-            "fbi_team_7",
-            Vector3(-2970, -70, -0),
-            Rotation(0, 0, -0),
-            optsFBIAgent_2
-        ),
-		restoration:gen_dummy(
-            400042,
-            "fbi_team_8",
-            Vector3(-2970, -144, -0),
-            Rotation(0, 0, -0),
-            optsFBIAgent_2
-        ),
-		restoration:gen_dummy(
-            400043,
-            "fbi_team_9",
-            Vector3(-2970, -219, -0),
-            Rotation(0, 0, -0),
-            optsFBIAgent_1
-        ),
-		restoration:gen_dummy(
-            400044,
-            "fbi_team_10",
-            Vector3(-2970, -297, -0),
-            Rotation(0, 0, -0),
-            optsFBIAgent_1
-        ),
-		restoration:gen_dummy(
-            400045,
-            "fbi_team_11",
-            Vector3(-2970, -359, -0),
-            Rotation(0, 0, -0),
-            optsFBIAgent_2
-        ),
-		restoration:gen_dummy(
-            400046,
-            "fbi_team_12",
-            Vector3(-2970, -419, -0),
-            Rotation(0, 0, -0),
-            optsFBIAgent_2
-        ),
-		restoration:gen_dummy(
-            400047,
-            "fbi_team_13",
-            Vector3(-2446, -2502, 0),
-            Rotation(-90, 0, -0),
-            optsFBIAgent_2
-        ),
-		restoration:gen_dummy(
-            400048,
-            "fbi_team_14",
-            Vector3(-2383, -2502, 0),
-            Rotation(-90, 0, -0),
-            optsFBIAgent_2
-        ),
-		restoration:gen_dummy(
-            400049,
-            "fbi_team_15",
-            Vector3(-2314, -2502, 0),
-            Rotation(-90, 0, -0),
-            optsFBIAgent_1
-        ),
-		restoration:gen_dummy(
-            400050,
-            "fbi_team_16",
-            Vector3(-2248, -2502, 0),
-            Rotation(-90, 0, -0),
-            optsFBIAgent_1
-        ),
-		restoration:gen_dummy(
-            400051,
-            "fbi_team_17",
-            Vector3(-2162, -2502, 0),
-            Rotation(-90, 0, -0),
-            optsFBIAgent_2
-        ),
-		restoration:gen_dummy(
-            400052,
-            "fbi_team_18",
-            Vector3(-2075, -2502, 0),
-            Rotation(-90, 0, -0),
-            optsFBIAgent_1
-        ),
-		restoration:gen_dummy(
-            400053,
-            "fbi_team_tank",
-            Vector3(-2348, -2573, 0),
-            Rotation(-90, 0, -0),
-            optsFBIAgent_3
-        ),
-		restoration:gen_missionscript(
-            400054,
-            "spawn_agents",
-            spawnFBI_Agents
-        ),
-		restoration:gen_missionscript(
-            400055,
-            "loop",
-            loopFBIAgents
-        ),
-		restoration:gen_missionscript(
-            400056,
-            "spawn_ground_snipers",
-            spawnGroundSnipers
-        ),
-		restoration:gen_so(
-            400057,
-            "hunt_so",
-            Vector3(3974, -2994, 540.404),
-            Rotation(0, 0, -0),
-            optsHunt_SO
-        ),
-		restoration:gen_dummy(
-            400058,
-            "bulldozer",
-            Vector3(-2961, 3277, -0),
-            Rotation(180, 0, -0),
-            optsDozer
-        ),
-		restoration:gen_dummytrigger(
-            400059,
-            "respawn_tank",
-            Vector3(-2400, -3577, 375),
-            Rotation(90, -0, -0),
-            optsrespawn_tank
-        ),
-    }
+	elements = {
+		-- Snipers
+		restoration:gen_dummy(400001, "sniper_1", Vector3(3385, -3308, 540.404), Rotation(-90, 0, 0), optsSniper_1),
+		restoration:gen_dummy(400002, "sniper_2", Vector3(3285, -3308, 540.404), Rotation(-90, 0, 0), optsSniper_2),
+		restoration:gen_dummy(400003, "sniper_3", Vector3(4202, 4376, 540.404), Rotation(90, 0, 0), optsSniper_3),
+		restoration:gen_dummy(400004, "sniper_4", Vector3(4133, 4368, 540.404), Rotation(90, 0, 0), optsSniper_4),
+		restoration:gen_dummy(400005, "sniper_5", Vector3(5936, 405, 540.404), Rotation(0, 0, 0), optsSniper_5),
+		restoration:gen_dummy(400006, "sniper_6", Vector3(5936, 500, 540.404), Rotation(0, 0, 0), optsSniper_6),
+		restoration:gen_so(400007, "sniper_so_1", Vector3(3974, -2994, 540.404), Rotation(0, 0, 0), optsSniper_SO),
+		restoration:gen_so(400008, "sniper_so_2", Vector3(4132, -2997, 540.404), Rotation(0, 0, 0), optsSniper_SO),
+		restoration:gen_so(400009, "sniper_so_3", Vector3(3509, 4051, 540.404), Rotation(-180, 0, 0), optsSniper_SO),
+		restoration:gen_so(400010, "sniper_so_4", Vector3(3701, 4051, 540.404), Rotation(-180, 0, 0), optsSniper_SO),
+		restoration:gen_so(400011, "sniper_so_5", Vector3(5643, 1060, 540.404), Rotation(90, 0, 0), optsSniper_SO),
+		restoration:gen_so(400012, "sniper_so_6", Vector3(5643, 929, 540.404), Rotation(90, 0, 0), optsSniper_SO),
+		-- Mission Scripts
+		restoration:gen_missionscript(400013, "spawn_snipers_1", spawnSnipers_1),
+		restoration:gen_missionscript(400014, "spawn_snipers_2", spawnSnipers_2),
+		restoration:gen_missionscript(400015, "spawn_snipers_3", spawnSnipers_3),
+		restoration:gen_dummytrigger(400016, "respawn_sniper_1", Vector3(-2400, -3677, 375), Rotation(90, 0, 0), optsrespawn_sniper_1),
+		restoration:gen_dummytrigger(400017, "respawn_sniper_2", Vector3(-2400, -3577, 375), Rotation(90, 0, 0), optsrespawn_sniper_2),
+		restoration:gen_dummytrigger(400018, "respawn_sniper_3", Vector3(-2400, -3677, 375), Rotation(90, 0, 0), optsrespawn_sniper_3),
+		restoration:gen_dummytrigger(400019, "respawn_sniper_4", Vector3(-2400, -3577, 375), Rotation(90, 0, 0), optsrespawn_sniper_4),
+		restoration:gen_dummytrigger(400020, "respawn_sniper_5", Vector3(-2400, -3677, 375), Rotation(90, 0, 0), optsrespawn_sniper_5),
+		restoration:gen_dummytrigger(400021, "respawn_sniper_6", Vector3(-2400, -3577, 375), Rotation(90, 0, 0), optsrespawn_sniper_6),
+		restoration:gen_dialogue(400022, "they_sending_snipers", Bain_sendsnipers),
+		-- Ground Snipers
+		restoration:gen_dummy(400023, "ground_sniper_1", Vector3(-2983, 193, 0), Rotation(0, 0, 0), optsGroundSniper_1),
+		restoration:gen_dummy(400024, "ground_sniper_2", Vector3(-2559, -2495, 0), Rotation(-90, 0, 0), optsGroundSniper_2),
+		restoration:gen_so(400025, "ground_sniper_loop_1_1", Vector3(-2189, 1500, 0), Rotation(-90, 0, 0), optsgroundSniper_SO_1_1),
+		restoration:gen_so(400026, "ground_sniper_loop_1_2", Vector3(-1024.726, 3595.228, 0), Rotation(-130, 0, 0), optsgroundSniper_SO_1_2),
+		restoration:gen_so(400027, "ground_sniper_loop_1_3", Vector3(617, 1198, 0), Rotation(-80, 0, 0), optsgroundSniper_SO_1_3),
+		restoration:gen_so(400028, "ground_sniper_loop_1_4", Vector3(-186, -1162, 0), Rotation(-90, 0, 0), optsgroundSniper_SO_1_4),
+		restoration:gen_so(400029, "ground_sniper_loop_2_1", Vector3(413, -1575, 0), Rotation(-90, 0, 0), optsgroundSniper_SO_2_1),
+		restoration:gen_so(400030, "ground_sniper_loop_2_2", Vector3(1096, -1170, 0), Rotation(-104, 0, 0), optsgroundSniper_SO_2_2),
+		restoration:gen_so(400031, "ground_sniper_loop_2_3", Vector3(1476, 656, 0), Rotation(-55, 0, 0), optsgroundSniper_SO_2_3),
+		restoration:gen_so(400032, "ground_sniper_loop_2_4", Vector3(-465, 1287, 0), Rotation(-90, 0, 0), optsgroundSniper_SO_2_4),
+		restoration:gen_dummytrigger(400033, "respawn_ground_sniper_1", Vector3(-2400, -3677, 375), Rotation(90, 0, 0), optsrespawn_ground_sniper_1),
+		restoration:gen_dummytrigger(400034, "respawn_ground_sniper_2", Vector3(-2400, -3577, 375), Rotation(90, 0, 0), optsrespawn_ground_sniper_2),
+		-- FBI Ready Team
+		restoration:gen_dummy(400035, "fbi_team_1", Vector3(-2974, 6585, 0), Rotation(180, 0, 0), optsFBIAgent_1),
+		restoration:gen_dummy(400036, "fbi_team_2",Vector3(-2973.040, 6639.992, 0), 	Rotation(180, 0, 0), optsFBIAgent_2),
+		restoration:gen_dummy(400037, "fbi_team_3", Vector3(-2971.906, 6704.982, 0), Rotation(180, 0, 0), optsFBIAgent_2),
+		restoration:gen_dummy(400038, "fbi_team_4", Vector3(-2970.963, 6758.974, 0), Rotation(180, 0, 0), optsFBIAgent_1),
+		restoration:gen_dummy(400039, "fbi_team_5", Vector3(-2970.021, 6812.965, 0), Rotation(180, 0, 0), optsFBIAgent_1),
+		restoration:gen_dummy(400040, "fbi_team_6", Vector3(-2969.235, 6857.958, 0), Rotation(180, 0, 0), optsFBIAgent_2),
+		restoration:gen_dummy(400041, "fbi_team_7", Vector3(-2970, -70, 0), Rotation(0, 0, 0), optsFBIAgent_2),
+		restoration:gen_dummy(400042, "fbi_team_8", Vector3(-2970, -144, 0), Rotation(0, 0, 0), optsFBIAgent_2),
+		restoration:gen_dummy(400043, "fbi_team_9", Vector3(-2970, -219, 0), Rotation(0, 0, 0), optsFBIAgent_1),
+		restoration:gen_dummy(400044, "fbi_team_10", Vector3(-2970, -297, 0), Rotation(0, 0, 0), optsFBIAgent_1),
+		restoration:gen_dummy(400045, "fbi_team_11", Vector3(-2970, -359, 0), Rotation(0, 0, 0), optsFBIAgent_2),
+		restoration:gen_dummy(400046, "fbi_team_12", Vector3(-2970, -419, 0), Rotation(0, 0, 0), optsFBIAgent_2),
+		restoration:gen_dummy(400047, "fbi_team_13", Vector3(-2446, -2502, 0), Rotation(-90, 0, 0), optsFBIAgent_2),
+		restoration:gen_dummy(400048, "fbi_team_14", Vector3(-2383, -2502, 0), Rotation(-90, 0, 0), optsFBIAgent_2),
+		restoration:gen_dummy(400049, "fbi_team_15", Vector3(-2314, -2502, 0), Rotation(-90, 0, 0), optsFBIAgent_1),
+		restoration:gen_dummy(400050, "fbi_team_16", Vector3(-2248, -2502, 0), Rotation(-90, 0, 0), optsFBIAgent_1),
+		restoration:gen_dummy(400051, "fbi_team_17", Vector3(-2162, -2502, 0), Rotation(-90, 0, 0), optsFBIAgent_2),
+		restoration:gen_dummy(400052, "fbi_team_18", Vector3(-2075, -2502, 0), Rotation(-90, 0, 0), optsFBIAgent_1),
+		restoration:gen_dummy(400053, "fbi_team_tank", Vector3(-2348, -2573, 0), Rotation(-90, 0, 0), optsFBIAgent_3),
+		restoration:gen_missionscript(400054, "spawn_agents", spawnFBI_Agents),
+		restoration:gen_missionscript(400055, "loop", loopFBIAgents),
+		restoration:gen_missionscript(400056, "spawn_ground_snipers", spawnGroundSnipers),
+		restoration:gen_so(400057, "hunt_so", Vector3(3974, -2994, 540.404), Rotation(0, 0, 0), optsHunt_SO),
+		restoration:gen_dummy(400058, "bulldozer", Vector3(-2961, 3277, 0), Rotation(180, 0, 0), optsDozer),
+		restoration:gen_dummytrigger(400059, "respawn_tank", Vector3(-2400, -3577, 375), Rotation(90, 0, 0), optsrespawn_tank),
+		-- Pro Job PONR
+		restoration:gen_pointofnoreturn(400060, "pro_job_ponr", Vector3(0, 0, 0), Rotation(0, 0, 0), opts_pro_job_ponr),
+		restoration:gen_counter(400061, "pro_job_ponr_counter", Vector3(0, 0, 0), Rotation(0, 0, 0), opts_pro_job_ponr_counter),
+	},
 }
-]]--

--- a/req/mission_script_add/watchdogs_2.lua
+++ b/req/mission_script_add/watchdogs_2.lua
@@ -1,12 +1,32 @@
---TODO: MAKE FBI READY TEAMS LESS SPAMMY
 local difficulty = tweak_data:difficulty_to_index(Global.game_settings and Global.game_settings.difficulty or "normal")
 local pro_job = Global.game_settings and Global.game_settings.one_down
+local cloaker = "units/payday2/characters/ene_spook_1/ene_spook_1"
 local sniper = "units/payday2/characters/ene_sniper_1/ene_sniper_1"
 local fbi_ready_team_1 = "units/payday2/characters/ene_hoxton_breakout_responder_1/ene_hoxton_breakout_responder_1"
 local fbi_ready_team_2 = "units/payday2/characters/ene_hoxton_breakout_responder_2/ene_hoxton_breakout_responder_2"
 local fbi_ready_team_dozer = "units/pd2_mod_lapd/characters/ene_bulldozer_3/ene_bulldozer_3"
 local tank = "units/payday2/characters/ene_bulldozer_1/ene_bulldozer_1"
-local deathwish_above = difficulty >= 7
+-- First ship sniper is disallowed on Normal outside of Pro Jobs
+local ship_sniper_enabled = pro_job or difficulty > 2
+-- Second ship sniper is disallowed below Overkill, or on Normal if Pro Job
+local ship_sniper_enabled_second = pro_job and difficulty > 2 or difficulty > 4
+-- Ship snipers respawn faster on DW/DS
+local ship_sniper_respawn_delay = difficulty < 7 and 90 or 60
+local ship_sniper_respawn_delay_rand = ship_sniper_respawn_delay
+-- Ground snipers are disallowed below Mayhem, or Very Hard if Pro Job
+local ground_sniper_enabled = pro_job and difficulty > 3 or difficulty > 5
+local ground_sniper_amount = difficulty > 6 and 2 or 1
+-- Ground snipers also respawn faster on DW/DS but take longer than ship snipers
+local ground_sniper_respawn_delay = ship_sniper_respawn_delay * 1.5
+local ground_sniper_respawn_delay_rand = ground_sniper_respawn_delay
+local ground_sniper_rotate_delay = 15
+local ground_sniper_rotate_delay_rand = 30
+local any_snipers_enabled = ship_sniper_enabled or ship_sniper_enabled_second or ground_sniper_enabled
+local fbi_ready_team_dozer_enabled = pro_job and difficulty > 5 or difficulty > 6
+local fbi_ready_team_dozer_trigger_times = (pro_job and difficulty > 6 or difficulty > 7) and 2 or 1
+local fbi_ready_team_group_spawn_amount = difficulty > 3 and 2 or 1
+local looping_dozer_respawn_delay = pro_job and 150 or 210
+local looping_dozer_respawn_delay_rand = looping_dozer_respawn_delay * 0.5
 local ponr_value = (difficulty <= 5 and 1080 or (difficulty == 6 or difficulty == 7) and 1050) or 1020
 local ponr_timer_player_mul = {
 	1,
@@ -16,95 +36,90 @@ local ponr_timer_player_mul = {
 	0.65,  -- 5+ players
 }
 
-local optsSniper_1 = {
+local opts_ship_sniper_1 = {
 	enemy = sniper,
 	on_executed = {
 		{ id = 400007, delay = 0, },
 	},
-	enabled = true,
+	enabled = ship_sniper_enabled,
 }
-local optsSniper_2 = {
+local opts_ship_sniper_2 = {
 	enemy = sniper,
 	on_executed = {
 		{ id = 400008, delay = 0, },
 	},
-	enabled = true,
+	enabled = ship_sniper_enabled_second,
 }
-local optsSniper_3 = {
+local opts_ship_sniper_3 = {
 	enemy = sniper,
 	on_executed = {
 		{ id = 400009, delay = 0, },
 	},
-	enabled = true,
+	enabled = ship_sniper_enabled,
 }
-local optsSniper_4 = {
+local opts_ship_sniper_4 = {
 	enemy = sniper,
 	on_executed = {
 		{ id = 400010, delay = 0, },
 	},
-	enabled = true,
+	enabled = ship_sniper_enabled_second,
 }
-local optsSniper_5 = {
+local opts_ship_sniper_5 = {
 	enemy = sniper,
 	on_executed = {
 		{ id = 400011, delay = 0, },
 	},
-	enabled = true,
+	enabled = ship_sniper_enabled,
 }
-local optsSniper_6 = {
+local opts_ship_sniper_6 = {
 	enemy = sniper,
 	on_executed = {
 		{ id = 400012, delay = 0, },
 	},
-	enabled = true,
+	enabled = ship_sniper_enabled_second,
 }
-local optsGroundSniper_1 = {
+local opts_ground_sniper_1 = {
 	enemy = sniper,
+	trigger_times = 1,
 	on_executed = {
 		{ id = 400025, delay = 0, },
 	},
-	enabled = true,
+	enabled = ground_sniper_enabled,
 }
-local optsGroundSniper_2 = {
+local opts_ground_sniper_2 = {
 	enemy = sniper,
+	trigger_times = 1,
 	on_executed = {
 		{ id = 400029, delay = 0, },
 	},
-	enabled = true,
+	enabled = ground_sniper_enabled,
 }
-local optsFBIAgent_1 = {
+local opts_fbi_ready_team_agent = {
 	enemy = fbi_ready_team_1,
-	participate_to_group_ai = true,
+	enemy_table = { fbi_ready_team_1, fbi_ready_team_2, },
+	-- participate_to_group_ai = true,
 	on_executed = {
 		{ id = 400057, delay = 0, },
 	},
 	enabled = true,
 }
-local optsFBIAgent_2 = {
-	enemy = fbi_ready_team_2,
-	participate_to_group_ai = true,
-	on_executed = {
-		{ id = 400057, delay = 0, },
-	},
-	enabled = true,
-}
-local optsFBIAgent_3 = {
+local opts_fbi_ready_team_dozer = {
 	enemy = fbi_ready_team_dozer,
-	trigger_times = 1,
-	participate_to_group_ai = true,
+	trigger_times = 0,
+	-- participate_to_group_ai = true,
 	on_executed = {
 		{ id = 400057, delay = 0, },
 	},
-	enabled = deathwish_above,
+	enabled = fbi_ready_team_dozer_enabled,
 }
-local optsDozer = {
+local opts_looping_dozer = {
 	enemy = tank,
 	on_executed = {
 		{ id = 400057, delay = 3, },
 	},
 	enabled = true,
 }
-local optsSniper_SO = {
+local opts_ship_sniper_so = {
 	scan = true,
 	align_position = true,
 	needs_pos_rsrv = true,
@@ -112,13 +127,13 @@ local optsSniper_SO = {
 	interval = 2,
 	so_action = "AI_sniper",
 }
-local optsHunt_SO = {
+local opts_hunt_so = {
 	scan = true,
 	SO_access = tostring(128 + 4096),
 	interval = 2,
 	so_action = "AI_hunt",
 }
-local optsgroundSniper_SO_1_1 = {
+local opts_ground_sniper_so_1_1 = {
 	scan = true,
 	align_position = true,
 	needs_pos_rsrv = true,
@@ -126,10 +141,10 @@ local optsgroundSniper_SO_1_1 = {
 	interval = 2,
 	so_action = "AI_sniper",
 	on_executed = {
-		{ id = 400026, delay = 15, },
+		{ id = 400026, delay = ground_sniper_rotate_delay, delay_rand = ground_sniper_rotate_delay_rand, },
 	},
 }
-local optsgroundSniper_SO_1_2 = {
+local opts_ground_sniper_so_1_2 = {
 	scan = true,
 	align_position = true,
 	needs_pos_rsrv = true,
@@ -137,10 +152,10 @@ local optsgroundSniper_SO_1_2 = {
 	interval = 2,
 	so_action = "AI_sniper",
 	on_executed = {
-		{ id = 400027, delay = 15, },
+		{ id = 400027, delay = ground_sniper_rotate_delay, delay_rand = ground_sniper_rotate_delay_rand, },
 	},
 }
-local optsgroundSniper_SO_1_3 = {
+local opts_ground_sniper_so_1_3 = {
 	scan = true,
 	align_position = true,
 	needs_pos_rsrv = true,
@@ -148,10 +163,10 @@ local optsgroundSniper_SO_1_3 = {
 	interval = 2,
 	so_action = "AI_sniper",
 	on_executed = {
-		{ id = 400028, delay = 15, },
+		{ id = 400028, delay = ground_sniper_rotate_delay, delay_rand = ground_sniper_rotate_delay_rand, },
 	},
 }
-local optsgroundSniper_SO_1_4 = {
+local opts_ground_sniper_so_1_4 = {
 	scan = true,
 	align_position = true,
 	needs_pos_rsrv = true,
@@ -159,10 +174,10 @@ local optsgroundSniper_SO_1_4 = {
 	interval = 2,
 	so_action = "AI_sniper",
 	on_executed = {
-		{ id = 400025, delay = 15, },
+		{ id = 400025, delay = ground_sniper_rotate_delay, delay_rand = ground_sniper_rotate_delay_rand, },
 	},
 }
-local optsgroundSniper_SO_2_1 = {
+local opts_ground_sniper_so_2_1 = {
 	scan = true,
 	align_position = true,
 	needs_pos_rsrv = true,
@@ -170,10 +185,10 @@ local optsgroundSniper_SO_2_1 = {
 	interval = 2,
 	so_action = "AI_sniper",
 	on_executed = {
-		{ id = 400030, delay = 15, },
+		{ id = 400030, delay = ground_sniper_rotate_delay, delay_rand = ground_sniper_rotate_delay_rand, },
 	},
 }
-local optsgroundSniper_SO_2_2 = {
+local opts_ground_sniper_so_2_2 = {
 	scan = true,
 	align_position = true,
 	needs_pos_rsrv = true,
@@ -181,10 +196,10 @@ local optsgroundSniper_SO_2_2 = {
 	interval = 2,
 	so_action = "AI_sniper",
 	on_executed = {
-		{ id = 400031, delay = 15, },
+		{ id = 400031, delay = ground_sniper_rotate_delay, delay_rand = ground_sniper_rotate_delay_rand, },
 	},
 }
-local optsgroundSniper_SO_2_3 = {
+local opts_ground_sniper_so_2_3 = {
 	scan = true,
 	align_position = true,
 	needs_pos_rsrv = true,
@@ -192,10 +207,10 @@ local optsgroundSniper_SO_2_3 = {
 	interval = 2,
 	so_action = "AI_sniper",
 	on_executed = {
-		{ id = 400032, delay = 15, },
+		{ id = 400032, delay = ground_sniper_rotate_delay, delay_rand = ground_sniper_rotate_delay_rand, },
 	},
 }
-local optsgroundSniper_SO_2_4 = {
+local opts_ground_sniper_so_2_4 = {
 	scan = true,
 	align_position = true,
 	needs_pos_rsrv = true,
@@ -203,10 +218,10 @@ local optsgroundSniper_SO_2_4 = {
 	interval = 2,
 	so_action = "AI_sniper",
 	on_executed = {
-		{ id = 400029, delay = 15, },
+		{ id = 400029, delay = ground_sniper_rotate_delay, delay_rand = ground_sniper_rotate_delay_rand, },
 	},
 }
-local spawnSnipers_1 = {
+local opts_spawn_ship_snipers_1 = {
 	enabled = true,
 	trigger_times = 1,
 	on_executed = {
@@ -215,7 +230,7 @@ local spawnSnipers_1 = {
 		{ id = 400022, delay = 0, },
 	},
 }
-local spawnSnipers_2 = {
+local opts_spawn_ship_snipers_2 = {
 	enabled = true,
 	trigger_times = 1,
 	on_executed = {
@@ -224,7 +239,7 @@ local spawnSnipers_2 = {
 		{ id = 400022, delay = 0, },
 	},
 }
-local spawnSnipers_3 = {
+local opts_spawn_ship_snipers_3 = {
 	enabled = true,
 	trigger_times = 1,
 	on_executed = {
@@ -233,129 +248,100 @@ local spawnSnipers_3 = {
 		{ id = 400022, delay = 0, },
 	},
 }
-local spawnGroundSnipers = {
+local opts_spawn_ground_snipers = {
 	enabled = true,
 	on_executed = {
 		{ id = 400023, delay = 0, },
 		{ id = 400024, delay = 0, },
 	},
 }
-local spawnFBI_Agents = {
+local opts_spawn_fbi_ready_teams = {
 	enabled = true,
-	trigger_times = 3,
+	trigger_times = 6,
+	amount = fbi_ready_team_group_spawn_amount,
 	on_executed = {
-		{ id = 400035, delay = 0, },
-		{ id = 400036, delay = 0, },
-		{ id = 400037, delay = 0, },
-		{ id = 400038, delay = 0, },
-		{ id = 400039, delay = 0, },
-		{ id = 400040, delay = 0, },
-		{ id = 400041, delay = 0, },
-		{ id = 400042, delay = 0, },
-		{ id = 400043, delay = 0, },
-		{ id = 400044, delay = 0, },
-		{ id = 400045, delay = 0, },
-		{ id = 400046, delay = 0, },
-		{ id = 400047, delay = 0, },
-		{ id = 400048, delay = 0, },
-		{ id = 400049, delay = 0, },
-		{ id = 400050, delay = 0, },
-		{ id = 400051, delay = 0, },
-		{ id = 400052, delay = 0, },
-		{ id = 400053, delay = 0, },
-		{ id = 400055, delay = 0, },
+		{ id = 400077, delay = 0, },
+		{ id = 400078, delay = 0, },
+		{ id = 400079, delay = 0, },
+		{ id = 400080, delay = 0, },
 	},
 }
-local loopFBIAgents = {
+local opts_loop_fbi_ready_teams = {
 	enabled = true,
+	trigger_times = 6,
 	on_executed = {
-		{ id = 400054, delay = 80, },
+		{ id = 400054, delay = 0, delay_rand = 0, },
+		{ id = 400055, delay = 10, delay_rand = 10, },  -- Move to different element (this points to itself)
 	},
 }
-local Bain_sendsnipers = {
+local opts_they_sending_snipers = {
 	dialogue = "play_pln_gen_snip_01",
 	trigger_times = 1,
-	can_not_be_muted = true,
+	enabled = any_snipers_enabled,
 }
-local optsrespawn_sniper_1 = {
+local opts_respawn_ship_sniper_1 = {
 	on_executed = {
-		{ id = 400001, delay = 30, },
+		{ id = 400001, delay = ship_sniper_respawn_delay, delay_rand = ship_sniper_respawn_delay_rand, },
 	},
-	elements = {
-		400001,
-	},
+	elements = { 400001, },
 	event = "death",
 }
-local optsrespawn_sniper_2 = {
+local opts_respawn_ship_sniper_2 = {
 	on_executed = {
-		{ id = 400002, delay = 30, },
+		{ id = 400002, delay = ship_sniper_respawn_delay, delay_rand = ship_sniper_respawn_delay_rand, },
 	},
-	elements = {
-		400002,
-	},
+	elements = { 400002, },
 	event = "death",
 }
-local optsrespawn_sniper_3 = {
+local opts_respawn_ship_sniper_3 = {
 	on_executed = {
-		{ id = 400003, delay = 30, },
+		{ id = 400003, delay = ship_sniper_respawn_delay, delay_rand = ship_sniper_respawn_delay_rand, },
 	},
-	elements = {
-		400003,
-	},
+	elements = { 400003, },
 	event = "death",
 }
-local optsrespawn_sniper_4 = {
+local opts_respawn_ship_sniper_4 = {
 	on_executed = {
-		{ id = 400004, delay = 30, },
+		{ id = 400004, delay = ship_sniper_respawn_delay, delay_rand = ship_sniper_respawn_delay_rand, },
 	},
-	elements = {
-		400004,
-	},
+	elements = { 400004, },
 	event = "death",
 }
-local optsrespawn_sniper_5 = {
+local opts_respawn_ship_sniper_5 = {
 	on_executed = {
-		{ id = 400005, delay = 30, },
+		{ id = 400005, delay = ship_sniper_respawn_delay, delay_rand = ship_sniper_respawn_delay_rand, },
 	},
-	elements = {
-		400005,
-	},
+	elements = { 400005, },
 	event = "death",
 }
-local optsrespawn_sniper_6 = {
+local opts_respawn_ship_sniper_6 = {
 	on_executed = {
-		{ id = 400006, delay = 30, },
+		{ id = 400006, delay = ship_sniper_respawn_delay, delay_rand = ship_sniper_respawn_delay_rand, },
 	},
-	elements = {
-		400006,
-	},
+	elements = { 400006, },
 	event = "death",
 }
-local optsrespawn_ground_sniper_1 = {
+local opts_ground_sniper_1_died = {
 	on_executed = {
-		{ id = 400023, delay = 30, },
+		{ id = 400064, delay = 0, },
+		{ id = 400063, delay = ground_sniper_respawn_delay, delay = ground_sniper_respawn_delay_rand, },
 	},
-	elements = {
-		400023,
-	},
+	elements = { 400023, },
 	event = "death",
 }
-local optsrespawn_ground_sniper_2 = {
+local opts_ground_sniper_2_died = {
 	on_executed = {
-		{ id = 400024, delay = 30, },
+		{ id = 400065, delay = 0, },
+		{ id = 400063, delay = ground_sniper_respawn_delay, delay = ground_sniper_respawn_delay_rand, },
 	},
-	elements = {
-		400024,
-	},
+	elements = { 400024, },
 	event = "death",
 }
-local optsrespawn_tank = {
+local opts_respawn_looping_dozer = {
 	on_executed = {
-		{ id = 400058, delay = 150, },
+		{ id = 400058, delay = looping_dozer_respawn_delay, delay_rand = looping_dozer_respawn_delay_rand },
 	},
-	elements = {
-		400058,
-	},
+	elements = { 400058, },
 	event = "death",
 }
 local opts_pro_job_ponr = {
@@ -380,74 +366,226 @@ local opts_pro_job_ponr_counter = {
 		{ id = 400060, delay = 0, },
 	},
 }
+local opts_pick_ground_sniper_first_spawn = {
+	amount = ground_sniper_amount,
+	enabled = ground_sniper_enabled,
+	on_executed = {
+		{ id = 400023, delay = 0, },
+		{ id = 400024, delay = 0, },
+	},
+}
+local opts_pick_ground_sniper_respawn = {
+	amount = 1,
+	enabled = ground_sniper_enabled,
+	ignore_disabled = true,
+	on_executed = {
+		{ id = 400023, delay = 0, },
+		{ id = 400024, delay = 0, },
+	},
+}
+local opts_reenable_ground_sniper_1 = {
+	enabled = true,
+	elements = { 400023, },
+	set_trigger_times = 1,
+	toggle = "on",
+}
+local opts_reenable_ground_sniper_2 = {
+	enabled = true,
+	elements = { 400024, },
+	set_trigger_times = 1,
+	toggle = "on",
+}
+local opts_dock_cloaker_group = {
+	enabled = true,
+	ignore_disabled = true,
+	interval = 60,
+	preferred_spawn_groups = {
+		"single_spooc",
+		-- "FBI_spoocs",
+	},
+	elements = {
+		400072,
+		400073,
+		400074,
+		400075,
+		103961,
+		103963,
+		103965,
+		103967,
+		103969,
+		103971,
+		103973,
+		103975,
+		103977,
+		103979,
+	},
+}
+local opts_pick_enable_dock_cloaker_spawns = {
+	enabled = true,
+	amount = 1,
+	amount_random = 0,
+	ignore_disabled = true,
+	trigger_times = 4,
+	on_executed = {
+		{ id = 400068, delay = 0, },
+		{ id = 400069, delay = 0, },
+		{ id = 400070, delay = 0, },
+		{ id = 400071, delay = 0, },
+	},
+}
+local opts_enable_dock_cloaker_spawns_dock_7 = {
+	enabled = true,
+	trigger_times = 1,
+	elements = { 400073, 400074, 400075, },
+	toggle = "on",
+}
+local opts_enable_dock_cloaker_spawns_dock_8 = {
+	enabled = true,
+	trigger_times = 1,
+	elements = { 103963, 103965, 103967, },
+	toggle = "on",
+}
+local opts_enable_dock_cloaker_spawns_dock_9 = {
+	enabled = true,
+	trigger_times = 1,
+	elements = { 103973, 103975, 103977, 103979, },
+	toggle = "on",
+}
+local opts_enable_dock_cloaker_spawns_corners = {
+	enabled = true,
+	trigger_times = 1,
+	elements = { 103961, 400072, 103969, 103971, },
+	toggle = "on",
+}
+local opts_dock_cloaker_spawn = {
+	enemy = cloaker,
+	enabled = false,
+	spawn_action = "e_sp_clk_up_manhole",
+}
+local opts_add_dock_cloaker_group = {
+	enabled = true,
+	trigger_times = 1,
+	spawn_groups = { 400066, },
+}
+local opts_fbi_ready_team_agent_spawn_group_1 = {
+	enabled = true,
+	on_executed = {
+		{ id = 400038, delay = 0, },
+		{ id = 400039, delay = 0, },
+		{ id = 400040, delay = 0, },
+	},
+}
+local opts_fbi_ready_team_agent_spawn_group_2 = {
+	enabled = true,
+	on_executed = {
+		{ id = 400043, delay = 0, },
+		{ id = 400044, delay = 0, },
+		{ id = 400045, delay = 0, },
+	},
+}
+local opts_fbi_ready_team_agent_spawn_group_3 = {
+	enabled = true,
+	on_executed = {
+		{ id = 400047, delay = 0, },
+		{ id = 400048, delay = 0, },
+		{ id = 400049, delay = 0, },
+	},
+}
+local opts_fbi_ready_team_dozer_spawn_group_1 = {
+	enabled = fbi_ready_team_dozer_enabled,
+	trigger_times = fbi_ready_team_dozer_trigger_times,
+	on_executed = {
+		{ id = 400053, delay = 0, },
+	},
+}
 
 return {
 	elements = {
-		-- Snipers
-		restoration:gen_dummy(400001, "sniper_1", Vector3(3385, -3308, 540.404), Rotation(-90, 0, 0), optsSniper_1),
-		restoration:gen_dummy(400002, "sniper_2", Vector3(3285, -3308, 540.404), Rotation(-90, 0, 0), optsSniper_2),
-		restoration:gen_dummy(400003, "sniper_3", Vector3(4202, 4376, 540.404), Rotation(90, 0, 0), optsSniper_3),
-		restoration:gen_dummy(400004, "sniper_4", Vector3(4133, 4368, 540.404), Rotation(90, 0, 0), optsSniper_4),
-		restoration:gen_dummy(400005, "sniper_5", Vector3(5936, 405, 540.404), Rotation(0, 0, 0), optsSniper_5),
-		restoration:gen_dummy(400006, "sniper_6", Vector3(5936, 500, 540.404), Rotation(0, 0, 0), optsSniper_6),
-		restoration:gen_so(400007, "sniper_so_1", Vector3(3974, -2994, 540.404), Rotation(0, 0, 0), optsSniper_SO),
-		restoration:gen_so(400008, "sniper_so_2", Vector3(4132, -2997, 540.404), Rotation(0, 0, 0), optsSniper_SO),
-		restoration:gen_so(400009, "sniper_so_3", Vector3(3509, 4051, 540.404), Rotation(-180, 0, 0), optsSniper_SO),
-		restoration:gen_so(400010, "sniper_so_4", Vector3(3701, 4051, 540.404), Rotation(-180, 0, 0), optsSniper_SO),
-		restoration:gen_so(400011, "sniper_so_5", Vector3(5643, 1060, 540.404), Rotation(90, 0, 0), optsSniper_SO),
-		restoration:gen_so(400012, "sniper_so_6", Vector3(5643, 929, 540.404), Rotation(90, 0, 0), optsSniper_SO),
-		-- Mission Scripts
-		restoration:gen_missionscript(400013, "spawn_snipers_1", spawnSnipers_1),
-		restoration:gen_missionscript(400014, "spawn_snipers_2", spawnSnipers_2),
-		restoration:gen_missionscript(400015, "spawn_snipers_3", spawnSnipers_3),
-		restoration:gen_dummytrigger(400016, "respawn_sniper_1", Vector3(-2400, -3677, 375), Rotation(90, 0, 0), optsrespawn_sniper_1),
-		restoration:gen_dummytrigger(400017, "respawn_sniper_2", Vector3(-2400, -3577, 375), Rotation(90, 0, 0), optsrespawn_sniper_2),
-		restoration:gen_dummytrigger(400018, "respawn_sniper_3", Vector3(-2400, -3677, 375), Rotation(90, 0, 0), optsrespawn_sniper_3),
-		restoration:gen_dummytrigger(400019, "respawn_sniper_4", Vector3(-2400, -3577, 375), Rotation(90, 0, 0), optsrespawn_sniper_4),
-		restoration:gen_dummytrigger(400020, "respawn_sniper_5", Vector3(-2400, -3677, 375), Rotation(90, 0, 0), optsrespawn_sniper_5),
-		restoration:gen_dummytrigger(400021, "respawn_sniper_6", Vector3(-2400, -3577, 375), Rotation(90, 0, 0), optsrespawn_sniper_6),
-		restoration:gen_dialogue(400022, "they_sending_snipers", Bain_sendsnipers),
+		-- Ship Snipers
+		restoration:gen_dummy(400001, "ship_sniper_1", Vector3(3385, -3308, 540), Rotation(-90, 0, 0), opts_ship_sniper_1),
+		restoration:gen_dummy(400002, "ship_sniper_2", Vector3(3285, -3308, 540), Rotation(-90, 0, 0), opts_ship_sniper_2),
+		restoration:gen_dummy(400003, "ship_sniper_3", Vector3(4202, 4376, 540), Rotation(90, 0, 0), opts_ship_sniper_3),
+		restoration:gen_dummy(400004, "ship_sniper_4", Vector3(4133, 4368, 540), Rotation(90, 0, 0), opts_ship_sniper_4),
+		restoration:gen_dummy(400005, "ship_sniper_5", Vector3(5936, 405, 540), Rotation(0, 0, 0), opts_ship_sniper_5),
+		restoration:gen_dummy(400006, "ship_sniper_6", Vector3(5936, 500, 540), Rotation(0, 0, 0), opts_ship_sniper_6),
+		restoration:gen_so(400007, "ship_sniper_so_1", Vector3(3974, -2994, 540), Rotation(0, 0, 0), opts_ship_sniper_so),
+		restoration:gen_so(400008, "ship_sniper_so_2", Vector3(4132, -2997, 540), Rotation(0, 0, 0), opts_ship_sniper_so),
+		restoration:gen_so(400009, "ship_sniper_so_3", Vector3(3509, 4051, 540), Rotation(-180, 0, 0), opts_ship_sniper_so),
+		restoration:gen_so(400010, "ship_sniper_so_4", Vector3(3701, 4051, 540), Rotation(-180, 0, 0), opts_ship_sniper_so),
+		restoration:gen_so(400011, "ship_sniper_so_5", Vector3(5643, 1060, 540), Rotation(90, 0, 0), opts_ship_sniper_so),
+		restoration:gen_so(400012, "ship_sniper_so_6", Vector3(5643, 929, 540), Rotation(90, 0, 0), opts_ship_sniper_so),
+		restoration:gen_missionscript(400013, "spawn_ship_snipers_1", opts_spawn_ship_snipers_1),
+		restoration:gen_missionscript(400014, "spawn_ship_snipers_2", opts_spawn_ship_snipers_2),
+		restoration:gen_missionscript(400015, "spawn_ship_snipers_3", opts_spawn_ship_snipers_3),
+		restoration:gen_dummytrigger(400016, "respawn_ship_sniper_1", Vector3(-2400, -3677, 375), Rotation(90, 0, 0), opts_respawn_ship_sniper_1),
+		restoration:gen_dummytrigger(400017, "respawn_ship_sniper_2", Vector3(-2400, -3577, 375), Rotation(90, 0, 0), opts_respawn_ship_sniper_2),
+		restoration:gen_dummytrigger(400018, "respawn_ship_sniper_3", Vector3(-2400, -3677, 375), Rotation(90, 0, 0), opts_respawn_ship_sniper_3),
+		restoration:gen_dummytrigger(400019, "respawn_ship_sniper_4", Vector3(-2400, -3577, 375), Rotation(90, 0, 0), opts_respawn_ship_sniper_4),
+		restoration:gen_dummytrigger(400020, "respawn_ship_sniper_5", Vector3(-2400, -3677, 375), Rotation(90, 0, 0), opts_respawn_ship_sniper_5),
+		restoration:gen_dummytrigger(400021, "respawn_ship_sniper_6", Vector3(-2400, -3577, 375), Rotation(90, 0, 0), opts_respawn_ship_sniper_6),
+		restoration:gen_dialogue(400022, "they_sending_snipers", opts_they_sending_snipers),
 		-- Ground Snipers
-		restoration:gen_dummy(400023, "ground_sniper_1", Vector3(-2983, 193, 0), Rotation(0, 0, 0), optsGroundSniper_1),
-		restoration:gen_dummy(400024, "ground_sniper_2", Vector3(-2559, -2495, 0), Rotation(-90, 0, 0), optsGroundSniper_2),
-		restoration:gen_so(400025, "ground_sniper_loop_1_1", Vector3(-2189, 1500, 0), Rotation(-90, 0, 0), optsgroundSniper_SO_1_1),
-		restoration:gen_so(400026, "ground_sniper_loop_1_2", Vector3(-1024.726, 3595.228, 0), Rotation(-130, 0, 0), optsgroundSniper_SO_1_2),
-		restoration:gen_so(400027, "ground_sniper_loop_1_3", Vector3(617, 1198, 0), Rotation(-80, 0, 0), optsgroundSniper_SO_1_3),
-		restoration:gen_so(400028, "ground_sniper_loop_1_4", Vector3(-186, -1162, 0), Rotation(-90, 0, 0), optsgroundSniper_SO_1_4),
-		restoration:gen_so(400029, "ground_sniper_loop_2_1", Vector3(413, -1575, 0), Rotation(-90, 0, 0), optsgroundSniper_SO_2_1),
-		restoration:gen_so(400030, "ground_sniper_loop_2_2", Vector3(1096, -1170, 0), Rotation(-104, 0, 0), optsgroundSniper_SO_2_2),
-		restoration:gen_so(400031, "ground_sniper_loop_2_3", Vector3(1476, 656, 0), Rotation(-55, 0, 0), optsgroundSniper_SO_2_3),
-		restoration:gen_so(400032, "ground_sniper_loop_2_4", Vector3(-465, 1287, 0), Rotation(-90, 0, 0), optsgroundSniper_SO_2_4),
-		restoration:gen_dummytrigger(400033, "respawn_ground_sniper_1", Vector3(-2400, -3677, 375), Rotation(90, 0, 0), optsrespawn_ground_sniper_1),
-		restoration:gen_dummytrigger(400034, "respawn_ground_sniper_2", Vector3(-2400, -3577, 375), Rotation(90, 0, 0), optsrespawn_ground_sniper_2),
+		restoration:gen_dummy(400023, "ground_sniper_1", Vector3(-2983, 193, 0), Rotation(0, 0, 0), opts_ground_sniper_1),
+		restoration:gen_dummy(400024, "ground_sniper_2", Vector3(-2559, -2495, 0), Rotation(-90, 0, 0), opts_ground_sniper_2),
+		restoration:gen_so(400025, "ground_sniper_loop_1_1", Vector3(-2189, 1500, 0), Rotation(-90, 0, 0), opts_ground_sniper_so_1_1),
+		restoration:gen_so(400026, "ground_sniper_loop_1_2", Vector3(-1024.726, 3595, 0), Rotation(-130, 0, 0), opts_ground_sniper_so_1_2),
+		restoration:gen_so(400027, "ground_sniper_loop_1_3", Vector3(617, 1198, 0), Rotation(-80, 0, 0), opts_ground_sniper_so_1_3),
+		restoration:gen_so(400028, "ground_sniper_loop_1_4", Vector3(-186, -1162, 0), Rotation(-90, 0, 0), opts_ground_sniper_so_1_4),
+		restoration:gen_so(400029, "ground_sniper_loop_2_1", Vector3(413, -1575, 0), Rotation(-90, 0, 0), opts_ground_sniper_so_2_1),
+		restoration:gen_so(400030, "ground_sniper_loop_2_2", Vector3(1096, -1170, 0), Rotation(-104, 0, 0), opts_ground_sniper_so_2_2),
+		restoration:gen_so(400031, "ground_sniper_loop_2_3", Vector3(1476, 656, 0), Rotation(-55, 0, 0), opts_ground_sniper_so_2_3),
+		restoration:gen_so(400032, "ground_sniper_loop_2_4", Vector3(-465, 1287, 0), Rotation(-90, 0, 0), opts_ground_sniper_so_2_4),
+		restoration:gen_dummytrigger(400033, "ground_sniper_1_died", Vector3(-2400, -3677, 375), Rotation(90, 0, 0), opts_ground_sniper_1_died),
+		restoration:gen_dummytrigger(400034, "ground_sniper_2_died", Vector3(-2400, -3577, 375), Rotation(90, 0, 0), opts_ground_sniper_2_died),
 		-- FBI Ready Team
-		restoration:gen_dummy(400035, "fbi_team_1", Vector3(-2974, 6585, 0), Rotation(180, 0, 0), optsFBIAgent_1),
-		restoration:gen_dummy(400036, "fbi_team_2",Vector3(-2973.040, 6639.992, 0), 	Rotation(180, 0, 0), optsFBIAgent_2),
-		restoration:gen_dummy(400037, "fbi_team_3", Vector3(-2971.906, 6704.982, 0), Rotation(180, 0, 0), optsFBIAgent_2),
-		restoration:gen_dummy(400038, "fbi_team_4", Vector3(-2970.963, 6758.974, 0), Rotation(180, 0, 0), optsFBIAgent_1),
-		restoration:gen_dummy(400039, "fbi_team_5", Vector3(-2970.021, 6812.965, 0), Rotation(180, 0, 0), optsFBIAgent_1),
-		restoration:gen_dummy(400040, "fbi_team_6", Vector3(-2969.235, 6857.958, 0), Rotation(180, 0, 0), optsFBIAgent_2),
-		restoration:gen_dummy(400041, "fbi_team_7", Vector3(-2970, -70, 0), Rotation(0, 0, 0), optsFBIAgent_2),
-		restoration:gen_dummy(400042, "fbi_team_8", Vector3(-2970, -144, 0), Rotation(0, 0, 0), optsFBIAgent_2),
-		restoration:gen_dummy(400043, "fbi_team_9", Vector3(-2970, -219, 0), Rotation(0, 0, 0), optsFBIAgent_1),
-		restoration:gen_dummy(400044, "fbi_team_10", Vector3(-2970, -297, 0), Rotation(0, 0, 0), optsFBIAgent_1),
-		restoration:gen_dummy(400045, "fbi_team_11", Vector3(-2970, -359, 0), Rotation(0, 0, 0), optsFBIAgent_2),
-		restoration:gen_dummy(400046, "fbi_team_12", Vector3(-2970, -419, 0), Rotation(0, 0, 0), optsFBIAgent_2),
-		restoration:gen_dummy(400047, "fbi_team_13", Vector3(-2446, -2502, 0), Rotation(-90, 0, 0), optsFBIAgent_2),
-		restoration:gen_dummy(400048, "fbi_team_14", Vector3(-2383, -2502, 0), Rotation(-90, 0, 0), optsFBIAgent_2),
-		restoration:gen_dummy(400049, "fbi_team_15", Vector3(-2314, -2502, 0), Rotation(-90, 0, 0), optsFBIAgent_1),
-		restoration:gen_dummy(400050, "fbi_team_16", Vector3(-2248, -2502, 0), Rotation(-90, 0, 0), optsFBIAgent_1),
-		restoration:gen_dummy(400051, "fbi_team_17", Vector3(-2162, -2502, 0), Rotation(-90, 0, 0), optsFBIAgent_2),
-		restoration:gen_dummy(400052, "fbi_team_18", Vector3(-2075, -2502, 0), Rotation(-90, 0, 0), optsFBIAgent_1),
-		restoration:gen_dummy(400053, "fbi_team_tank", Vector3(-2348, -2573, 0), Rotation(-90, 0, 0), optsFBIAgent_3),
-		restoration:gen_missionscript(400054, "spawn_agents", spawnFBI_Agents),
-		restoration:gen_missionscript(400055, "loop", loopFBIAgents),
-		restoration:gen_missionscript(400056, "spawn_ground_snipers", spawnGroundSnipers),
-		restoration:gen_so(400057, "hunt_so", Vector3(3974, -2994, 540.404), Rotation(0, 0, 0), optsHunt_SO),
-		restoration:gen_dummy(400058, "bulldozer", Vector3(-2961, 3277, 0), Rotation(180, 0, 0), optsDozer),
-		restoration:gen_dummytrigger(400059, "respawn_tank", Vector3(-2400, -3577, 375), Rotation(90, 0, 0), optsrespawn_tank),
+		-- restoration:gen_dummy(400035, "fbi_ready_team_agent_1", Vector3(-2974, 6585, 0), Rotation(180, 0, 0), opts_fbi_ready_team_agent),
+		-- restoration:gen_dummy(400036, "fbi_ready_team_agent_2",Vector3(-2973, 6640, 0), Rotation(180, 0, 0), opts_fbi_ready_team_agent),
+		-- restoration:gen_dummy(400037, "fbi_ready_team_agent_3", Vector3(-2972, 6705, 0), Rotation(180, 0, 0), opts_fbi_ready_team_agent),
+		restoration:gen_dummy(400038, "fbi_ready_team_agent_4", Vector3(-2971, 6759, 0), Rotation(180, 0, 0), opts_fbi_ready_team_agent),
+		restoration:gen_dummy(400039, "fbi_ready_team_agent_5", Vector3(-2970, 6813, 0), Rotation(180, 0, 0), opts_fbi_ready_team_agent),
+		restoration:gen_dummy(400040, "fbi_ready_team_agent_6", Vector3(-2969, 6858, 0), Rotation(180, 0, 0), opts_fbi_ready_team_agent),
+		-- restoration:gen_dummy(400041, "fbi_ready_team_agent_7", Vector3(-2970, -70, 0), Rotation(0, 0, 0), opts_fbi_ready_team_agent),
+		-- restoration:gen_dummy(400042, "fbi_ready_team_agent_8", Vector3(-2970, -144, 0), Rotation(0, 0, 0), opts_fbi_ready_team_agent),
+		restoration:gen_dummy(400043, "fbi_ready_team_agent_9", Vector3(-2970, -219, 0), Rotation(0, 0, 0), opts_fbi_ready_team_agent),
+		restoration:gen_dummy(400044, "fbi_ready_team_agent_10", Vector3(-2970, -297, 0), Rotation(0, 0, 0), opts_fbi_ready_team_agent),
+		restoration:gen_dummy(400045, "fbi_ready_team_agent_11", Vector3(-2970, -359, 0), Rotation(0, 0, 0), opts_fbi_ready_team_agent),
+		-- restoration:gen_dummy(400046, "fbi_ready_team_agent_12", Vector3(-2970, -419, 0), Rotation(0, 0, 0), opts_fbi_ready_team_agent),
+		restoration:gen_dummy(400047, "fbi_ready_team_agent_13", Vector3(-2446, -2502, 0), Rotation(-90, 0, 0), opts_fbi_ready_team_agent),
+		restoration:gen_dummy(400048, "fbi_ready_team_agent_14", Vector3(-2383, -2502, 0), Rotation(-90, 0, 0), opts_fbi_ready_team_agent),
+		restoration:gen_dummy(400049, "fbi_ready_team_agent_15", Vector3(-2314, -2502, 0), Rotation(-90, 0, 0), opts_fbi_ready_team_agent),
+		-- restoration:gen_dummy(400050, "fbi_ready_team_agent_16", Vector3(-2248, -2502, 0), Rotation(-90, 0, 0), opts_fbi_ready_team_agent),
+		-- restoration:gen_dummy(400051, "fbi_ready_team_agent_17", Vector3(-2162, -2502, 0), Rotation(-90, 0, 0), opts_fbi_ready_team_agent),
+		-- restoration:gen_dummy(400052, "fbi_ready_team_agent_18", Vector3(-2075, -2502, 0), Rotation(-90, 0, 0), opts_fbi_ready_team_agent),
+		restoration:gen_dummy(400053, "fbi_ready_team_dozer", Vector3(-2348, -2573, 0), Rotation(-90, 0, 0), opts_fbi_ready_team_dozer),
+		restoration:gen_element_random(400054, "spawn_fbi_ready_teams", opts_spawn_fbi_ready_teams),
+		restoration:gen_missionscript(400055, "loop_fbi_ready_teams", opts_loop_fbi_ready_teams),
+		restoration:gen_missionscript(400056, "spawn_ground_snipers", opts_spawn_ground_snipers),
+		restoration:gen_so(400057, "hunt_so", Vector3(3974, -2994, 540), Rotation(0, 0, 0), opts_hunt_so),
+		restoration:gen_dummy(400058, "looping_dozer", Vector3(-2961, 3277, 0), Rotation(180, 0, 0), opts_looping_dozer),
+		restoration:gen_dummytrigger(400059, "respawn_looping_dozer", Vector3(-2400, -3577, 375), Rotation(90, 0, 0), opts_respawn_looping_dozer),
 		-- Pro Job PONR
-		restoration:gen_pointofnoreturn(400060, "pro_job_ponr", Vector3(0, 0, 0), Rotation(0, 0, 0), opts_pro_job_ponr),
-		restoration:gen_counter(400061, "pro_job_ponr_counter", Vector3(0, 0, 0), Rotation(0, 0, 0), opts_pro_job_ponr_counter),
+		restoration:gen_pointofnoreturn(400060, "pro_job_ponr", Vector3(75, 0, 0), Rotation(0, 0, 0), opts_pro_job_ponr),
+		restoration:gen_counter(400061, "pro_job_ponr_counter", Vector3(75, -50, 0), Rotation(0, 0, 0), opts_pro_job_ponr_counter),
+		-- More Sniper stuff added later
+		restoration:gen_element_random(400062, "pick_ground_sniper_first_spawn", opts_pick_ground_sniper_first_spawn),
+		restoration:gen_element_random(400063, "pick_ground_sniper_respawn", opts_pick_ground_sniper_respawn),
+		restoration:gen_toggleelement(400064, "reenable_ground_sniper_1", opts_reenable_ground_sniper_1),
+		restoration:gen_toggleelement(400065, "reenable_ground_sniper_2", opts_reenable_ground_sniper_2),
+		-- 
+		restoration:gen_spawngroup(400066, "dock_cloaker_group", nil, nil, opts_dock_cloaker_group),
+		restoration:gen_element_random(400067, "pick_enable_dock_cloaker_spawns", opts_pick_enable_dock_cloaker_spawns),
+		restoration:gen_toggleelement(400068, "enable_dock_cloaker_spawns_dock_7", opts_enable_dock_cloaker_spawns_dock_7),
+		restoration:gen_toggleelement(400069, "enable_dock_cloaker_spawns_dock_8", opts_enable_dock_cloaker_spawns_dock_8),
+		restoration:gen_toggleelement(400070, "enable_dock_cloaker_spawns_dock_9", opts_enable_dock_cloaker_spawns_dock_9),
+		restoration:gen_toggleelement(400071, "enable_dock_cloaker_spawns_corners", opts_enable_dock_cloaker_spawns_corners),
+		restoration:gen_dummy(400072, "dock_cloaker_10", Vector3(4485, 3450, 0), Rotation(180, 0, 0), opts_dock_cloaker_spawn),
+		restoration:gen_dummy(400073, "dock_cloaker_11", Vector3(3650, 3450, 0), Rotation(180, 0, 0), opts_dock_cloaker_spawn),
+		restoration:gen_dummy(400074, "dock_cloaker_12", Vector3(2550, 3450, 0), Rotation(180, 0, 0), opts_dock_cloaker_spawn),
+		restoration:gen_dummy(400075, "dock_cloaker_13", Vector3(1650, 3450, 0), Rotation(180, 0, 0), opts_dock_cloaker_spawn),
+		restoration:gen_preferedadd(400076, "add_dock_cloaker_group", opts_add_dock_cloaker_group),
+		restoration:gen_missionscript(400077, "fbi_ready_team_agent_spawn_group_1", opts_fbi_ready_team_agent_spawn_group_1),
+		restoration:gen_missionscript(400078, "fbi_ready_team_agent_spawn_group_2", opts_fbi_ready_team_agent_spawn_group_2),
+		restoration:gen_missionscript(400079, "fbi_ready_team_agent_spawn_group_3", opts_fbi_ready_team_agent_spawn_group_3),
+		restoration:gen_missionscript(400079, "fbi_ready_team_dozer_spawn_group_1", opts_fbi_ready_team_dozer_spawn_group_1),
 	},
 }

--- a/req/mission_script_add/watchdogs_2.lua
+++ b/req/mission_script_add/watchdogs_2.lua
@@ -130,7 +130,7 @@ local opts_ship_sniper_so = {
 local opts_hunt_so = {
 	scan = true,
 	SO_access = tostring(128 + 4096),
-	interval = 2,
+	use_instigator = true,
 	so_action = "AI_hunt",
 }
 local opts_ground_sniper_so_1_1 = {
@@ -250,7 +250,9 @@ local opts_spawn_ship_snipers_3 = {
 }
 local opts_spawn_ground_snipers = {
 	enabled = true,
+	trigger_times = 1,
 	on_executed = {
+		{ id = 400022, delay = 0, },
 		{ id = 400023, delay = 0, },
 		{ id = 400024, delay = 0, },
 	},


### PR DESCRIPTION
- Add anti-grief support to Watchdogs day 2
- Update the Ready Team setpiece to be less spammy, and delay the initial assault
- Snipers being enabled is now difficulty-based, and same with respawn cooldowns
- The warehouse being closed is now a chance-based event, up to 25% chance on DW/DS PJ, rather than always happening only on MH+
- Added hiding Cloakers spawning at the dockside
- Fix cheat spawns being enabled/disabled improperly
- Balancing multipliers now support forcibly including or excluding team AI (primarily for PONR elements to use)
- Fix crash with flashlights patch
- Element generator functions are much more flexible now, existing mission script add elements **should** be unaffected