### PR TITLE
More custom weapons

### DIFF
--- a/lua/sc/loc/loc.lua
+++ b/lua/sc/loc/loc.lua
@@ -2669,6 +2669,11 @@ Hooks:Add("LocalizationManagerPostInit", "SC_Localization_Weapons_Eng", function
 					["bm_sr1_sc_desc"] = "#{skill_color}#Deals 75% of its damage through body armor.##",
 					--Nagant Revolver
 					["bm_m1895_sc_desc"] = "A late 19th century 7-shooter and one of the only revolvers that can make use of a suppressor. #{risk}#Strangely##, this one comes with a 6-shot cylinder instead.\n\n#{skill_color}#Can pierce body armor, multiple enemies, shields and thin walls.##\n\nCan be #{skill_color}#fanned for an increased fire rate## at the cost of #{important_1}#more recoil, reduced effective range and the inabilty to aim down your sights.##",
+					--AF2011
+					["bm_af2011_sc_desc"] = "Handgun made to celebrate a hundred years of an all-time classic. Now featuring #{risk}#double the barrels##!",
+					["bm_wp_upg_af2011_a_uno_desc"] = "Internal modification that makes the barrels fire separately rather than simultaneously.",
+					--Triad
+					["bm_triad_sc_desc"] = "#{skill_color}#Deals 50% of its damage through body armor and can pierce multiple enemies.##\n\nAlt-fire fires #{skill_color}#3## rounds with enough force to #{skill_color}#pierce body armor, shields and thin walls##.",
 
 			--[[ SMGs ]]
 				--Kobus 90

--- a/lua/sc/tweak_data/weaponfactorytweakdata.lua
+++ b/lua/sc/tweak_data/weaponfactorytweakdata.lua
@@ -25125,7 +25125,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 					end
 				end									
 			end			
-				
+
 			if self.parts.wpn_fps_upg_1911_tritium then --Pawcio's Illuminated Ironsights Pack
 				local iron_sights = {
 					"wpn_fps_upg_b92fs_tritium",
@@ -25144,69 +25144,69 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 						self.parts[part_id].stats = { value = 0 }
 						self.parts[part_id].custom_stats = nil
 					end
-				end																										
+				end
 			end
-							
+
 			if self.parts.wpn_fps_upg_o_compm2 then --Pawcio's Aimpoint Comp M2 Sight
-				self.parts.wpn_fps_upg_o_compm2.supported = true		
+				self.parts.wpn_fps_upg_o_compm2.supported = true
 				self.parts.wpn_fps_upg_o_compm2.stats = {
 					value = 3,
 					zoom = 5
-				}		
-			end		
-			
+				}
+			end
+
 			if self.parts.wpn_fps_upg_o_compm4s then --Pawcio's Aimpoint CompM4s Sight
-				self.parts.wpn_fps_upg_o_compm4s.supported = true		
+				self.parts.wpn_fps_upg_o_compm4s.supported = true
 				self.parts.wpn_fps_upg_o_compm4s.stats = {
 					value = 3,
 					zoom = 5
 				}
 			end
-			
-			if self.parts.wpn_fps_upg_o_coyote then
-				self.parts.wpn_fps_upg_o_coyote.supported = true		
+
+			if self.parts.wpn_fps_upg_o_coyote then --Pawcio's Coyote Sight
+				self.parts.wpn_fps_upg_o_coyote.supported = true
 				self.parts.wpn_fps_upg_o_coyote.stats = {
 					value = 3,
 					zoom = 1
 				}
 			end
-			
-			if self.parts.wpn_fps_upg_o_kobra then
-				self.parts.wpn_fps_upg_o_kobra.supported = true		
+
+			if self.parts.wpn_fps_upg_o_kobra then --Pawcio's Kobra Sight
+				self.parts.wpn_fps_upg_o_kobra.supported = true
 				self.parts.wpn_fps_upg_o_kobra.stats = {
 					value = 3,
 					zoom = 1
 				}
 			end
-			
-			if self.parts.wpn_fps_upg_o_visionking then
-				self.parts.wpn_fps_upg_o_visionking.supported = true	
+
+			if self.parts.wpn_fps_upg_o_visionking then --Pawcio's VisionKing VS1.5-5x30QZ Sight
+				self.parts.wpn_fps_upg_o_visionking.supported = true
 				self.parts.wpn_fps_upg_o_visionking.desc_id = "bm_wp_upg_o_4"
-				self.parts.wpn_fps_upg_o_visionking.perks = {"scope"}	
+				self.parts.wpn_fps_upg_o_visionking.perks = {"scope"}
 				self.parts.wpn_fps_upg_o_visionking.stats = {
 					value = 3,
 					zoom = 30
 				}
 			end
 
-			if self.parts.wpn_fps_upg_o_st10 then
-				self.parts.wpn_fps_upg_o_st10.supported = true	
+			if self.parts.wpn_fps_upg_o_st10 then --Pawcio's US Optics ST-10 Sight
+				self.parts.wpn_fps_upg_o_st10.supported = true
 				self.parts.wpn_fps_upg_o_st10.desc_id = "bm_wp_upg_o_5"
-				self.parts.wpn_fps_upg_o_st10.perks = {"scope"}	
+				self.parts.wpn_fps_upg_o_st10.perks = {"scope"}
 				self.parts.wpn_fps_upg_o_st10.stats = {
 					value = 8,
 					zoom = 40
 				}
-			end	
-			
-			if self.parts.wpn_fps_upg_o_romeo3 then
-				self.parts.wpn_fps_upg_o_romeo3.supported = true		
+			end
+
+			if self.parts.wpn_fps_upg_o_romeo3 then --Pawcio's Sig Sauer ROMEO3 Sight
+				self.parts.wpn_fps_upg_o_romeo3.supported = true
 				self.parts.wpn_fps_upg_o_romeo3.desc_id = "bm_wp_upg_o_1_1"
 				self.parts.wpn_fps_upg_o_romeo3.stats = {
 					value = 3,
 					zoom = 1
 				}
-				self.parts.wpn_fps_upg_o_romeo3_pis.supported = true		
+				self.parts.wpn_fps_upg_o_romeo3_pis.supported = true
 				self.parts.wpn_fps_upg_o_romeo3_pis.desc_id = "bm_wp_upg_o_1_1"
 				self.parts.wpn_fps_upg_o_romeo3_pis.stats = {
 					value = 3,
@@ -25214,10 +25214,10 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 				}
 			end
 
-			if self.parts.wpn_fps_upg_o_su230_mdrs then
-				self.parts.wpn_fps_upg_o_su230_mdrs.supported = true	
+			if self.parts.wpn_fps_upg_o_su230_mdrs then --Pawcio's ELCAN SpecterDR MDRS Sight
+				self.parts.wpn_fps_upg_o_su230_mdrs.supported = true
 				self.parts.wpn_fps_upg_o_su230_mdrs.desc_id = "bm_wp_upg_o_4_rds"
-				self.parts.wpn_fps_upg_o_su230_mdrs.perks = {"scope"}	
+				self.parts.wpn_fps_upg_o_su230_mdrs.perks = {"scope"}
 				self.parts.wpn_fps_upg_o_su230_mdrs.stats = {
 					value = 8,
 					zoom = 30
@@ -25226,70 +25226,70 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 					value = 1,
 					gadget_zoom = 2
 				}
-			end	
-			
-			if self.parts.wpn_fps_upg_o_acog_rmr then
-				self.parts.wpn_fps_upg_o_acog_rmr.supported = true	
+			end
+
+			if self.parts.wpn_fps_upg_o_acog_rmr then --Pawcio's Trijicon TA31F-RMR Sight
+				self.parts.wpn_fps_upg_o_acog_rmr.supported = true
 				self.parts.wpn_fps_upg_o_acog_rmr.desc_id = "bm_wp_upg_o_4_rds"
-				self.parts.wpn_fps_upg_o_acog_rmr.perks = {"scope"}	
+				self.parts.wpn_fps_upg_o_acog_rmr.perks = {"scope"}
 				self.parts.wpn_fps_upg_o_acog_rmr.stats = {
 					value = 8,
 					zoom = 30
-				}	
+				}
 				self.parts.wpn_fps_upg_o_acog_rmr_switch.stats = {
 					value = 1,
 					gadget_zoom = 2
 				}
-			end		
-			
-			if self.parts.wpn_fps_upg_o_ta648rmr then
-				self.parts.wpn_fps_upg_o_ta648rmr.supported = true	
+			end
+
+			if self.parts.wpn_fps_upg_o_ta648rmr then --Pawcio's Trijicon ACOG TA648-RMR Sight
+				self.parts.wpn_fps_upg_o_ta648rmr.supported = true
 				self.parts.wpn_fps_upg_o_ta648rmr.desc_id = "bm_wp_upg_o_6_rds_mount"
-				self.parts.wpn_fps_upg_o_ta648rmr.perks = {"scope"}	
+				self.parts.wpn_fps_upg_o_ta648rmr.perks = {"scope"}
 				self.parts.wpn_fps_upg_o_ta648rmr.stats = {
 					value = 8,
 					zoom = 50
-				}	
+				}
 				self.parts.wpn_fps_upg_o_ta648rmr_switch.stats = {
 					value = 1,
 					gadget_zoom = 2
 				}
 			end
 
-			if self.parts.wpn_fps_upg_o_susat then
-				self.parts.wpn_fps_upg_o_susat.supported = true	
+			if self.parts.wpn_fps_upg_o_susat then --Pawcio's SUSAT Sight
+				self.parts.wpn_fps_upg_o_susat.supported = true
 				self.parts.wpn_fps_upg_o_susat.desc_id = "bm_wp_upg_o_4_irons"
-				self.parts.wpn_fps_upg_o_susat.perks = {"scope"}	
+				self.parts.wpn_fps_upg_o_susat.perks = {"scope"}
 				self.parts.wpn_fps_upg_o_susat.stats = {
 					value = 8,
 					zoom = 30
-				}	
+				}
 				self.parts.wpn_fps_upg_o_susat_steelsight.stats = {
 					value = 1,
 					gadget_zoom = 1
 				}
 			end
 
-			if self.parts.wpn_fps_upg_o_horzine then
+			if self.parts.wpn_fps_upg_o_horzine then --Pawcio's Horzine Tech Sight
 				self.parts.wpn_fps_upg_o_horzine.supported = true
 				self.parts.wpn_fps_upg_o_horzine.desc_id = "bm_wp_upg_o_1_1_ammo"
 				self.parts.wpn_fps_upg_o_horzine.stats = {
 					value = 8,
 					zoom = 1
-				}		
+				}
 			end
-			
-			if self.parts.wpn_fps_upg_o_pk01_vi then
+
+			if self.parts.wpn_fps_upg_o_pk01_vi then --Pawcio's BelOMO PK-01 VI Sight
 				self.parts.wpn_fps_upg_o_pk01_vi.supported = true
 				self.parts.wpn_fps_upg_o_pk01_vi.desc_id = "bm_wp_upg_o_1_8_laser"
-				self.parts.wpn_fps_upg_o_pk01_vi.perks = {"scope", "gadget"}	
+				self.parts.wpn_fps_upg_o_pk01_vi.perks = {"scope", "gadget"}
 				self.parts.wpn_fps_upg_o_pk01_vi.stats = {
 					value = 8,
 					zoom = 1
-				}		
+				}
 			end
 
-			if self.parts.wpn_fps_upg_o_mro then
+			if self.parts.wpn_fps_upg_o_mro then --Pawcio's Trijicon MRO Sight
 				self.parts.wpn_fps_upg_o_mro.supported = true
 				self.parts.wpn_fps_upg_o_mro.desc_id = "bm_wp_upg_o_1_2"
 				self.parts.wpn_fps_upg_o_mro.stats = {
@@ -25297,8 +25297,8 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 					zoom = 2
 				}
 			end
-			
-			if self.parts.wpn_fps_upg_o_okp7 then
+
+			if self.parts.wpn_fps_upg_o_okp7 then --Pawcio's OKP-7 Sight
 				self.parts.wpn_fps_upg_o_okp7.supported = true
 				self.parts.wpn_fps_upg_o_okp7.desc_id = "bm_wp_upg_o_1_1"
 				self.parts.wpn_fps_upg_o_okp7.stats = {
@@ -25306,15 +25306,33 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 					zoom = 1
 				}
 			end
-			
-			if self.parts.wpn_fps_upg_fl_anpeq2 then
+
+			if self.parts.wpn_fps_upg_fl_anpeq2 then --Pawcio's Lost Gadgets
 				self.parts.wpn_fps_upg_fl_anpeq2.stats.recoil = 0
-				self.parts.wpn_fps_upg_fl_m600p.stats.recoil = 0
 				self.parts.wpn_fps_upg_fl_pis_unimax_inforce.stats.concealment = 0
+				self.parts.wpn_fps_upg_fl_m600p.stats.recoil = 0
 				self.parts.wpn_fps_upg_fl_unimax_inforce.stats.concealment = 0
+
+				self.parts.wpn_fps_upg_fl_anpeq2.desc_id = "bm_wp_upg_fl_laser"
+				self.parts.wpn_fps_upg_fl_utg.desc_id = "bm_wp_upg_fl_laser"
+				self.parts.wpn_fps_upg_fl_pis_utg.desc_id = "bm_wp_upg_fl_laser"
+				self.parts.wpn_fps_upg_fl_unimax.desc_id = "bm_wp_upg_fl_laser"
+				self.parts.wpn_fps_upg_fl_pis_unimax.desc_id = "bm_wp_upg_fl_laser"
+
+				self.parts.wpn_fps_upg_fl_unimax_inforce.desc_id = "bm_wp_upg_fl_dual"
+				self.parts.wpn_fps_upg_fl_pis_unimax_inforce.desc_id = "bm_wp_upg_fl_dual"
+				self.parts.wpn_fps_upg_fl_dbal_d2.desc_id = "bm_wp_upg_fl_dual"
+
+				self.parts.wpn_fps_upg_fl_m600p.desc_id = "bm_wp_upg_fl_flashlight"
+				self.parts.wpn_fps_upg_fl_pis_inforce_apl.desc_id = "bm_wp_upg_fl_flashlight"
 			end
-	
-			if self.parts.wpn_fps_upg_xm8_barrel_long then
+
+			if self.parts.wpn_fps_upg_fl_pis_micro90 then
+				self.parts.wpn_fps_upg_fl_pis_micro90.desc_id = "bm_wp_upg_fl_flashlight"
+				self.parts.wpn_fps_upg_fl_wml.desc_id = "bm_wp_upg_fl_flashlight"
+			end
+
+			if self.parts.wpn_fps_upg_xm8_barrel_long then --Pawcio's XM8
 				self.parts.wpn_fps_upg_xm8_barrel_long.supported = true
 				self.parts.wpn_fps_upg_xm8_barrel_long.stats = deep_clone(barrels.long_b2_stats)
 				self.parts.wpn_fps_upg_xm8_barrel_long.custom_stats = deep_clone(barrels.long_b2_stats)
@@ -26025,7 +26043,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 					unit = "units/pd2_dlc_born/weapons/wpn_fps_smg_hajk_pts/wpn_fps_smg_hajk_o_standard",
 					third_unit = "units/pd2_dlc_born/weapons/wpn_third_smg_hajk_pts/wpn_third_smg_hajk_o_standard"
 				}
-				
+
 				self.wpn_fps_snp_amr2_npc.override = deep_clone(self.wpn_fps_snp_amr2.override)
 				self.wpn_fps_snp_amr2_npc.uses_parts = deep_clone(self.wpn_fps_snp_amr2.uses_parts)
 			end
@@ -26040,6 +26058,8 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 				self.parts.wpn_fps_snp_tac50_mag.custom_stats = nil
 
 				self.parts.wpn_fps_upg_tac50_supp.supported = true
+				self.parts.wpn_fps_upg_tac50_supp.has_description = true
+				self.parts.wpn_fps_upg_tac50_supp.desc_id = "bm_wp_upg_suppressor"
 				self.parts.wpn_fps_upg_tac50_supp.stats = {
 					value = 2,
 					suppression = 12,
@@ -26048,7 +26068,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 				self.parts.wpn_fps_upg_tac50_supp.custom_stats = {}
 				self.parts.wpn_fps_upg_tac50_supp.perks = {"silencer"}
 			end
-		
+
 			if self.parts.wpn_fps_upg_m107cq_ammo_416 then --Pawcio's M107
 				self.parts.wpn_fps_upg_m107cq_ammo_416.pcs = nil
 				self.parts.wpn_fps_upg_m107cq_ammo_416.supported = true
@@ -26250,7 +26270,8 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 					wpn_fps_upg_a_rip = deep_clone(shot_ammo.a_rip_semi_override),
 					wpn_fps_upg_a_piercing = deep_clone(shot_ammo.a_piercing_semi_override),
 					wpn_fps_upg_a_dragons_breath = deep_clone(shot_ammo.a_dragons_breath_semi_override)			
-				}	
+				}
+				table.insert(self.wpn_fps_shot_mp153.uses_parts, "wpn_fps_upg_a_dragons_breath")
 			end
 
 			if self.parts.wpn_fps_upg_scarl_barrel_cqc then  --Pawcio's SCAR-L
@@ -26933,6 +26954,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 				}
 
 				self.parts.wpn_fps_upg_vss_mag_20rnd.supported = true
+				self.parts.wpn_fps_upg_vss_mag_20rnd.has_description = false
 				self.parts.wpn_fps_upg_vss_mag_20rnd.stats = {
 					value = 2,
 					extra_ammo = 10,
@@ -27368,7 +27390,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 				self.parts.wpn_fps_upg_aug9mm_stock_tactical.stats = {
 					value = 0,
 					spread = 1,
-					recoil = -2 
+					recoil = -2
 				}
 				self.parts.wpn_fps_upg_aug9mm_stock_tactical.custom_stats = nil
 
@@ -27380,7 +27402,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 				self.parts.wpn_fps_pis_mars_mag.supported = true
 				self.parts.wpn_fps_pis_mars_mag.stats = { value = 0 }
 				self.parts.wpn_fps_pis_mars_mag.custom_stats = nil
-				
+
 				self.parts.wpn_fps_upg_mars_barrel_long.supported = true
 				self.parts.wpn_fps_upg_mars_barrel_long.stats = deep_clone(barrels.long_b2_stats)
 				self.parts.wpn_fps_upg_mars_barrel_long.custom_stats = deep_clone(barrels.long_b2_stats)
@@ -27456,7 +27478,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 				self.parts.wpn_fps_upg_m1895_supp_ro2.custom_stats = {}
 				self.parts.wpn_fps_upg_m1895_supp_ro2.perks = {"silencer"}
 			end
-			
+
 			if self.parts.wpn_fps_upg_sw27_barrel_short then
 				self.parts.wpn_fps_upg_sw27_barrel_short.supported = true
 				self.parts.wpn_fps_upg_sw27_barrel_short.stats = deep_clone(barrels.short_b3_stats)
@@ -27464,11 +27486,11 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 				self.parts.wpn_fps_upg_sw27_barrel_long.supported = true
 				self.parts.wpn_fps_upg_sw27_barrel_long.stats = deep_clone(barrels.long_b3_stats)
 				self.parts.wpn_fps_upg_sw27_barrel_long.custom_stats = deep_clone(barrels.long_b3_stats)
-				
+
 				self.parts.wpn_fps_upg_sw27_cylinder_smooth.supported = true
 				self.parts.wpn_fps_upg_sw27_cylinder_smooth.has_description = false
 				self.parts.wpn_fps_upg_sw27_cylinder_smooth.stats = {value = 1}
-				
+
 				self.parts.wpn_fps_upg_sw27_grip_classic.supported = true
 				self.parts.wpn_fps_upg_sw27_grip_classic.stats = deep_clone(grips.quickdraw_dual)
 				self.parts.wpn_fps_upg_sw27_grip_classic.custom_stats = deep_clone(grips.quickdraw_dual)
@@ -27478,7 +27500,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 				self.parts.wpn_fps_upg_sw27_grip_rubber.supported = true
 				self.parts.wpn_fps_upg_sw27_grip_rubber.stats = deep_clone(grips.quickdraw_1)
 				self.parts.wpn_fps_upg_sw27_grip_rubber.custom_stats = deep_clone(grips.quickdraw_1)
-				
+
 				self.parts.wpn_fps_upg_sw27_scope.supported = true
 				self.parts.wpn_fps_upg_sw27_scope.has_description = true
 				self.parts.wpn_fps_upg_sw27_scope.desc_id = "bm_wp_upg_o_4"
@@ -27490,12 +27512,11 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 			end
 
 			if self.parts.wpn_fps_upg_einhander_stock_removed then
-				self.parts.wpn_fps_upg_einhander_stock_removed.stats = {
-					value = 4,
-					reload = -4,
-					concealment = 2
-				}
+				self.parts.wpn_fps_upg_einhander_stock_removed.supported = true
+				self.parts.wpn_fps_upg_einhander_stock_removed.stats = deep_clone(stocks.remove_folded_stats)
+				self.parts.wpn_fps_upg_einhander_stock_removed.custom_stats = deep_clone(stocks.remove_folded_stats)
 
+				self.parts.wpn_fps_smg_einhander_mag.supported = true
 				self.parts.wpn_fps_smg_einhander_mag.stats = { value = 0 }
 				self.parts.wpn_fps_smg_einhander_mag.custom_stats = nil
 
@@ -27522,12 +27543,12 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 				}
 				self.parts.wpn_fps_upg_a545_supp_tgp_a.custom_stats = {}
 				self.parts.wpn_fps_upg_a545_supp_tgp_a.perks = {"silencer"}
-				
+
 				self.parts.wpn_fps_upg_a545_dtk1.supported = true
 				self.parts.wpn_fps_upg_a545_dtk1.stats = deep_clone(muzzle_device.muzz_rec_c)
 				self.parts.wpn_fps_upg_a545_dtk1.custom_stats = deep_clone(muzzle_device.muzz_rec_c)
 			end
-			
+
 			if self.parts.wpn_fps_upg_aek971_supp_tgp_a then
 				self.parts.wpn_fps_upg_aek971_supp_tgp_a.supported = true
 				self.parts.wpn_fps_upg_aek971_supp_tgp_a.stats = {
@@ -27598,7 +27619,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 				self.parts.wpn_fps_upg_aku94_grip_tapco.supported = true
 				self.parts.wpn_fps_upg_aku94_grip_tapco.stats = deep_clone(grips.recoil_1)
 				self.parts.wpn_fps_upg_aku94_grip_tapco.custom_stats = deep_clone(grips.recoil_1)
-				
+
 				self.parts.wpn_fps_upg_aku94_mag_40.supported = true
 				self.parts.wpn_fps_upg_aku94_mag_40.stats = {
 					extra_ammo = 10,
@@ -27621,7 +27642,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 					spread = 1,
 					recoil = -2,
 				}
-				
+
 				self.wpn_fps_ass_aku94.override.wpn_fps_upg_vg_ass_smg_verticalgrip = {
 					stats = { recoil = 2, concealment = -1 }
 				}
@@ -27654,14 +27675,14 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 				self.parts.wpn_fps_upg_sr3m_mag_20rnd.custom_stats = { 
 					ads_speed_mult = 0.95
 				}
-				
+
 				self.parts.wpn_fps_upg_sr3m_supp.supported = true
 				self.parts.wpn_fps_upg_sr3m_supp.has_description = true
 				self.parts.wpn_fps_upg_sr3m_supp.desc_id = "bm_wp_upg_suppressor"
 				self.parts.wpn_fps_upg_sr3m_supp.stats = deep_clone(muzzle_device.supp_acc2_c)
 				self.parts.wpn_fps_upg_sr3m_supp.custom_stats = deep_clone(muzzle_device.supp_acc2_c)
 				self.parts.wpn_fps_upg_sr3m_supp.perks = {"silencer"}
-				
+
 				self.parts.wpn_fps_upg_sr3m_supp_groza.supported = true
 				self.parts.wpn_fps_upg_sr3m_supp_groza.has_description = true
 				self.parts.wpn_fps_upg_sr3m_supp_groza.desc_id = "bm_wp_upg_suppressor"
@@ -27708,7 +27729,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 			if self.parts.wpn_fps_gre_air16_mag then
 				self.parts.wpn_fps_gre_air16_mag.stats = { value = 0 }
 				self.parts.wpn_fps_gre_air16_mag.custom_stats = nil
-				
+
 				self.parts.wpn_fps_upg_air16_bayonet.supported = true -- makes the gun disappear, honestly tempted to keep it in
 				self.parts.wpn_fps_upg_air16_bayonet.stats = {
 					value = 5,
@@ -27734,14 +27755,14 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 				self.parts.wpn_fps_lmg_ultimax_cmag.supported = true
 				self.parts.wpn_fps_lmg_ultimax_cmag.stats = { value = 0 }
 				self.parts.wpn_fps_lmg_ultimax_cmag.custom_stats = nil
-				
+
 				self.parts.wpn_fps_upg_ultimax_barrel_long.supported = true
 				self.parts.wpn_fps_upg_ultimax_barrel_long.stats = deep_clone(barrels.long_b2_stats)
 				self.parts.wpn_fps_upg_ultimax_barrel_long.custom_stats = deep_clone(barrels.long_b2_stats)
-				
+
 				self.parts.wpn_fps_upg_ultimax_stanag.supported = true
 				self.parts.wpn_fps_upg_ultimax_stanag.has_description = false
-				self.parts.wpn_fps_upg_ultimax_stanag.stats = {	
+				self.parts.wpn_fps_upg_ultimax_stanag.stats = {
 					value = 2,
 					extra_ammo = -70,
 					spread = -1,
@@ -27769,7 +27790,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 				self.parts.wpn_fps_upg_lsat_barrel_short.supported = true
 				self.parts.wpn_fps_upg_lsat_barrel_short.stats = deep_clone(barrels.short_b2_stats)
 				self.parts.wpn_fps_upg_lsat_barrel_short.custom_stats = deep_clone(barrels.short_b2_stats)
-				
+
 				self.parts.wpn_fps_upg_lsat_bipod.supported = true
 				self.parts.wpn_fps_upg_lsat_bipod.has_description = true
 				self.parts.wpn_fps_upg_lsat_bipod.desc_id = "bm_sc_bipod_desc"
@@ -27806,7 +27827,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 				self.parts.wpn_fps_upg_mg4_barrel_short.supported = true
 				self.parts.wpn_fps_upg_mg4_barrel_short.stats = deep_clone(barrels.short_b2_stats)
 				self.parts.wpn_fps_upg_mg4_barrel_short.custom_stats = deep_clone(barrels.short_b2_stats)
-				
+
 				self.parts.wpn_fps_upg_mg4_bipod.supported = true
 				self.parts.wpn_fps_upg_mg4_bipod.has_description = true
 				self.parts.wpn_fps_upg_mg4_bipod.desc_id = "bm_sc_bipod_desc"
@@ -27828,7 +27849,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 					spread = -1,
 					concealment = 1
 				}
-				
+
 				self.parts.wpn_fps_upg_mg4_mag_pouch.supported = true
 				self.parts.wpn_fps_upg_mg4_mag_pouch.has_description = false
 				self.parts.wpn_fps_upg_mg4_mag_pouch.stats = {
@@ -27850,7 +27871,6 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 				self.parts.wpn_fps_upg_mg4_stock_removed.stats = deep_clone(stocks.remove_adj_stats)
 				self.parts.wpn_fps_upg_mg4_stock_removed.custom_stats = deep_clone(stocks.remove_adj_stats)
 			end
-			
 
 			if self.parts.wpn_fps_lmg_mg3_rec then
 				self.parts.wpn_fps_lmg_mg3_rec.adds = {}
@@ -27877,14 +27897,14 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 				}
 				self.parts.wpn_fps_upg_mg3_mag_box.custom_stats = {
 					ads_speed_mult = 1.1
-				}				
+				}
 
 				self.parts.wpn_fps_upg_mg3_bolt_heavy.supported = true
 				self.parts.wpn_fps_upg_mg3_bolt_heavy.stats = {
 					value = 1,
 					recoil = 2
 				}
-				self.parts.wpn_fps_upg_mg3_bolt_heavy.custom_stats = { 
+				self.parts.wpn_fps_upg_mg3_bolt_heavy.custom_stats = {
 					rof_mult = 0.75
 				}
 
@@ -27927,16 +27947,18 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 				self.parts.wpn_fps_upg_toz66_choke.supported = true
 				self.parts.wpn_fps_upg_toz66_choke.stats = deep_clone(muzzle_device.muzz_rec_c)
 				self.parts.wpn_fps_upg_toz66_choke.custom_stats = deep_clone(muzzle_device.muzz_rec_c)
-				
+
 				self.parts.wpn_fps_upg_toz66_choke_modified.supported = true
 				self.parts.wpn_fps_upg_toz66_choke_modified.stats = deep_clone(muzzle_device.muzz_acc_c)
 				self.parts.wpn_fps_upg_toz66_choke_modified.custom_stats = deep_clone(muzzle_device.muzz_acc_c)
-				
+
 				self.parts.wpn_fps_upg_toz66_duckbill.supported = true
 				self.parts.wpn_fps_upg_toz66_duckbill.has_description = true
 				self.parts.wpn_fps_upg_toz66_duckbill.desc_id = "bm_wp_ns_duck_desc_sc"
 				self.parts.wpn_fps_upg_toz66_duckbill.stats = deep_clone(self.parts.wpn_fps_upg_ns_duck.stats)
 				self.parts.wpn_fps_upg_toz66_duckbill.custom_stats = deep_clone(self.parts.wpn_fps_upg_ns_duck.custom_stats)
+
+				table.insert(self.wpn_fps_shot_toz66.uses_parts, "wpn_fps_upg_a_rip")
 			end
 
 			if self.wpn_fps_sho_x_toz66 then
@@ -27946,8 +27968,10 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 				self.wpn_fps_sho_x_toz66.override.wpn_fps_upg_a_custom_free.custom_stats.rays = 4
 				self.wpn_fps_sho_x_toz66.override.wpn_fps_upg_a_piercing = {custom_stats = deep_clone(shot_ammo.a_piercing_heavy_override.custom_stats)}
 				self.wpn_fps_sho_x_toz66.override.wpn_fps_upg_a_piercing.custom_stats.rays = 9
+
+				table.insert(self.wpn_fps_sho_x_toz66.uses_parts, "wpn_fps_upg_a_rip")
 			end
-			
+
 			if self.parts.wpn_fps_shot_toz34_body then
 				self.parts.wpn_fps_shot_toz34_body.stats = { value = 0 }
 				self.parts.wpn_fps_shot_toz34_body.custom_stats = nil
@@ -27955,23 +27979,496 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 				self.parts.wpn_fps_upg_toz34_choke.supported = true
 				self.parts.wpn_fps_upg_toz34_choke.stats = deep_clone(muzzle_device.muzz_rec_c)
 				self.parts.wpn_fps_upg_toz34_choke.custom_stats = deep_clone(muzzle_device.muzz_rec_c)
-				
+
 				self.parts.wpn_fps_upg_toz34_choke_modified.supported = true
 				self.parts.wpn_fps_upg_toz34_choke_modified.stats = deep_clone(muzzle_device.muzz_acc_c)
 				self.parts.wpn_fps_upg_toz34_choke_modified.custom_stats = deep_clone(muzzle_device.muzz_acc_c)
-				
+
 				self.parts.wpn_fps_upg_toz34_duckbill.supported = true
 				self.parts.wpn_fps_upg_toz34_duckbill.has_description = true
 				self.parts.wpn_fps_upg_toz34_duckbill.desc_id = "bm_wp_ns_duck_desc_sc"
 				self.parts.wpn_fps_upg_toz34_duckbill.stats = deep_clone(self.parts.wpn_fps_upg_ns_duck.stats)
 				self.parts.wpn_fps_upg_toz34_duckbill.custom_stats = deep_clone(self.parts.wpn_fps_upg_ns_duck.custom_stats)
-				
+
 				self.parts.wpn_fps_upg_toz34_barrel_short.supported = true
 				self.parts.wpn_fps_upg_toz34_barrel_short.stats = deep_clone(barrels.short_b3_stats)
 				self.parts.wpn_fps_upg_toz34_barrel_short.custom_stats = deep_clone(barrels.short_b3_stats)
 				self.parts.wpn_fps_upg_toz34_stock_short.supported = true
 				self.parts.wpn_fps_upg_toz34_stock_short.stats = deep_clone(stocks.remove_fixed_stats)
 				self.parts.wpn_fps_upg_toz34_stock_short.custom_stats = deep_clone(stocks.remove_fixed_stats)
+
+				table.insert(self.wpn_fps_shot_toz34.uses_parts, "wpn_fps_upg_a_rip")
+			end
+
+			if self.parts.wpn_fps_shot_triple_barrel_short then
+				self.parts.wpn_fps_shot_triple_barrel_short.supported = true
+				self.parts.wpn_fps_shot_triple_barrel_short.stats = deep_clone(barrels.short_b2_stats)
+				self.parts.wpn_fps_shot_triple_barrel_short.custom_stats = deep_clone(barrels.short_b2_stats)
+
+				table.insert(self.wpn_fps_shot_triple.uses_parts, "wpn_fps_upg_a_rip")
+			end
+
+			if self.parts.wpn_fps_upg_appistol_supp then
+				self.parts.wpn_fps_upg_appistol_supp.supported = true
+				self.parts.wpn_fps_upg_appistol_supp.stats = {
+					value = 2,
+					suppression = 12,
+					alert_size = -1
+				}
+				self.parts.wpn_fps_upg_appistol_supp.custom_stats = {}
+				self.parts.wpn_fps_upg_appistol_supp.perks = {"silencer"}
+
+				self.parts.wpn_fps_upg_appistol_flashlight.supported = true
+				self.parts.wpn_fps_upg_appistol_flashlight.desc_id = "bm_wp_upg_fl_flashlight"
+				self.parts.wpn_fps_upg_appistol_flashlight.stats = { value = 3 }
+
+				self.parts.wpn_fps_upg_appistol_mag_extended.supported = true
+				self.parts.wpn_fps_upg_appistol_mag_extended.has_description = false
+				self.parts.wpn_fps_upg_appistol_mag_extended.stats = {
+					value = 6,
+					extra_ammo = 18,
+					concealment = -2,
+					reload = -4
+				}
+				self.parts.wpn_fps_upg_appistol_mag_extended.custom_stats = {
+					ads_speed_mult = 1.05
+				}
+
+				self.parts.wpn_fps_upg_appistol_sight_pistol.supported = true
+				self.parts.wpn_fps_upg_appistol_sight_pistol.stats = {
+					value = 0,
+					zoom = 1
+				}
+				self.parts.wpn_fps_upg_appistol_sight_pistol.desc_id = "bm_wp_upg_o_1_1"
+				self.parts.wpn_fps_upg_appistol_sight_smg.supported = true
+				self.parts.wpn_fps_upg_appistol_sight_smg.stats = {
+					value = 0,
+					zoom = 5
+				}
+				self.parts.wpn_fps_upg_appistol_sight_smg.desc_id = "bm_wp_upg_o_1_5"
+			end
+
+			if self.parts.wpn_fps_ass_rk62_mag then
+				self.parts.wpn_fps_ass_rk62_mag.supported = true
+				self.parts.wpn_fps_ass_rk62_mag.stats = { value = 0 }
+				self.parts.wpn_fps_ass_rk62_mag.custom_stats = nil
+
+				self.parts.wpn_fps_upg_rk62_barrel_short.supported = true
+				self.parts.wpn_fps_upg_rk62_barrel_short.stats = deep_clone(barrels.short_b1_stats)
+				self.parts.wpn_fps_upg_rk62_barrel_short.custom_stats = deep_clone(barrels.short_b1_stats)
+
+				self.parts.wpn_fps_upg_rk62_grip_rk95.supported = true
+				self.parts.wpn_fps_upg_rk62_grip_rk95.stats = deep_clone(grips.acc_1)
+
+				self.parts.wpn_fps_upg_rk62_handguard_railed.supported = true
+				self.parts.wpn_fps_upg_rk62_handguard_railed.stats = {
+					value = 4,
+					spread = 1,
+					concealment = -1
+				}
+				self.parts.wpn_fps_upg_rk62_handguard_rk95.supported = true
+				self.parts.wpn_fps_upg_rk62_handguard_rk95.stats = {
+					value = 4,
+					recoil = 2,
+					concealment = -1
+				}
+
+				self.parts.wpn_fps_upg_rk62_mag_rk95.supported = true
+				self.parts.wpn_fps_upg_rk62_mag_rk95.stats = {
+					value = 1,
+					concealment = 1,
+					recoil = -2
+				}
+
+				self.parts.wpn_fps_upg_rk62_stock_removed.supported = true
+				self.parts.wpn_fps_upg_rk62_stock_removed.stats = deep_clone(stocks.remove_adj_stats)
+				self.parts.wpn_fps_upg_rk62_stock_removed.custom_stats = deep_clone(stocks.remove_adj_stats)
+
+				self.parts.wpn_fps_upg_rk62_stock_rk95.supported = true
+				self.parts.wpn_fps_upg_rk62_stock_rk95.stats = deep_clone(stocks.adj_to_fold_stats)
+				self.parts.wpn_fps_upg_rk62_stock_rk95.custom_stats = deep_clone(stocks.adj_to_fold_stats)
+
+				self.wpn_fps_ass_rk62.override.wpn_fps_upg_m4_s_standard = {
+					stats = { value = 0 },
+					custom_stats = {}
+				}
+			end
+
+			if self.parts.wpn_fps_shot_m1912_receiver then
+				self.parts.wpn_fps_shot_m1912_receiver.supported = true
+				self.parts.wpn_fps_shot_m1912_receiver.stats = { value = 0 }
+				self.parts.wpn_fps_shot_m1912_receiver.custom_stats = nil
+
+				self.parts.wpn_fps_upg_m1912_forend_field.supported = true
+				self.parts.wpn_fps_upg_m1912_forend_field.stats = deep_clone(barrels.long_b2_stats)
+				self.parts.wpn_fps_upg_m1912_forend_field.custom_stats = deep_clone(barrels.long_b2_stats)
+				self.parts.wpn_fps_upg_m1912_barrel_riot.supported = true
+				self.parts.wpn_fps_upg_m1912_barrel_riot.stats = deep_clone(barrels.short_b2_stats)
+				self.parts.wpn_fps_upg_m1912_barrel_riot.custom_stats = deep_clone(barrels.short_b2_stats)
+				self.parts.wpn_fps_upg_m1912_barrel_trench.supported = true
+				self.parts.wpn_fps_upg_m1912_barrel_trench.stats = {
+					value = 4,
+					spread = -3,
+					recoil = 2,
+					concealment = 2
+				}
+				self.parts.wpn_fps_upg_m1912_barrel_trench.custom_stats = deep_clone(barrels.short_b2_stats)
+
+				self.parts.wpn_fps_upg_m1912_ns_cutts.supported = true
+				self.parts.wpn_fps_upg_m1912_ns_cutts.stats = deep_clone(muzzle_device.muzz_dual_c)
+				self.parts.wpn_fps_upg_m1912_ns_cutts.custom_stats = deep_clone(muzzle_device.muzz_dual_c)
+
+				self.parts.wpn_fps_upg_m1912_forend_field.supported = true
+				self.parts.wpn_fps_upg_m1912_forend_field.stats = {
+					value = 4,
+					recoil = -2,
+					concealment = 1,
+				}
+
+				self.parts.wpn_fps_upg_m1912_stock_pad.supported = true
+				self.parts.wpn_fps_upg_m1912_stock_pad.stats = {
+					value = 4,
+					recoil = 2,
+					concealment = -1,
+				}
+				self.parts.wpn_fps_upg_m1912_stock_pad.custom_stats = { ads_speed_mult = 1.025 }
+				self.parts.wpn_fps_upg_m1912_stock_cheekrest.supported = true
+				self.parts.wpn_fps_upg_m1912_stock_cheekrest.stats = {
+					value = 4,
+					spread = 1,
+					concealment = -1,
+				}
+				self.parts.wpn_fps_upg_m1912_stock_cheekrest.custom_stats = { ads_speed_mult = 1.025 }
+				self.parts.wpn_fps_upg_m1912_stock_sawnoff.supported = true
+				self.parts.wpn_fps_upg_m1912_stock_sawnoff.stats = deep_clone(stocks.remove_fixed_stats)
+				self.parts.wpn_fps_upg_m1912_stock_sawnoff.custom_stats = deep_clone(stocks.remove_fixed_stats)
+
+				table.insert(self.wpn_fps_shot_m1912.uses_parts, "wpn_fps_upg_a_rip")
+				self.wpn_fps_shot_m1912.override.wpn_fps_upg_a_slug = deep_clone(shot_ammo.a_slug_pump_override)
+				self.wpn_fps_shot_m1912.override.wpn_fps_upg_a_custom = deep_clone(shot_ammo.a_custom_pump_override)
+				self.wpn_fps_shot_m1912.override.wpn_fps_upg_a_custom_free = deep_clone(shot_ammo.a_custom_pump_override)
+				self.wpn_fps_shot_m1912.override.wpn_fps_upg_a_explosive = deep_clone(shot_ammo.a_explosive_pump_override)
+				self.wpn_fps_shot_m1912.override.wpn_fps_upg_a_rip = deep_clone(shot_ammo.a_rip_pump_override)
+				self.wpn_fps_shot_m1912.override.wpn_fps_upg_a_piercing = deep_clone(shot_ammo.a_piercing_pump_override)
+				self.wpn_fps_shot_m1912.override.wpn_fps_upg_a_dragons_breath = deep_clone(shot_ammo.a_dragons_breath_pump_override)
+			end
+
+			if self.parts.wpn_fps_ass_fnar_mag then
+				self.parts.wpn_fps_ass_fnar_mag.supported = true
+				self.parts.wpn_fps_ass_fnar_mag.stats = { value = 0 }
+				self.parts.wpn_fps_ass_fnar_mag.custom_stats = nil
+
+				self.parts.wpn_fps_upg_fnar_barrel_heavy.supported = true
+				self.parts.wpn_fps_upg_fnar_barrel_heavy.stats = deep_clone(barrels.long_b2_stats)
+				self.parts.wpn_fps_upg_fnar_barrel_heavy.custom_stats = deep_clone(barrels.long_b2_stats)
+
+				self.parts.wpn_fps_upg_fnar_supp_nt4.supported = true
+				self.parts.wpn_fps_upg_fnar_supp_nt4.stats = {
+					value = 2,
+					suppression = 12,
+					alert_size = -1
+				}
+				self.parts.wpn_fps_upg_fnar_supp_nt4.custom_stats = {}
+				self.parts.wpn_fps_upg_fnar_supp_nt4.perks = {"silencer"}
+				self.parts.wpn_fps_upg_fnar_barrel_ext_jp_stndcomp.supported = true
+				self.parts.wpn_fps_upg_fnar_barrel_ext_jp_stndcomp.stats = deep_clone(muzzle_device.muzz_acc_c)
+				self.parts.wpn_fps_upg_fnar_barrel_ext_jp_stndcomp.custom_stats = deep_clone(muzzle_device.muzz_acc_c)
+				self.parts.wpn_fps_upg_fnar_barrel_ext_tbrake.supported = true
+				self.parts.wpn_fps_upg_fnar_barrel_ext_tbrake.stats = deep_clone(muzzle_device.muzz_rec2_c)
+				self.parts.wpn_fps_upg_fnar_barrel_ext_tbrake.custom_stats = deep_clone(muzzle_device.muzz_rec2_c)
+
+				self.parts.wpn_fps_upg_fnar_mag_20.supported = true
+				self.parts.wpn_fps_upg_fnar_mag_20.has_description = false
+				self.parts.wpn_fps_upg_fnar_mag_20.stats = {
+					value = 2,
+					extra_ammo = 10,
+					reload = -3,
+					concealment = -1
+				}
+				self.parts.wpn_fps_upg_fnar_mag_20.custom_stats = {
+					ads_speed_mult = 1.025
+				}
+
+				self.parts.wpn_fps_upg_fnar_bipod_harris.supported = true
+				self.parts.wpn_fps_upg_fnar_bipod_harris.stats = { value = 0 }
+				self.parts.wpn_fps_upg_fnar_bipod_harris.custom_stats = nil
+
+				self.parts.wpn_fps_upg_fnar_gadget_dueck_offset.pcs = nil -- cba
+			end
+
+			if self.parts.wpn_fps_snp_mk12_mk4 then
+				self.parts.wpn_fps_snp_mk12_mk4.supported = true
+				self.parts.wpn_fps_snp_mk12_mk4.stats = {
+					value = 8,
+					zoom = 40
+				}
+				self.parts.wpn_fps_snp_mk12_mk4.desc_id = "bm_wp_upg_o_5"
+				self.parts.wpn_fps_snp_mk12_mk4.perks = {"scope"}
+				self.parts.wpn_fps_snp_mk12_mk4.stance_mod = {
+					wpn_fps_snp_mk12 = {
+						translation = Vector3(0, -8, -0.818)
+					}
+				}
+
+				self.parts.wpn_fps_snp_mk12_mag_stanag20.supported = true
+				self.parts.wpn_fps_snp_mk12_mag_stanag20.stats = { value = 0 }
+				self.parts.wpn_fps_snp_mk12_mag_stanag20.custom_stats = nil
+
+				self.parts.wpn_fps_upg_mk12_bipod_harris.supported = true
+				self.parts.wpn_fps_upg_mk12_bipod_harris.stats = { value = 0 }
+				self.parts.wpn_fps_upg_mk12_bipod_harris.custom_stats = nil
+
+				self.parts.wpn_fps_upg_mk12_barrel_short.supported = true
+				self.parts.wpn_fps_upg_mk12_barrel_short.stats = deep_clone(barrels.short_b2_stats)
+				self.parts.wpn_fps_upg_mk12_barrel_short.custom_stats = deep_clone(barrels.short_b2_stats)
+
+				self.parts.wpn_fps_upg_mk12_ns_mk12.supported = true
+				self.parts.wpn_fps_upg_mk12_ns_mk12.stats = deep_clone(muzzle_device.muzz_acc_c)
+				self.parts.wpn_fps_upg_mk12_ns_mk12.custom_stats = deep_clone(muzzle_device.muzz_acc_c)
+				self.parts.wpn_fps_upg_mk12_ns_tbrake.supported = true
+				self.parts.wpn_fps_upg_mk12_ns_tbrake.stats = deep_clone(muzzle_device.muzz_rec2_c)
+				self.parts.wpn_fps_upg_mk12_ns_tbrake.custom_stats = deep_clone(muzzle_device.muzz_rec2_c)
+				self.parts.wpn_fps_upg_mk12_supp_sf_minimonster.supported = true
+				self.parts.wpn_fps_upg_mk12_supp_sf_minimonster.stats = {
+					value = 2,
+					suppression = 12,
+					alert_size = -1
+				}
+				self.parts.wpn_fps_upg_mk12_supp_sf_minimonster.custom_stats = {}
+				self.parts.wpn_fps_upg_mk12_supp_sf_minimonster.perks = {"silencer"}
+				self.parts.wpn_fps_upg_mk12_supp_m4_2000.supported = true
+				self.parts.wpn_fps_upg_mk12_supp_m4_2000.stats = deep_clone(muzzle_device.supp_acc_r)
+				self.parts.wpn_fps_upg_mk12_supp_m4_2000.custom_stats = deep_clone(muzzle_device.supp_acc_r)
+				self.parts.wpn_fps_upg_mk12_supp_m4_2000.perks = {"silencer"}
+
+				self.parts.wpn_fps_upg_mk12_mag_pmag.supported = true
+				self.parts.wpn_fps_upg_mk12_mag_pmag.has_description = false
+				self.parts.wpn_fps_upg_mk12_mag_pmag.stats = {
+					value = 2,
+					extra_ammo = 10,
+					reload = -3,
+					concealment = -1
+				}
+				self.parts.wpn_fps_upg_mk12_mag_pmag.custom_stats = {
+					ads_speed_mult = 1.025
+				}
+				self.parts.wpn_fps_upg_mk12_mag_stanag30.supported = true
+				self.parts.wpn_fps_upg_mk12_mag_stanag30.has_description = false
+				self.parts.wpn_fps_upg_mk12_mag_stanag30.stats = {
+					value = 2,
+					extra_ammo = 10,
+					reload = -3,
+					concealment = -1
+				}
+				self.parts.wpn_fps_upg_mk12_mag_stanag30.custom_stats = {
+					ads_speed_mult = 1.025
+				}
+
+				self.parts.wpn_fps_upg_mk12_stock_solid.supported = true
+				self.parts.wpn_fps_upg_mk12_stock_solid.stats = deep_clone(stocks.adj_to_fixed_rec_stats)
+				self.parts.wpn_fps_upg_mk12_stock_solid.custom_stats = deep_clone(stocks.adj_to_fixed_rec_stats)
+
+				self.wpn_fps_snp_mk12.override.wpn_fps_upg_m4_s_standard = {
+					stats = {},
+					custom_stats = {}
+				}
+
+				self.parts.wpn_fps_upg_mk12_handguard_ddm4fsp.supported = true
+				self.parts.wpn_fps_upg_mk12_handguard_ddm4fsp.stats = {
+					value = 2,
+					recoil = 2,
+					concealment = -1
+				}
+				self.parts.wpn_fps_upg_mk12_handguard_ddmk18.supported = true
+				self.parts.wpn_fps_upg_mk12_handguard_ddmk18.stats = {
+					value = 2,
+					recoil = -2,
+					concealment = 1
+				}
+				self.parts.wpn_fps_upg_mk12_handguard_ergo_z.supported = true
+				self.parts.wpn_fps_upg_mk12_handguard_ergo_z.stats = {
+					value = 2,
+					spread = -1,
+					recoil = -2,
+					concealment = 2
+				}
+
+				self.parts.wpn_fps_upg_mk12_grip_hogue.supported = true
+				self.parts.wpn_fps_upg_mk12_grip_hogue.stats = { value = 0 }
+				self.parts.wpn_fps_upg_mk12_grip_hogue.custom_stats = nil
+
+				self.parts.wpn_fps_upg_mk12_irons_carry_handle.supported = true
+				self.parts.wpn_fps_upg_mk12_irons_carry_handle.stats = { value = 0 }
+				self.parts.wpn_fps_upg_mk12_irons_carry_handle.custom_stats = nil
+				self.parts.wpn_fps_upg_mk12_irons_lirisy.supported = true
+				self.parts.wpn_fps_upg_mk12_irons_lirisy.stats = { value = 0 }
+				self.parts.wpn_fps_upg_mk12_irons_lirisy.custom_stats = nil
+
+				self.parts.wpn_fps_upg_mk12_stock_vltor.pcs = nil
+				self.parts.wpn_fps_upg_mk12_dueck_offset.pcs = nil -- cba
+			end
+
+			if self.parts.wpn_fps_ass_ak12_2014_mag then
+				self.parts.wpn_fps_ass_ak12_2014_mag.supported = true
+				self.parts.wpn_fps_ass_ak12_2014_mag.stats = { value = 0 }
+				self.parts.wpn_fps_ass_ak12_2014_mag.custom_stats = nil
+
+				self.parts.wpn_fps_upg_ak12_2014_barrel_dmr.supported = true
+				self.parts.wpn_fps_upg_ak12_2014_barrel_dmr.has_description = nil
+				self.parts.wpn_fps_upg_ak12_2014_barrel_dmr.stats = deep_clone(barrels.long_b3_stats)
+				self.parts.wpn_fps_upg_ak12_2014_barrel_dmr.custom_stats = deep_clone(barrels.long_b3_stats)
+				self.parts.wpn_fps_upg_ak12_2014_barrel_long.supported = true
+				self.parts.wpn_fps_upg_ak12_2014_barrel_long.stats = deep_clone(barrels.long_b2_stats)
+				self.parts.wpn_fps_upg_ak12_2014_barrel_long.custom_stats = deep_clone(barrels.long_b2_stats)
+				self.parts.wpn_fps_upg_ak12_2014_barrel_short.supported = true
+				self.parts.wpn_fps_upg_ak12_2014_barrel_short.stats = deep_clone(barrels.short_b2_stats)
+				self.parts.wpn_fps_upg_ak12_2014_barrel_short.custom_stats = deep_clone(barrels.short_b2_stats)
+				self.parts.wpn_fps_upg_ak12_2014_barrel_cqb.supported = true
+				self.parts.wpn_fps_upg_ak12_2014_barrel_cqb.stats = deep_clone(barrels.short_b3_stats)
+				self.parts.wpn_fps_upg_ak12_2014_barrel_cqb.custom_stats = deep_clone(barrels.short_b3_stats)
+
+				self.parts.wpn_fps_upg_ak12_2014_magwell_krebs1.supported = true
+				self.parts.wpn_fps_upg_ak12_2014_magwell_krebs1.has_description = nil
+				self.parts.wpn_fps_upg_ak12_2014_magwell_krebs1.stats = {
+					value = 5,
+					concealment = -1,
+					reload = 1
+				}
+				self.parts.wpn_fps_upg_ak12_2014_magwell_krebs2.supported = true
+				self.parts.wpn_fps_upg_ak12_2014_magwell_krebs2.has_description = nil
+				self.parts.wpn_fps_upg_ak12_2014_magwell_krebs2.stats = {
+					value = 5,
+					concealment = -1,
+					reload = 1
+				}
+
+				self.parts.wpn_fps_upg_ak12_2014_grip_fab_ag47.supported = true
+				self.parts.wpn_fps_upg_ak12_2014_grip_fab_ag47.stats = deep_clone(grips.recoil_1)
+				self.parts.wpn_fps_upg_ak12_2014_grip_fab_agr47.supported = true
+				self.parts.wpn_fps_upg_ak12_2014_grip_fab_agr47.stats = deep_clone(grips.acc_1)
+				self.parts.wpn_fps_upg_ak12_2014_grip_ak.supported = true
+				self.parts.wpn_fps_upg_ak12_2014_grip_ak.stats = deep_clone(grips.quickdraw_1)
+				self.parts.wpn_fps_upg_ak12_2014_grip_ak.custom_stats = deep_clone(grips.quickdraw_1)
+
+				self.parts.wpn_fps_upg_ak12_2014_handguard_keymodshort.supported = true
+				self.parts.wpn_fps_upg_ak12_2014_handguard_keymodshort.stats = {
+					value = 2,
+					spread = 1,
+					recoil = -2
+				}
+				self.parts.wpn_fps_upg_ak12_2014_handguard_keymod.supported = true
+				self.parts.wpn_fps_upg_ak12_2014_handguard_keymod.stats = {
+					value = 2,
+					spread = 1,
+					concealment = -1
+				}
+				self.parts.wpn_fps_upg_ak12_2014_handguard_keymodlong.supported = true
+				self.parts.wpn_fps_upg_ak12_2014_handguard_keymodlong.stats = {
+					value = 2,
+					spread = 2,
+					concealment = -2
+				}
+
+				self.parts.wpn_fps_upg_ak12_2014_handguard_new.supported = true
+				self.parts.wpn_fps_upg_ak12_2014_handguard_new.stats = {
+					value = 2,
+					spread = -2,
+					recoil = 4
+				}
+				self.parts.wpn_fps_upg_ak12_2014_handguard_newlong.supported = true
+				self.parts.wpn_fps_upg_ak12_2014_handguard_newlong.stats = {
+					value = 2,
+					spread = -1,
+					recoil = 4,
+					concealment = -1
+				}
+
+				self.parts.wpn_fps_upg_ak12_2014_handguard_old.supported = true
+				self.parts.wpn_fps_upg_ak12_2014_handguard_old.stats = {
+					value = 2,
+					spread = -1,
+					recoil = 2
+				}
+				self.parts.wpn_fps_upg_ak12_2014_handguard_oldlong.supported = true
+				self.parts.wpn_fps_upg_ak12_2014_handguard_oldlong.stats = {
+					value = 2,
+					recoil = 2,
+					concealment = -1
+				}
+
+				self.parts.wpn_fps_upg_ak12_2014_mag_bakelite.supported = true
+				self.parts.wpn_fps_upg_ak12_2014_mag_bakelite.stats = { value = 0 }
+				self.parts.wpn_fps_upg_ak12_2014_mag_bakelite.custom_stats = nil
+				self.parts.wpn_fps_upg_ak12_2014_mag_steel.supported = true
+				self.parts.wpn_fps_upg_ak12_2014_mag_steel.stats = { value = 0 }
+				self.parts.wpn_fps_upg_ak12_2014_mag_steel.custom_stats = nil
+
+				self.parts.wpn_fps_upg_ak12_2014_mag_polymeremagpul.supported = true
+				self.parts.wpn_fps_upg_ak12_2014_mag_polymeremagpul.stats = deep_clone(self.parts.wpn_fps_m4_upg_m_quick.stats)
+				self.parts.wpn_fps_upg_ak12_2014_mag_polymeremagpul.custom_stats = nil
+				self.parts.wpn_fps_upg_ak12_2014_mag_bakelitemagpul.supported = true
+				self.parts.wpn_fps_upg_ak12_2014_mag_bakelitemagpul.stats = deep_clone(self.parts.wpn_fps_m4_upg_m_quick.stats)
+				self.parts.wpn_fps_upg_ak12_2014_mag_bakelitemagpul.custom_stats = nil
+				self.parts.wpn_fps_upg_ak12_2014_mag_steelmagpul.supported = true
+				self.parts.wpn_fps_upg_ak12_2014_mag_steelmagpul.stats = deep_clone(self.parts.wpn_fps_m4_upg_m_quick.stats)
+				self.parts.wpn_fps_upg_ak12_2014_mag_steelmagpul.custom_stats = nil
+				self.parts.wpn_fps_upg_ak12_2014_mag_steeldual.supported = true
+				self.parts.wpn_fps_upg_ak12_2014_mag_steeldual.stats = deep_clone(self.parts.wpn_fps_m4_upg_m_quick.stats)
+				self.parts.wpn_fps_upg_ak12_2014_mag_steeldual.custom_stats = nil
+
+				self.parts.wpn_fps_upg_ak12_2014_mag_steel20.supported = true
+				self.parts.wpn_fps_upg_ak12_2014_mag_steel20.stats = {
+					value = 2,
+					concealment = 2,
+					reload = 5,
+					extra_ammo = -10
+				}
+				self.parts.wpn_fps_upg_ak12_2014_mag_steel20.custom_stats = { 
+					ads_speed_mult = 0.95
+				}
+				self.parts.wpn_fps_upg_ak12_2014_mag_steel20dual.supported = true
+				self.parts.wpn_fps_upg_ak12_2014_mag_steel20dual.stats = {
+					value = 2,
+					spread = -1,
+					concealment = 1,
+					reload = 8,
+					extra_ammo = -10
+				}
+				self.parts.wpn_fps_upg_ak12_2014_mag_steel20dual.custom_stats = { 
+					ads_speed_mult = 0.95
+				}
+				self.parts.wpn_fps_upg_ak12_2014_mag_steel20magpul.supported = true
+				self.parts.wpn_fps_upg_ak12_2014_mag_steel20magpul.stats = {
+					value = 2,
+					spread = -1,
+					concealment = 1,
+					reload = 8,
+					extra_ammo = -10
+				}
+				self.parts.wpn_fps_upg_ak12_2014_mag_steel20magpul.custom_stats = { 
+					ads_speed_mult = 0.95
+				}
+				self.parts.wpn_fps_upg_ak12_2014_mag_waffle40.supported = true
+				self.parts.wpn_fps_upg_ak12_2014_mag_waffle40.stats = {
+					extra_ammo = 10,
+					concealment = -1,
+					reload = -3
+				}
+				self.parts.wpn_fps_upg_ak12_2014_mag_waffle40.custom_stats = {
+					ads_speed_mult = 1.025
+				}
+
+				self.parts.wpn_fps_upg_ak12_2014_stock_ext.supported = true
+				self.parts.wpn_fps_upg_ak12_2014_stock_ext.stats = deep_clone(stocks.adj_hvy_acc_stats)
+				self.parts.wpn_fps_upg_ak12_2014_stock_ext.custom_stats = deep_clone(stocks.adj_hvy_acc_stats)
+				self.parts.wpn_fps_upg_ak12_2014_stock_ak.supported = true
+				self.parts.wpn_fps_upg_ak12_2014_stock_ak.stats = deep_clone(stocks.adj_to_fixed_rec_stats)
+				self.parts.wpn_fps_upg_ak12_2014_stock_ak.custom_stats = deep_clone(stocks.adj_to_fixed_rec_stats)
+
+				self.wpn_fps_ass_ak12_2014.override.wpn_fps_upg_m4_s_standard = {
+					stats = {},
+					custom_stats = {}
+				}
 			end
 
 	--[[ RJC9000'S MODS ]]
@@ -34456,8 +34953,8 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 						self.parts.wpn_fps_shot_m37_fg_long.supported = true
 						self.parts.wpn_fps_shot_m37_fg_long.stats = {
 							value = 1,
-							recoil = 1,
-							concealment = -2
+							recoil = 2,
+							concealment = -1
 						}
 						--Tactical Pump
 						self.parts.wpn_fps_shot_m37_fg_tactical.supported = true
@@ -35869,7 +36366,9 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 				self.parts.wpn_fps_shot_minibeck_s_solid.supported = true
 				self.parts.wpn_fps_shot_minibeck_s_solid.stats = deep_clone(stocks.add_fixed_stats)
 				self.parts.wpn_fps_shot_minibeck_s_solid.custom_stats = deep_clone(stocks.add_fixed_stats)
-		
+
+				table.insert(self.wpn_fps_shot_minibeck.uses_parts, "wpn_fps_upg_a_rip")
+
 				--(Holt 9mm) Silver Slide
 				self.parts.wpn_fps_pis_holt_b_silver.supported = true
 				self.parts.wpn_fps_pis_holt_b_silver.stats = {
@@ -38514,6 +39013,20 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 			self.parts.wpn_fps_ass_tingledingle_m_extended.custom_stats = {
 				ads_speed_mult = 1.125
 			}
+
+			self.parts.wpn_fps_ass_tingledingle_fg_stealth.supported = true
+			self.parts.wpn_fps_ass_tingledingle_fg_stealth.stats = {
+				value = 99,
+				recoil = -20,
+				concealment = 10
+			}
+
+			self.parts.wpn_fps_ass_tingledingle_detector.supported = true
+			self.parts.wpn_fps_ass_tingledingle_detector.stats = {
+				value = 99,
+				concealment = -2
+			}
+			self.parts.wpn_fps_ass_tingledingle_detector.perks = { "highlight" }
 		end
 
 		if self.parts.wpn_fps_spe_raygun_body then --Zdann's Raygun
@@ -41157,6 +41670,9 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 			self.wpn_fps_pis_x_toz81.override.wpn_fps_upg_a_piercing.desc_id = "bm_wp_upg_a_piercing_9_auto_desc_per_pellet"
 			self.wpn_fps_pis_x_toz81.override.wpn_fps_upg_a_piercing.custom_stats.rays = 9
 			self.wpn_fps_pis_x_toz81.override.wpn_fps_upg_a_dragons_breath = deep_clone(shot_ammo.a_dragons_breath_pump_override)
+
+			table.insert(self.wpn_fps_pis_toz81.uses_parts, "wpn_fps_upg_a_piercing")
+			table.insert(self.wpn_fps_pis_x_toz81.uses_parts, "wpn_fps_upg_a_piercing")
 		end
 
 		if self.parts.wpn_fps_shot_or12_vg then
@@ -42049,6 +42565,122 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 					extra_ammo = 144,
 					reload = -10
 				}
+			}
+		end
+
+		if self.parts.wpn_fps_shot_f500_b_silencer then
+			self.parts.wpn_fps_shot_f500_b_silencer.supported = true
+			self.parts.wpn_fps_shot_f500_b_silencer.stats = {
+				value = 2,
+				suppression = 12,
+				alert_size = -1
+			}
+			self.parts.wpn_fps_shot_f500_b_silencer.custom_stats = {}
+			self.parts.wpn_fps_shot_f500_b_silencer.perks = {"silencer"}
+
+			self.wpn_fps_shot_f500.override = self.wpn_fps_shot_f500.override or {}
+			self.wpn_fps_shot_f500.override.wpn_fps_upg_a_slug = deep_clone(shot_ammo.a_slug_pump_override)
+			self.wpn_fps_shot_f500.override.wpn_fps_upg_a_custom = deep_clone(shot_ammo.a_custom_pump_override)
+			self.wpn_fps_shot_f500.override.wpn_fps_upg_a_custom_free = deep_clone(shot_ammo.a_custom_pump_override)
+			self.wpn_fps_shot_f500.override.wpn_fps_upg_a_explosive = deep_clone(shot_ammo.a_explosive_pump_override)
+			self.wpn_fps_shot_f500.override.wpn_fps_upg_a_rip = deep_clone(shot_ammo.a_rip_pump_override)
+			self.wpn_fps_shot_f500.override.wpn_fps_upg_a_piercing = deep_clone(shot_ammo.a_piercing_pump_override)
+			self.wpn_fps_shot_f500.override.wpn_fps_upg_a_dragons_breath = deep_clone(shot_ammo.a_dragons_breath_pump_override)
+		end
+
+		if self.parts.wpn_fps_shot_toz194_b_short then
+			self.parts.wpn_fps_shot_toz194_b_short.supported = true
+			self.parts.wpn_fps_shot_toz194_b_short.stats = {
+				value = 3,
+				spread = -2,
+				concealment = 2,
+				extra_ammo = -2
+			}
+			self.parts.wpn_fps_shot_toz194_b_short.custom_stats = deep_clone(barrels.short_b2_stats)
+
+			self.parts.wpn_fps_shot_toz194_b_silencer.supported = true
+			self.parts.wpn_fps_shot_toz194_b_silencer.stats = {
+				value = 2,
+				suppression = 12,
+				alert_size = -1
+			}
+			self.parts.wpn_fps_shot_toz194_b_silencer.custom_stats = {}
+			self.parts.wpn_fps_shot_toz194_b_silencer.perks = {"silencer"}
+
+			self.parts.wpn_fps_shot_toz194_grip_plastic.supported = true
+			self.parts.wpn_fps_shot_toz194_grip_plastic.stats = {
+				value = 2,
+				recoil = -2,
+				spread = 1
+			}
+			self.parts.wpn_fps_shot_toz194_fg_plastic.supported = true
+			self.parts.wpn_fps_shot_toz194_fg_plastic.stats = {
+				value = 2,
+				recoil = -2,
+				spread = 1
+			}
+
+			self.parts.wpn_fps_shot_toz194_g_stock.supported = true
+			self.parts.wpn_fps_shot_toz194_g_stock.stats = deep_clone(stocks.add_folder_stats)
+			self.parts.wpn_fps_shot_toz194_g_stock.custom_stats = deep_clone(stocks.add_folder_stats)
+
+			self.wpn_fps_shot_toz194.override = self.wpn_fps_shot_toz194.override or {}
+			self.wpn_fps_shot_toz194.override.wpn_fps_upg_a_slug = deep_clone(shot_ammo.a_slug_pump_override)
+			self.wpn_fps_shot_toz194.override.wpn_fps_upg_a_custom = deep_clone(shot_ammo.a_custom_pump_override)
+			self.wpn_fps_shot_toz194.override.wpn_fps_upg_a_custom_free = deep_clone(shot_ammo.a_custom_pump_override)
+			self.wpn_fps_shot_toz194.override.wpn_fps_upg_a_explosive = deep_clone(shot_ammo.a_explosive_pump_override)
+			self.wpn_fps_shot_toz194.override.wpn_fps_upg_a_rip = deep_clone(shot_ammo.a_rip_pump_override)
+			self.wpn_fps_shot_toz194.override.wpn_fps_upg_a_piercing = deep_clone(shot_ammo.a_piercing_pump_override)
+			self.wpn_fps_shot_toz194.override.wpn_fps_upg_a_dragons_breath = deep_clone(shot_ammo.a_dragons_breath_pump_override)
+		end
+
+		if self.parts.wpn_fps_pis_welrod_b_short then
+			self.parts.wpn_fps_pis_welrod_b_short.supported = true
+			self.parts.wpn_fps_pis_welrod_b_short.stats = deep_clone(barrels.short_b2_stats)
+			self.parts.wpn_fps_pis_welrod_b_short.custom_stats = deep_clone(barrels.short_b2_stats)
+
+			self.parts.wpn_fps_pis_welrod_glow.supported = true
+			self.parts.wpn_fps_pis_welrod_glow.stats = { value = 0 }
+			self.parts.wpn_fps_pis_welrod_glow.custom_stats = nil
+
+			self.parts.wpn_fps_pis_welrod_trigger_guard.supported = true
+			self.parts.wpn_fps_pis_welrod_trigger_guard.stats = { value = 0 }
+			self.parts.wpn_fps_pis_welrod_trigger_guard.custom_stats = nil
+		end
+
+		if self.parts.wpn_fps_smg_spectre_m4_so_gold then
+			self.parts.wpn_fps_smg_spectre_m4_so_gold.supported = true
+			self.parts.wpn_fps_smg_spectre_m4_so_gold.stats = { value = 0 }
+			self.parts.wpn_fps_smg_spectre_m4_so_gold.custom_stats = nil
+
+			self.parts.wpn_fps_smg_spectre_m4_m_standard.supported = true
+			self.parts.wpn_fps_smg_spectre_m4_m_standard.stats = {
+				extra_ammo = 10,
+				concealment = -1,
+				reload = -3
+			}
+			self.parts.wpn_fps_smg_spectre_m4_m_standard.custom_stats = {
+				ads_speed_mult = 1.025
+			}
+			self.parts.wpn_fps_smg_x_spectre_m4_m_standard.supported = true
+			self.parts.wpn_fps_smg_x_spectre_m4_m_standard.stats = {
+				extra_ammo = 10,
+				concealment = -1,
+				reload = -3
+			}
+			self.parts.wpn_fps_smg_x_spectre_m4_m_standard.custom_stats = {
+				ads_speed_mult = 1.025
+			}
+
+			self.parts.wpn_fps_smg_spectre_m4_no_stock.supported = true
+			self.parts.wpn_fps_smg_spectre_m4_no_stock.stats = deep_clone(stocks.remove_folder_stats)
+			self.parts.wpn_fps_smg_spectre_m4_no_stock.custom_stats = deep_clone(stocks.remove_folder_stats)
+
+			self.parts.wpn_fps_smg_spectre_m4_no_vg.supported = true
+			self.parts.wpn_fps_smg_spectre_m4_no_vg.stats = {
+				value = 2,
+				recoil = -4,
+				concealment = 2
 			}
 		end
 
@@ -43754,6 +44386,9 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 		self.wpn_fps_shot_jackhammer.override.wpn_fps_upg_a_rip = deep_clone(shot_ammo.a_rip_semi_override)
 		self.wpn_fps_shot_jackhammer.override.wpn_fps_upg_a_piercing = deep_clone(shot_ammo.a_piercing_semi_override)
 		self.wpn_fps_shot_jackhammer.override.wpn_fps_upg_a_dragons_breath = deep_clone(shot_ammo.a_dragons_breath_semi_override)
+
+		table.insert(self.wpn_fps_shot_jackhammer.uses_parts, "wpn_fps_upg_a_dragons_breath")
+		table.insert(self.wpn_fps_shot_jackhammer.uses_parts, "wpn_fps_upg_a_rip")
 	end
 
 	if self.parts.wpn_fps_rsass_handguard then --youngrich99 and FrenchyAU's Remington RSASS
@@ -44212,6 +44847,8 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 			falloff_end_mult = 1.3,
 			ads_speed_mult = 1.1
 		}
+
+		table.insert(self.wpn_fps_sho_littlest.uses_parts, "wpn_fps_upg_a_rip")
 	end
 
 	if self.parts.wpn_fps_pis_pb_ns_std then
@@ -44347,7 +44984,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 			recoil = 2,
 			concealment = -1
 		}
-		
+
 		self.parts.wpn_fps_snp_enfield_no5i_stock_pad.supported = true
 		self.parts.wpn_fps_snp_enfield_no5i_stock_pad.stats = {
 			value = 2,
@@ -44374,6 +45011,142 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 		self.parts.wpn_fps_snp_enfield_no5i_scope.stats = {
 			value = 0,
 			zoom = 30
+		}
+	end
+
+	if self.parts.wpn_fps_pis_mp443_m_extended then
+		self.parts.wpn_fps_pis_mp443_m_extended.supported = true
+		self.parts.wpn_fps_pis_mp443_m_extended.stats = {
+			value = 2,
+			concealment = -2,
+			extra_ammo = 8,
+			reload = -4
+		}
+		self.parts.wpn_fps_pis_mp443_m_extended.custom_stats = {
+			ads_speed_mult = 1.025
+		}
+
+		self.parts.wpn_fps_pis_mp443_sl_long.supported = true
+		self.parts.wpn_fps_pis_mp443_sl_long.stats = deep_clone(barrels.long_b2_stats)
+		self.parts.wpn_fps_pis_mp443_sl_long.custom_stats = deep_clone(barrels.long_b2_stats)
+	end
+
+	if self.parts.wpn_fps_pis_af2011_m_ext then
+		self.parts.wpn_fps_pis_af2011_m_ext.supported = true
+		self.parts.wpn_fps_pis_af2011_m_ext.stats = {
+			value = 3,
+			concealment = -2,
+			extra_ammo = 8,
+			reload = -3
+		}
+
+		self.parts.wpn_fps_pis_af2011_parts.supported = true
+		self.parts.wpn_fps_pis_af2011_parts.stats = {
+			spread_multi = {1.5, 0.75}
+		}
+
+		self.parts.wpn_fps_pis_af2011_a_uno.supported = true
+		self.parts.wpn_fps_pis_af2011_a_uno.type = "custom"
+		self.parts.wpn_fps_pis_af2011_a_uno.alt_icon = "guis/textures/pd2/blackmarket/icons/mods/wpn_fps_upg_i_autofire"
+		self.parts.wpn_fps_pis_af2011_a_uno.name_id = self.parts.wpn_fps_upg_i_singlefire.name_id
+		self.parts.wpn_fps_pis_af2011_a_uno.has_description = true
+		self.parts.wpn_fps_pis_af2011_a_uno.desc_id = "bm_wp_upg_af2011_a_uno_desc"
+		self.parts.wpn_fps_pis_af2011_a_uno.stats = { spread_multi = {1, 1} }
+		self.parts.wpn_fps_pis_af2011_a_uno.custom_stats = {
+			burst_fire = false,
+			info_lock_semi = true,
+			rof_mult = 1.16666666666
+		}
+
+		self.parts.wpn_fps_pis_af2011_g_bling.supported = true
+		self.parts.wpn_fps_pis_af2011_g_bling.has_description = false
+		self.parts.wpn_fps_pis_af2011_g_bling.stats = deep_clone(grips.recoil_1)
+		self.parts.wpn_fps_pis_af2011_g_wood.supported = true
+		self.parts.wpn_fps_pis_af2011_g_wood.has_description = false
+		self.parts.wpn_fps_pis_af2011_g_wood.stats = deep_clone(grips.recoil_acc)
+
+		self.parts.wpn_fps_pis_af2011_b_silver.supported = true
+		self.parts.wpn_fps_pis_af2011_b_silver.stats = { value = 0 }
+		self.parts.wpn_fps_pis_af2011_b_silver.custom_stats = nil
+	end
+
+	if self.parts.wpn_fps_pis_cz75b_ba_ext then
+		self.parts.wpn_fps_pis_cz75b_ba_ext.supported = true
+		self.parts.wpn_fps_pis_cz75b_ba_ext.stats = deep_clone(barrels.long_b1_stats)
+		self.parts.wpn_fps_pis_cz75b_ba_ext.custom_stats = deep_clone(barrels.long_b1_stats)
+
+		self.parts.wpn_fps_pis_cz75b_sl_comp.supported = true
+		self.parts.wpn_fps_pis_cz75b_sl_comp.stats = deep_clone(barrels.long_b1_stats)
+		self.parts.wpn_fps_pis_cz75b_sl_comp.custom_stats = deep_clone(barrels.long_b1_stats)
+
+		self.parts.wpn_fps_pis_cz75b_co_85.supported = true
+		self.parts.wpn_fps_pis_cz75b_co_85.stats = { value = 0 }
+		self.parts.wpn_fps_pis_cz75b_co_85.custom_stats = nil
+
+		self.parts.wpn_fps_pis_cz75b_fg_mag.supported = true
+		self.parts.wpn_fps_pis_cz75b_fg_mag.stats = {
+			value = 3,
+			recoil = 4,
+			concealment = -2
+		}
+
+		self.parts.wpn_fps_pis_cz75b_m_ext.supported = true
+		self.parts.wpn_fps_pis_cz75b_m_ext.stats = {
+			value = 2,
+			concealment = -2,
+			extra_ammo = 8,
+			reload = -4
+		}
+		self.parts.wpn_fps_pis_cz75b_m_ext.custom_stats = {
+			ads_speed_mult = 1.025
+		}
+
+		self.parts.wpn_fps_pis_cz75b_f_stainless.supported = true
+		self.parts.wpn_fps_pis_cz75b_f_stainless.stats = { value = 0 }
+		self.parts.wpn_fps_pis_cz75b_f_stainless.custom_stats = nil
+		self.parts.wpn_fps_pis_cz75b_sl_stainless.supported = true
+		self.parts.wpn_fps_pis_cz75b_sl_stainless.stats = { value = 0 }
+		self.parts.wpn_fps_pis_cz75b_sl_stainless.custom_stats = nil
+
+		self.parts.wpn_fps_pis_cz75b_f_blued.supported = true
+		self.parts.wpn_fps_pis_cz75b_f_blued.stats = { value = 0 }
+		self.parts.wpn_fps_pis_cz75b_f_blued.custom_stats = nil
+		self.parts.wpn_fps_pis_cz75b_sl_blued.supported = true
+		self.parts.wpn_fps_pis_cz75b_sl_blued.stats = { value = 0 }
+		self.parts.wpn_fps_pis_cz75b_sl_blued.custom_stats = nil
+
+		self.parts.wpn_fps_pis_cz75b_f_gold.supported = true
+		self.parts.wpn_fps_pis_cz75b_f_gold.stats = { value = 0 }
+		self.parts.wpn_fps_pis_cz75b_f_gold.custom_stats = nil
+		self.parts.wpn_fps_pis_cz75b_sl_gold.supported = true
+		self.parts.wpn_fps_pis_cz75b_sl_gold.stats = { value = 0 }
+		self.parts.wpn_fps_pis_cz75b_sl_gold.custom_stats = nil
+
+		self.parts.wpn_fps_pis_cz75b_g_coco.supported = true
+		self.parts.wpn_fps_pis_cz75b_g_coco.stats = deep_clone(grips.recoil_1)
+		self.parts.wpn_fps_pis_cz75b_g_wal.supported = true
+		self.parts.wpn_fps_pis_cz75b_g_wal.stats = deep_clone(grips.acc_1)
+		self.parts.wpn_fps_pis_cz75b_g_pre.supported = true
+		self.parts.wpn_fps_pis_cz75b_g_pre.stats = deep_clone(grips.quickdraw_acc)
+		self.parts.wpn_fps_pis_cz75b_g_pre.custom_stats = deep_clone(grips.quickdraw_acc)
+		self.parts.wpn_fps_pis_cz75b_g_rub.supported = true
+		self.parts.wpn_fps_pis_cz75b_g_rub.stats = deep_clone(grips.quickdraw_1)
+		self.parts.wpn_fps_pis_cz75b_g_rub.custom_stats = deep_clone(grips.quickdraw_1)
+
+		for i, part_id in pairs(self.wpn_fps_pis_cz75b.uses_parts) do
+			if self.parts and self.parts[part_id] and self.parts[part_id].type and self.parts[part_id].type == "barrel_ext" and not self.parts[part_id].depends_on then
+				self.wpn_fps_pis_cz75b.override[part_id] = {a_obj = "a_cz75bns", parent = "barrel"}
+				self.parts.wpn_fps_pis_cz75b_ba_std.override[part_id] = {a_obj = "a_cz75bns"}
+				self.parts.wpn_fps_pis_cz75b_ba_ext.override[part_id] = {a_obj = "a_cz75bns_ext"}
+			end
+		end
+		self.wpn_fps_pis_x_cz75b.override.wpn_fps_pis_cz75b_m_ext = {
+			stats = {
+				value = 2,
+				concealment = -2,
+				extra_ammo = 16,
+				reload = -4
+			}
 		}
 	end
 
@@ -44937,6 +45710,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 
 	if self.parts.wpn_fps_ass_mdr_308_barrel_sniper then
 		self.parts.wpn_fps_ass_mdr_308_barrel_sniper.supported = true
+		self.parts.wpn_fps_ass_mdr_308_barrel_sniper.has_description = false
 		self.parts.wpn_fps_ass_mdr_308_barrel_sniper.stats = deep_clone(barrels.long_b2_stats)
 		self.parts.wpn_fps_ass_mdr_308_barrel_sniper.custom_stats = deep_clone(barrels.long_b2_stats)
 	end

--- a/lua/sc/tweak_data/weapontweakdata.lua
+++ b/lua/sc/tweak_data/weapontweakdata.lua
@@ -13010,9 +13010,10 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 						self.model70.stats_modifiers = nil
 						self.model70.reload_speed_multiplier = 1.125
 						self.model70.panic_suppression_chance = 0.05
-						self.model70.timers.reload_empty = 3.6
+						self.model70.timers.reload_empty = 3.25
+						self.model70.timers.reload_not_empty = 4.3
 						self.model70.timers.reload_exit_empty = 1.5
-						self.model70.timers.reload_exit_not_empty = 0.95
+						self.model70.timers.reload_exit_not_empty = 1.05
 
 					--R93 (Blaser R93)
 						self.r93.has_description = true
@@ -16904,7 +16905,6 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 				self.x_kedr.AMMO_MAX = 180
 				self.x_kedr.fire_mode_data.fire_rate = 0.06
 				self.x_kedr.single.fire_rate = 0.06
-				self.x_kedr.kick = self.stat_info.kick_tables.even_recoil
 				self.x_kedr.kick = self.stat_info.kick_tables.left_recoil
 				self.x_kedr.kick_pattern = {
 					{0, self.stat_info.kick_tables.vertical_kick},
@@ -20118,6 +20118,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 				}
 				self.sw642.supported = true
 				self.sw642.ads_speed = 0.160
+				self.sw642.sounds.fire = "mateba_fire"
 				self.sw642.damage_falloff = {
 					start_dist = 1000,
 					end_dist = 3200,
@@ -20151,6 +20152,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 				self.x_sw642.desc_id = "bm_ap_armor_50_weapon_sc_desc"
 				self.x_sw642.CLIP_AMMO_MAX = 10
 				self.x_sw642.AMMO_MAX = 60
+				self.x_sw642.sounds.fire = "mateba_fire"
 				self.x_sw642.fire_mode_data.fire_rate = 0.16666667
 				self.x_sw642.kick = self.stat_info.kick_tables.moderate_kick
 				self.x_sw642.kick_pattern = {
@@ -20873,6 +20875,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 				}
 				self.sr3m.supported = true
 				self.sr3m.ads_speed = 0.300
+				self.sr3m.armor_piercing_chance = 0.25
 				self.sr3m.damage_falloff = {
 					start_dist = 1000,
 					end_dist = 3800,
@@ -21152,6 +21155,420 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 				self.toz34.stats_modifiers = {damage = 1}
 				self.toz34.reload_speed_multiplier = 1.02
 				self.toz34.timers = deep_clone(self.b682.timers)
+			end
+
+			if self.triple then
+				self.triple.recategorize = { "break_shot" }
+				self.triple.categories = { "shotgun" }
+				self.triple.damage_type = "shotgun_heavy"
+				self.triple.damage_type_single_ray = "anti_materiel"
+				self.triple.rays = 8
+				self.triple.muzzleflash = "effects/payday2/particles/weapons/big_51b_auto_fps" --"effects/particles/shotgun/shotgun_gen"
+				self.triple.CLIP_AMMO_MAX = 3
+				self.triple.AMMO_MAX = 30
+				self.triple.sounds.fire_single = "huntsman_fire"
+				self.triple.sounds.fire_auto = "huntsman_fire"
+				self.triple.BURST_FIRE = false
+				self.triple.fire_mode_data = {}
+				self.triple.fire_mode_data.fire_rate = 0.2
+				self.triple.kick = self.stat_info.kick_tables.vertical_kick
+				self.triple.kick_pattern = {
+					{0, self.stat_info.kick_tables.vertical_kick},
+					{2, self.stat_info.kick_tables.pattern_r4},
+					{3, self.stat_info.kick_tables.pattern_v4},
+				}
+				self.triple.supported = true
+				self.triple.ads_speed = 0.400
+				self.triple.damage_falloff = {
+					start_dist = 700,
+					end_dist = 3200,
+					min_mult = 0.125
+				}
+				self.triple.stats = {
+					damage = 240,
+					spread = 62,
+					recoil = 39,
+					spread_moving = 6,
+					zoom = 1,
+					concealment = 23,
+					suppression = 6,
+					alert_size = 2,
+					extra_ammo = 101,
+					total_ammo_mod = 400,
+					value = 1,
+					reload = 20
+				}
+				self.triple.stats_modifiers = nil
+				self.triple.panic_suppression_chance = 0.05
+				if BeardLib.Utils:FindMod("Restored Mosconi Reload Animation") then
+					self.triple.animations.ignore_nonemptyreload = true
+				end
+			end
+
+			if self.appistol then
+				self.appistol.categories = {
+					"pistol",
+					"pistol_pdw"
+				}
+				self.appistol.recategorize = { "light_pis" }
+				self.appistol.damage_type = "shotgun_heavy"
+				self.appistol.has_description = true
+				self.appistol.desc_id = "bm_sr1_sc_desc"
+				self.appistol.fire_mode_data.fire_rate = 0.1
+				self.appistol.AMMO_MAX = 90
+				self.appistol.kick = self.stat_info.kick_tables.moderate_kick
+				self.appistol.kick_pattern = {
+					{0, self.stat_info.kick_tables.moderate_kick},
+					{5, self.stat_info.kick_tables.right_kick},
+					{9, self.stat_info.kick_tables.moderate_kick}
+				}
+				self.appistol.CLIP_AMMO_MAX = 18
+				self.appistol.supported = true
+				self.appistol.ads_speed = 0.160
+				self.appistol.armor_piercing_chance = 0.75
+				self.appistol.hs_mult = 1.33333
+				self.appistol.damage_falloff = {
+					start_dist = 1500,
+					end_dist = 3400,
+					min_mult = 0.555555
+				}
+				self.appistol.stats = {
+					damage = 18,
+					spread = 62,
+					recoil = 79,
+					spread_moving = 9,
+					zoom = 1,
+					concealment = 29,
+					suppression = 11,
+					alert_size = 2,
+					extra_ammo = 101,
+					total_ammo_mod = 400,
+					value = 1,
+					reload = 20
+				}
+				self.appistol.stats_modifiers = nil
+				self.appistol.panic_suppression_chance = 0.05
+			end
+
+			if self.rk62 then
+				self.rk62.warsaw = true
+				self.rk62.recategorize = { "heavy_ar" }	
+				self.rk62.damage_type = "assault_rifle"
+				self.rk62.CLIP_AMMO_MAX = 30
+				self.rk62.tactical_reload = 1
+				self.rk62.AMMO_MAX = 120
+				self.rk62.fire_mode_data.fire_rate = 0.0857142857142857
+				self.rk62.auto.fire_rate = 0.0857142857142857
+				self.rk62.kick = self.stat_info.kick_tables.moderate_right_kick
+				self.rk62.kick_pattern = {
+					{0, self.stat_info.kick_tables.right_kick},
+					{6, self.stat_info.kick_tables.moderate_left_kick},
+					{10, self.stat_info.kick_tables.moderate_kick},
+					{12, self.stat_info.kick_tables.moderate_right_kick},
+					{18, self.stat_info.kick_tables.moderate_kick},
+					{22, self.stat_info.kick_tables.moderate_right_kick}
+				}
+				self.rk62.supported = true
+				self.rk62.ads_speed = 0.300
+				self.rk62.damage_falloff = {
+					start_dist = 2500,
+					end_dist = 6000,
+					min_mult = 0.6
+				}
+				self.rk62.stats = {
+					damage = 30,
+					spread = 78,
+					recoil = 69,
+					spread_moving = 6,
+					zoom = 1,
+					concealment = 26,
+					suppression = 8,
+					alert_size = 2,
+					extra_ammo = 101,
+					total_ammo_mod = 400,
+					value = 1,
+					reload = 20
+				}
+				self.rk62.stats_modifiers = nil
+				self.rk62.panic_suppression_chance = 0.05
+				self.rk62.timers = deep_clone(self.akm.timers)
+			end
+
+			if self.m1912 then
+				self.m1912.recategorize = { "heavy_shot" }
+				self.m1912.damage_type = "shotgun_heavy"
+				self.m1912.damage_type_single_ray = "sniper"
+				self.m1912.has_description = false
+				self.m1912.tactical_reload = 1
+				self.m1912.rays = 8
+				self.m1912.CLIP_AMMO_MAX = 6
+				self.m1912.muzzleflash = "effects/payday2/particles/weapons/big_51b_auto_fps" --"effects/particles/shotgun/shotgun_gen"
+				self.m1912.kick = self.stat_info.kick_tables.left_kick
+				self.m1912.fire_mode_data.fire_rate = 0.6
+				self.m1912.fire_rate_multiplier = 0.87
+				self.m1912.BURST_FIRE = {
+					count = 1,
+					rof_mult = 1.8,
+					auto_burst = true,
+					slamfire = true,
+					no_ads = true,
+					spread_mult = 3,
+					range_mult = 0.66,
+					recoil_mult = 1.2,
+					last_recoil_mult = 1.2
+				}
+				self.m1912.BURST_TYPE = "slam"
+				self.m1912.AMMO_MAX = 40
+				self.m1912.supported = true
+				self.m1912.ads_speed = 0.320
+				self.m1912.damage_falloff = {
+					start_dist = 900,
+					end_dist = 2800,
+					min_mult = 0.1333
+				}
+				self.m1912.stats = {
+					damage = 180,
+					spread = 74,
+					recoil = 37,
+					spread_moving = 6,
+					zoom = 1,
+					concealment = 21,
+					suppression = 7,
+					alert_size = 2,
+					extra_ammo = 101,
+					total_ammo_mod = 400,
+					value = 1,
+					reload = 20
+				}	
+				self.m1912.stats_modifiers = {damage = 1}
+				self.m1912.panic_suppression_chance = 0.05
+				self.m1912.timers = deep_clone(self.m1897.timers)
+			end
+
+			if self.fnar then
+				self.fnar.nato = true
+				self.fnar.categories = {
+					"snp",
+					"semi_snp"
+				}
+				self.fnar.recategorize = { "light_snp" }
+				self.fnar.damage_type = "sniper"
+				self.fnar.upgrade_blocks = nil
+				self.fnar.has_description = true
+				self.fnar.lock_slide = true
+				self.fnar.sounds.magazine_empty = "wp_rifle_slide_lock"
+				self.fnar.desc_id = "bm_ap_weapon_semi_sc_desc"
+				self.fnar.CLIP_AMMO_MAX = 10
+				self.fnar.tactical_reload = 1
+				self.fnar.AMMO_MAX = 60
+				self.fnar.FIRE_MODE = "single"
+				self.fnar.fire_mode_data.fire_rate = 0.17142857
+				self.fnar.sms = sms_preset.semi_snp_light
+				self.fnar.kick = self.stat_info.kick_tables.vertical_kick
+				self.fnar.kick_pattern = {
+					{0, self.stat_info.kick_tables.right_kick},
+					{3, self.stat_info.kick_tables.left_kick},
+					{8, self.stat_info.kick_tables.even_recoil},
+					{11, self.stat_info.kick_tables.vertical_kick}
+				}
+				self.fnar.can_shoot_through_enemy = true
+				self.fnar.can_shoot_through_shield = true
+				self.fnar.can_shoot_through_wall = true
+				self.fnar.supported = true
+				self.fnar.ads_speed = 0.460
+				self.fnar.damage_falloff = {
+					start_dist = 2000,
+					end_dist = 6000,
+					min_mult = 0.5
+				}
+				self.fnar.stats = {
+					damage = 60,
+					spread = 88,
+					recoil = 43,
+					zoom = 1,
+					concealment = 22,
+					suppression = 8,
+					alert_size = 2,
+					extra_ammo = 101,
+					total_ammo_mod = 400,
+					value = 9,
+					reload = 20
+				}
+				self.fnar.armor_piercing_chance = 1
+				self.fnar.stats_modifiers = nil
+				self.fnar.panic_suppression_chance = 0.05
+				self.fnar.timers = deep_clone(self.siltstone.timers)
+			end	
+
+			if self.mk12 then
+				self.mk12.categories = {
+					"snp",
+					"semi_snp"
+				}
+				self.mk12.recategorize = { "light_snp" }
+				self.mk12.damage_type = "sniper"
+				self.mk12.upgrade_blocks = nil
+				self.mk12.has_description = true
+				self.mk12.desc_id = "bm_ap_weapon_semi_sc_desc"
+				self.mk12.CLIP_AMMO_MAX = 20
+				self.mk12.AMMO_MAX = 72
+				self.mk12.FIRE_MODE = "single"
+				self.mk12.fire_mode_data = {}
+				self.mk12.fire_mode_data.fire_rate = 0.1764705
+				self.mk12.sms = sms_preset.semi_snp_light
+				self.mk12.kick = self.stat_info.kick_tables.vertical_kick
+				self.mk12.kick_pattern = {
+					{0, self.stat_info.kick_tables.vertical_kick},
+					{3, self.stat_info.kick_tables.horizontal_recoil},
+					{4, self.stat_info.kick_tables.left_recoil},
+					{5, self.stat_info.kick_tables.left_kick},
+					{8, self.stat_info.kick_tables.even_recoil}
+				}
+				self.mk12.can_shoot_through_enemy = true
+				self.mk12.can_shoot_through_shield = true
+				self.mk12.can_shoot_through_wall = true
+				self.mk12.supported = true
+				self.mk12.ads_speed = 0.460
+				self.mk12.damage_falloff = {
+					start_dist = 2000,
+					end_dist = 6000,
+					min_mult = 0.33333
+				}
+				self.mk12.stats = {
+					damage = 30,
+					spread = 86,
+					recoil = 59,
+					spread_moving = 6,
+					zoom = 1,
+					concealment = 21,
+					suppression = 6,
+					alert_size = 2,
+					extra_ammo = 101,
+					total_ammo_mod = 400,
+					value = 9,
+					reload = 20
+				}
+				self.mk12.stats_modifiers = nil
+				self.mk12.hs_mult = 2
+				self.mk12.keep_ammo = 1
+				self.mk12.reload_speed_multiplier = 0.9
+				self.mk12.armor_piercing_chance = 1
+				self.mk12.panic_suppression_chance = 0.05
+				self.mk12.timers = deep_clone(self.new_m4.timers)
+			end
+
+			if self.ak12_2014 then
+				self.ak12_2014.warsaw = true
+				self.ak12_2014.recategorize = { "heavy_ar" }	
+				self.ak12_2014.damage_type = "assault_rifle"
+				self.ak12_2014.CLIP_AMMO_MAX = 30
+				self.ak12_2014.tactical_reload = 1
+				self.ak12_2014.AMMO_MAX = 120
+				self.ak12_2014.BURST_FIRE = {
+					count = 3,
+					rof_mult = 1.6666,
+					recoil_mult = 0.75,
+					last_recoil_mult = 1.05
+				}		
+				self.ak12_2014.ADAPTIVE_BURST_SIZE = false
+				self.ak12_2014.fire_mode_data.fire_rate = 0.0923076923076923
+				self.ak12_2014.auto.fire_rate = 0.0923076923076923
+				self.ak12_2014.kick = self.stat_info.kick_tables.moderate_right_kick
+				self.ak12_2014.kick_pattern = {
+					{0, self.stat_info.kick_tables.right_kick},
+					{6, self.stat_info.kick_tables.moderate_left_kick},
+					{10, self.stat_info.kick_tables.moderate_kick},
+					{12, self.stat_info.kick_tables.moderate_right_kick},
+					{18, self.stat_info.kick_tables.moderate_kick},
+					{22, self.stat_info.kick_tables.moderate_right_kick}
+				}
+				self.ak12_2014.supported = true
+				self.ak12_2014.ads_speed = 0.320
+				self.ak12_2014.damage_falloff = {
+					start_dist = 2500,
+					end_dist = 6000,
+					min_mult = 0.6
+				}
+				self.ak12_2014.stats = {
+					damage = 30,
+					spread = 77,
+					recoil = 71,
+					spread_moving = 6,
+					zoom = 1,
+					concealment = 25,
+					suppression = 8,
+					alert_size = 2,
+					extra_ammo = 101,
+					total_ammo_mod = 400,
+					value = 1,
+					reload = 20
+				}
+				self.ak12_2014.stats_modifiers = nil
+				self.ak12_2014.panic_suppression_chance = 0.05
+				self.ak12_2014.timers = deep_clone(self.ak74.timers)
+			end
+
+			if self.triad then
+				self.triad.recategorize = {"heavy_pis", "handcannon"}
+				self.triad.use_data.selection_index = 2
+				self.triad.has_description = true
+				self.triad.desc_id = "bm_triad_sc_desc"
+				self.triad.CLIP_AMMO_MAX = 6
+				self.triad.AMMO_MAX = 60
+				self.triad.fire_mode_data.fire_rate = 0.2
+				self.triad.fire_mode_data.volley = {}
+				self.triad.fire_mode_data.volley.spread_mul = 1.25
+				self.triad.fire_mode_data.volley.damage_mul = 1
+				self.triad.fire_mode_data.volley.ammo_usage = 3
+				self.triad.fire_mode_data.volley.rays = 3
+				self.triad.fire_mode_data.volley.can_shoot_through_wall = true
+				self.triad.fire_mode_data.volley.can_shoot_through_shield = true
+				self.triad.fire_mode_data.volley.can_shoot_through_enemy = true
+				self.triad.fire_mode_data.volley.can_shoot_through_enemy_unlim = true
+				self.triad.fire_mode_data.volley.armor_piercing_chance = 1
+				self.triad.fire_mode_data.volley.muzzleflash = "effects/payday2/particles/weapons/50cal_auto_fps"
+				self.triad.fire_mode_data.volley.trail_effect = "effects/particles/weapons/sniper_trail_sc"
+				self.triad.fire_mode_data.toggable = {
+					"volley",
+					"auto"
+				}
+				self.triad.no_charge_anims = true
+				self.triad.kick = self.stat_info.kick_tables.moderate_kick
+				self.triad.kick_pattern = {
+					{0, self.stat_info.kick_tables.right_kick},
+					{2, self.stat_info.kick_tables.vertical_kick},
+					{4, self.stat_info.kick_tables.moderate_right_kick}
+				}
+				self.triad.supported = true
+				self.triad.ads_speed = 0.200
+				self.triad.weapon_hold = "model3"
+				self.triad.damage_falloff = {
+					start_dist = 1800,
+					end_dist = 4000,
+					min_mult = 0.3333
+				}
+				self.triad.stats = {
+					damage = 60,
+					spread = 72,
+					recoil = 43,
+					spread_moving = 5,
+					zoom = 1,
+					concealment = 23,
+					suppression = 8,
+					alert_size = 2,
+					extra_ammo = 101,
+					total_ammo_mod = 400,
+					value = 1,
+					reload = 20
+				}
+				self.triad.stats_modifiers = nil
+				self.triad.panic_suppression_chance = 0.05
+				self.triad.armor_piercing_chance = 0.5
+				self.triad.can_shoot_through_enemy = true
+				self.triad.can_shoot_through_enemy_unlim = true
+				self.triad.timers = deep_clone(self.chinchilla.timers)
+
+				self.x_triad.use_data.selection_index = 5
 			end
 
 			--Pawcio's GTAV Pack
@@ -22364,6 +22781,92 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 
 				self.fckmyfingers.use_data.selection_index = 5
 			end
+
+			if self.b42 then
+				self.b42.categories = {
+					"snp"
+				}
+				self.b42.recategorize = { "light_snp" }
+				self.b42.damage_type = "sniper"
+				self.b42.always_play_anims = true
+				self.b42.has_description = true
+				self.b42.desc_id = "bm_ap_weapon_sc_desc"
+				self.b42.upgrade_blocks = nil
+				self.b42.CLIP_AMMO_MAX = 10
+				self.b42.AMMO_MAX = 40
+				self.b42.tactical_reload = 1
+				self.b42.fire_mode_data.fire_rate = 1
+				self.b42.fire_rate_multiplier = 1.4
+				self.b42.kick = self.stat_info.kick_tables.vertical_kick
+				self.b42.muzzleflash = "effects/payday2/particles/weapons/awp_muzzle"
+				self.b42.supported = true
+				self.b42.ads_speed = 0.360
+				self.b42.damage_falloff = {
+					start_dist = 3800,
+					end_dist = 6800,
+					min_mult = 0.5
+				}
+				self.b42.stats = {
+					damage = 90,
+					spread = 89,
+					recoil = 46,
+					spread_moving = 8,
+					zoom = 1,
+					concealment = 24,
+					suppression = 6,
+					alert_size = 2,
+					extra_ammo = 101,
+					total_ammo_mod = 400,
+					value = 9,
+					reload = 20
+				}
+				self.b42.stats_modifiers = nil
+				self.b42.panic_suppression_chance = 0.05
+				self.b42.armor_piercing_chance = 1
+				self.b42.timers = deep_clone(self.model70.timers)
+			end
+
+			if self.axewscope then
+				self.axewscope.recategorize = {"light_pis"}
+				self.axewscope.has_description = false
+				self.axewscope.tactical_reload = 1
+				self.axewscope.fire_mode_data.fire_rate = 0.12
+				self.axewscope.single.fire_rate = 0.12
+				self.axewscope.CLIP_AMMO_MAX = 16
+				self.axewscope.AMMO_MAX = 75
+				self.axewscope.kick = self.stat_info.kick_tables.even_recoil
+				self.axewscope.kick_pattern = {
+					{0, self.stat_info.kick_tables.even_recoil},
+					{3, self.stat_info.kick_tables.left_kick},
+					{7, self.stat_info.kick_tables.moderate_kick}
+				}
+				self.axewscope.supported = true
+				self.axewscope.ads_speed = 0.180
+				self.axewscope.damage_falloff = {
+					start_dist = 1700,
+					end_dist = 4000,
+					min_mult = 0.25
+				}
+				self.axewscope.stats = {
+					damage = 24,
+					spread = 70,
+					recoil = 85,
+					spread_moving = 5,
+					zoom = 1,
+					concealment = 27,
+					suppression = 11,
+					alert_size = 2,
+					extra_ammo = 101,
+					total_ammo_mod = 400,
+					value = 1,
+					reload = 20
+				}
+				self.axewscope.stats_modifiers = nil
+				self.axewscope.panic_suppression_chance = 0.05
+				self.axewscope.reload_speed_multiplier = 1.1
+				self.axewscope.timers = deep_clone(self.p226.timers)
+			end
+
 
 		--[[     RJC9000'S MODS     ]]--
 
@@ -27989,7 +28492,181 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 				self.f500.timers.shotgun_reload_shell = 0.5666666666666667
 				self.f500.timers.shotgun_reload_exit_not_empty = 0.3
 				self.f500.timers.shotgun_reload_exit_empty = 0.7
-			end	
+			end
+
+			if self.toz194 then
+				self.toz194.recategorize = { "heavy_shot" }
+				self.toz194.damage_type = "shotgun_heavy"
+				self.toz194.damage_type_single_ray = "sniper"
+				self.toz194.tactical_reload = 1
+				self.toz194.fire_mode_data.fire_rate = 0.5
+				self.toz194.fire_rate_multiplier = 0.9
+				self.toz194.CLIP_AMMO_MAX = 7
+				self.toz194.AMMO_MAX = 40
+				self.toz194.supported = true
+				self.toz194.ads_speed = 0.280
+				self.toz194.damage_falloff = {
+					start_dist = 800,
+					end_dist = 2500,
+					min_mult = 0.1333
+				}
+				self.toz194.stats = {
+					damage = 180,
+					spread = 56,
+					recoil = 43,
+					spread_moving = 6,
+					zoom = 1,
+					concealment = 27,
+					suppression = 7,
+					alert_size = 2,
+					extra_ammo = 101,
+					total_ammo_mod = 400,
+					value = 1,
+					reload = 20
+				}
+				self.toz194.kick = self.stat_info.kick_tables.moderate_kick
+				self.toz194.muzzleflash = "effects/payday2/particles/weapons/big_51b_auto_fps" --"effects/particles/shotgun/shotgun_gen"
+				self.toz194.panic_suppression_chance = 0.05
+				self.toz194.stats_modifiers = nil
+				self.toz194.rays = 8
+				self.toz194.timers.shotgun_reload_enter = 0.3
+				self.toz194.timers.shotgun_reload_first_shell_offset = 0.33
+				self.toz194.timers.shotgun_reload_shell = 0.5666666666666667
+				self.toz194.timers.shotgun_reload_exit_not_empty = 0.3
+				self.toz194.timers.shotgun_reload_exit_empty = 0.7
+			end
+
+			if self.welrod then
+				self.welrod.recategorize = {"light_pis"}
+				self.welrod.damage_type = "pistol"
+				self.welrod.has_description = false
+				self.welrod.lock_slide = true
+				self.welrod.fire_mode_data.fire_rate = 0.6
+				self.welrod.tactical_reload = 1
+				self.welrod.CLIP_AMMO_MAX = 8
+				self.welrod.AMMO_MAX = 40
+				self.welrod.kick = self.stat_info.kick_tables.even_recoil
+				self.welrod.kick_pattern = {
+					{0, self.stat_info.kick_tables.moderate_kick},
+					{5, self.stat_info.kick_tables.right_kick},
+					{9, self.stat_info.kick_tables.right_recoil},
+					{14, self.stat_info.kick_tables.right_kick},
+					{22, self.stat_info.kick_tables.even_recoil}
+				}
+				self.welrod.supported = true
+				self.welrod.ads_speed = 0.200
+				self.welrod.damage_falloff = {
+					start_dist = 2000,
+					end_dist = 5000,
+					min_mult = 0.5
+				}
+				self.welrod.stats = {
+					damage = 24,
+					spread = 74,
+					recoil = 69,
+					spread_moving = 9,
+					zoom = 1,
+					concealment = 30,
+					suppression = 20,
+					alert_size = 1,
+					extra_ammo = 101,
+					total_ammo_mod = 400,
+					value = 1,
+					reload = 20
+				}
+				self.welrod.stats_modifiers = nil
+				self.welrod.panic_suppression_chance = 0.05
+				self.welrod.hs_mult = 2.5
+				self.welrod.timers = deep_clone(self.ppk.timers)
+			end
+
+			if self.spectre_m4 then
+				self.spectre_m4.categories = { "smg" }
+				self.spectre_m4.recategorize = { "light_smg" }
+				self.spectre_m4.damage_type = "machine_gun"
+				self.spectre_m4.fire_mode_data.fire_rate = 0.07058823529411764705882352941176
+				self.spectre_m4.CAN_TOGGLE_FIREMODE = true
+				self.spectre_m4.tactical_reload = 1
+				self.spectre_m4.CLIP_AMMO_MAX = 40
+				self.spectre_m4.AMMO_MAX = 90
+				self.spectre_m4.kick = self.stat_info.kick_tables.moderate_left_kick
+				self.spectre_m4.kick_pattern = {
+					{0, self.stat_info.kick_tables.left_kick},
+					{4, self.stat_info.kick_tables.left_recoil},
+					{7, self.stat_info.kick_tables.right_recoil},
+					{13, self.stat_info.kick_tables.moderate_right_kick},
+					{18, self.stat_info.kick_tables.moderate_kick},
+					{20, self.stat_info.kick_tables.moderate_left_kick}
+				}
+				self.spectre_m4.supported = true
+				self.spectre_m4.ads_speed = 0.200
+				self.spectre_m4.damage_falloff = {
+					start_dist = 1300,
+					end_dist = 2700,
+					min_mult = 0.25
+				}
+				self.spectre_m4.stats = {
+					damage = 20,
+					spread = 58,
+					recoil = 81,
+					spread_moving = 6,
+					zoom = 1,
+					concealment = 27,
+					suppression = 9,
+					alert_size = 2,
+					extra_ammo = 101,
+					total_ammo_mod = 400,
+					value = 9,
+					reload = 20
+				}
+				self.spectre_m4.stats_modifiers = nil
+				self.spectre_m4.panic_suppression_chance = 0.05
+				self.spectre_m4.timers = deep_clone(self.tec9.timers)
+
+				self.x_spectre_m4.recategorize = { "light_smg" }
+				self.x_spectre_m4.damage_type = "machine_gun"
+				self.x_spectre_m4.CLIP_AMMO_MAX = 80
+				self.x_spectre_m4.tactical_reload = 2
+				self.x_spectre_m4.AMMO_MAX = 180
+				self.x_spectre_m4.fire_mode_data.fire_rate = 0.07058823529411764705882352941176
+				self.x_spectre_m4.single.fire_rate = 0.07058823529411764705882352941176
+				self.x_spectre_m4.kick = self.stat_info.kick_tables.moderate_left_kick
+				self.x_spectre_m4.kick_pattern = {
+					{0, self.stat_info.kick_tables.left_kick},
+					{4, self.stat_info.kick_tables.left_recoil},
+					{7, self.stat_info.kick_tables.right_recoil},
+					{13, self.stat_info.kick_tables.moderate_right_kick},
+					{18, self.stat_info.kick_tables.moderate_kick},
+					{20, self.stat_info.kick_tables.moderate_left_kick}
+				}
+				self.x_spectre_m4.supported = true
+				self.x_spectre_m4.ads_speed = 0.200
+				self.x_spectre_m4.damage_falloff = {
+					start_dist = 1300,
+					end_dist = 2700,
+					min_mult = 0.25
+				}
+				self.x_spectre_m4.stats = {
+					damage = 20,
+					spread = 48,
+					recoil = 71,
+					spread_moving = 6,
+					zoom = 1,
+					concealment = 27,
+					suppression = 9,
+					alert_size = 2,
+					extra_ammo = 101,
+					total_ammo_mod = 400,
+					value = 9,
+					reload = 20
+				}
+				self.x_spectre_m4.stats_modifiers = nil
+				self.x_spectre_m4.panic_suppression_chance = 0.05
+				self.x_spectre_m4.reload_speed_multiplier = 0.75
+				self.x_spectre_m4.animations.weapon_hold = "x_akmsu"
+				self.x_spectre_m4.animations.reload_name_id = "x_akmsu"
+				self.x_spectre_m4.timers = deep_clone(self.x_scorpion.timers)
+			end
 
 			if self.nothing then --Silent Enforcer's No Wep
 				self.nothing.recategorize = { "wpn_special" }
@@ -29004,6 +29681,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 			}
 			self.pb.supported = true
 			self.pb.ads_speed = 0.120
+			self.pb.armor_piercing_chance = 0
 			self.pb.damage_falloff = {
 				start_dist = 800,
 				end_dist = 2000,
@@ -29208,6 +29886,194 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 			
 			self.enfield_no4i.use_data.selection_index = 5
 		end
+
+		if self.mp443 then
+			self.mp443.recategorize = { "light_pis" }
+			self.mp443.damage_type = "light_pistol"
+			self.mp443.fire_mode_data.fire_rate =  0.0882352
+			self.mp443.AMMO_MAX = 75
+			self.mp443.CLIP_AMMO_MAX = 18
+			self.mp443.has_description = false
+			self.mp443.tactical_reload = 1
+			self.mp443.lock_slide = true
+			self.mp443.kick = self.stat_info.kick_tables.even_recoil
+			self.mp443.kick_pattern = {
+				{0, self.stat_info.kick_tables.moderate_kick},
+				{3, self.stat_info.kick_tables.right_kick},
+				{8, self.stat_info.kick_tables.moderate_left_kick},
+				{14, self.stat_info.kick_tables.even_recoil}
+			}
+			self.mp443.supported = true
+			self.mp443.ads_speed = 0.140
+			self.mp443.damage_falloff = {
+				start_dist = 1700,
+				end_dist = 3500,
+				min_mult = 0.25
+			}
+			self.mp443.stats = {
+				damage = 24,
+				spread = 62,
+				recoil = 85,
+				spread_moving = 9,
+				zoom = 1,
+				concealment = 29,
+				suppression = 12,
+				alert_size = 2,
+				extra_ammo = 101,
+				total_ammo_mod = 400,
+				value = 1,
+				reload = 20
+			}
+			self.mp443.stats_modifiers = nil
+			self.mp443.panic_suppression_chance = 0.05
+			self.mp443.reload_speed_multiplier = 1.1
+			self.mp443.timers = deep_clone(self.lemming.timers)
+		end
+
+		if self.af2011 then
+			self.af2011.recategorize = { "heavy_pis" }
+			self.af2011.damage_type = "heavy_pistol"
+			self.af2011.fire_mode_data.fire_rate =  0.2
+			self.af2011.has_description = false
+			self.af2011.desc_id = "bm_af2011_sc_desc"
+			self.af2011.AMMO_MAX = 40
+			self.af2011.CLIP_AMMO_MAX = 16
+			self.af2011.has_description = false
+			self.af2011.tactical_reload = 2
+			self.af2011.CAN_TOGGLE_FIREMODE = false
+			self.af2011.rays = 1
+			self.af2011.BURST_FIRE = {
+				count = 2,
+				delay = 0.2,
+				rof_mult = 20,
+				lock = true,
+				recoil_mult = 0,
+				last_recoil_mult = 2,
+				burst_default = true
+			}
+			self.af2011.lock_slide = true
+			self.af2011.kick = self.stat_info.kick_tables.even_recoil
+			self.af2011.kick_pattern = {
+				{0, self.stat_info.kick_tables.moderate_kick},
+				{3, self.stat_info.kick_tables.right_kick},
+				{8, self.stat_info.kick_tables.moderate_left_kick},
+				{14, self.stat_info.kick_tables.even_recoil}
+			}
+			self.af2011.supported = true
+			self.af2011.ads_speed = 0.200
+			self.af2011.damage_falloff = {
+				start_dist = 1100,
+				end_dist = 2800,
+				min_mult = 0.2
+			}
+			self.af2011.stats = {
+				damage = 45,
+				spread = 60,
+				recoil = 77,
+				spread_moving = 9,
+				zoom = 1,
+				concealment = 26,
+				suppression = 12,
+				alert_size = 2,
+				extra_ammo = 101,
+				total_ammo_mod = 400,
+				value = 1,
+				reload = 20
+			}
+			self.af2011.stats_modifiers = nil
+			self.af2011.panic_suppression_chance = 0.05
+			self.af2011.reload_speed_multiplier = 0.9
+			self.af2011.timers = deep_clone(self.b92fs.timers)
+
+			self.x_af2011.use_data.selection_index = 5
+		end
+
+		if self.cz75b then
+			self.cz75b.recategorize = {"light_pis"}
+			self.cz75b.has_description = false
+			self.cz75b.tactical_reload = 1
+			self.cz75b.fire_mode_data.fire_rate = 0.08571428571
+			self.cz75b.single.fire_rate = 0.08571428571
+			self.cz75b.CLIP_AMMO_MAX = 16
+			self.cz75b.AMMO_MAX = 75
+			self.cz75b.kick = self.stat_info.kick_tables.even_recoil
+			self.cz75b.kick_pattern = {
+				{0, self.stat_info.kick_tables.even_recoil},
+				{3, self.stat_info.kick_tables.left_kick},
+				{7, self.stat_info.kick_tables.moderate_kick}
+			}
+			self.cz75b.supported = true
+			self.cz75b.ads_speed = 0.140
+			self.cz75b.damage_falloff = {
+				start_dist = 1500,
+				end_dist = 3600,
+				min_mult = 0.25
+			}
+			self.cz75b.stats = {
+				damage = 24,
+				spread = 63,
+				recoil = 81,
+				spread_moving = 5,
+				zoom = 1,
+				concealment = 31,
+				suppression = 11,
+				alert_size = 2,
+				extra_ammo = 101,
+				total_ammo_mod = 400,
+				value = 1,
+				reload = 20
+			}
+			self.cz75b.stats_modifiers = nil
+			self.cz75b.panic_suppression_chance = 0.05
+			self.cz75b.reload_speed_multiplier = 0.95
+			self.cz75b.timers = deep_clone(self.p226.timers)
+
+				self.x_cz75b.recategorize = { "light_pis" }
+				self.x_cz75b.damage_type = "light_pistol"
+				self.x_cz75b.fire_mode_data.fire_rate =  0.08571428571
+				self.x_cz75b.BURST_FIRE = {
+					count = 2,
+					delay = 0.15,
+					rof_mult = 4,
+					recoil_mult = 0.25,
+					last_recoil_mult = 1.05,
+				}
+				self.x_cz75b.AMMO_MAX = 150
+				self.x_cz75b.CLIP_AMMO_MAX = 32
+				self.x_cz75b.tactical_reload = 2
+				self.x_cz75b.lock_slide = true
+				self.x_cz75b.kick = self.stat_info.kick_tables.even_recoil
+				self.x_cz75b.kick_pattern = {
+					{0, self.stat_info.kick_tables.even_recoil},
+					{3, self.stat_info.kick_tables.left_kick},
+					{7, self.stat_info.kick_tables.moderate_kick}
+				}
+				self.x_cz75b.supported = true
+				self.x_cz75b.ads_speed = 0.140
+				self.x_cz75b.damage_falloff = {
+					start_dist = 1500,
+					end_dist = 3600,
+					min_mult = 0.25
+				}
+				self.x_cz75b.stats = {
+					damage = 24,
+					spread = 53,
+					recoil = 71,
+					spread_moving = 5,
+					zoom = 1,
+					concealment = 31,
+					suppression = 11,
+					alert_size = 2,
+					extra_ammo = 101,
+					total_ammo_mod = 400,
+					value = 1,
+					reload = 20
+				}
+				self.x_cz75b.stats_modifiers = nil
+				self.x_cz75b.panic_suppression_chance = 0.05
+				self.x_cz75b.timers = deep_clone(self.x_b92fs.timers)
+		end	
+
 
 		if self.abzats then
 			self.abzats.recategorize = { "break_shot" }


### PR DESCRIPTION
- New weapons : 
Pistols : AF2011, CZ 75 b (& akimbo), CZ 75 Czechmate, GTA5 AP Pistol, MP-443 Grach, The Triad, Welrod.
SMGs : Spectre M4 (& akimbo).
Shotguns : Chiappa Triple Threat, TOZ-194, Winchester M1912.
ARs : ACR (without M203), AK-12 (2014), Valmet Rk.62.
Snipers : FN FNAR, Mk.12 SPR, Steyr Elite
- Tweaked the Platypus 70's reload timers.
- Changed the Lost Gadgets and Stealth Flashlights to use proper descriptions instead of the generic ones.
- Added missing ammo types (mostly Tombstone Buckshot) to shotguns that didn't have them available.
- Added support for the rest of the TingleDingle's attachments.
- Many other minor fixes.
- Removed a bunch of whitespaces. Gotta save those few bytes of storage space.