### PR TITLE
Whitespace cleanup + some more weapons

### DIFF
--- a/lua/sc/loc/loc.lua
+++ b/lua/sc/loc/loc.lua
@@ -2673,7 +2673,7 @@ Hooks:Add("LocalizationManagerPostInit", "SC_Localization_Weapons_Eng", function
 					["bm_af2011_sc_desc"] = "Handgun made to celebrate a hundred years of an all-time classic. Now featuring #{risk}#double the barrels##!",
 					["bm_wp_upg_af2011_a_uno_desc"] = "Internal modification that makes the barrels fire separately rather than simultaneously.",
 					--Triad
-					["bm_triad_sc_desc"] = "#{skill_color}#Deals 50% of its damage through body armor and can pierce multiple enemies.##\n\nAlt-fire fires #{skill_color}#3## rounds with enough force to #{skill_color}#pierce body armor, shields and thin walls##.",
+					["bm_triad_sc_desc"] = "#{skill_color}#Can pierce body armor, multiple enemies, shields within max damage range and thin walls.##\n\nAlt-fire fires #{skill_color}#all 3 barrels at once## at the cost of #{important_1}#more recoil and spread.##",
 
 			--[[ SMGs ]]
 				--Kobus 90
@@ -3091,7 +3091,7 @@ Hooks:Add("LocalizationManagerPostInit", "SC_Localization_Weapons_Eng", function
 				["bm_ray_sc_desc"] = "Become the \"#{risk}#Grim Reaper##\" with this 4-shot #{heat_warm_color}#incendiary## rocket launcher.\n\nRockets leave behind a #{heat_warm_color}#pool of fire## and explosive damage dealt by this weapon #{skill_color}#instantly destroys turrets## and deals an extra #{skill_color}#500%## damage against non-titan Bulldozers.",
 				-- Toy weapons
 				["bm_w_toym16_sc_desc"] = "\"No full-auto in buildings.\"",
-				["bm_w_toy1911_sc_desc"] = "Airsoft pistol modified with a turbo electric motor, allowing you to #{skill_color}#switch to fully automatic fire##.\nRemember, no full-auto in buildings.",
+				["bm_w_toy1911_sc_desc"] = "\"No full-auto in buildings.\"",
 
 	})
 

--- a/lua/sc/tweak_data/weaponfactorytweakdata.lua
+++ b/lua/sc/tweak_data/weaponfactorytweakdata.lua
@@ -269,7 +269,7 @@ local stocks = {
 				recoil = 0,
 				concealment = -2,
 				ads_speed_mult = 1.05
-			},	
+			},
 		--Folder > Heavy Adjustable Stock --Con ++Stab
 			folder_to_hvy_rec2_stats = {
 				value = 5,
@@ -277,7 +277,7 @@ local stocks = {
 				recoil = 4,
 				concealment = -2,
 				ads_speed_mult = 1.05
-			},	
+			},
 		--Folder > Adjustable Stock -Con -Stab ++Acc
 			folder_to_adj_acc2_stats = {
 				value = 4,
@@ -285,7 +285,7 @@ local stocks = {
 				recoil = -2,
 				concealment = -1,
 				ads_speed_mult = 1.025
-			},	
+			},
 		--Folder > Adjustable Stock -Con +Acc
 			folder_to_adj_acc1_stats = {
 				value = 4,
@@ -338,7 +338,7 @@ local stocks = {
 				concealment = 4,
 				ads_speed_mult = 0.9
 			},
-	
+
 	--DEFAULT ADJUSTABLE STOCK (DEFAULT M4)
 		--Adjustable > Thumbhole ---Con ++Stab +Acc
 			adj_to_thumb_stats = {
@@ -702,7 +702,7 @@ local muzzle_device = {
 			value = 1,
 		},
 
-	-- +Con -Acc/Range 
+	-- +Con -Acc/Range
 		muzz_con_a = {
 			value = 3,
 			spread = -1,
@@ -720,7 +720,7 @@ local muzzle_device = {
 			falloff_start_mult = 0.9,
 			falloff_end_mult = 0.9
 		},
-	-- +Con -Stab 
+	-- +Con -Stab
 		muzz_con_r = {
 			value = 3,
 			recoil = -2,
@@ -739,7 +739,7 @@ local muzzle_device = {
 		},
 
 
-	-- +Stab -Acc/Range 
+	-- +Stab -Acc/Range
 		muzz_rec_a = {
 			value = 3,
 			spread = -1,
@@ -776,7 +776,7 @@ local muzzle_device = {
 			falloff_start_mult = 0.85,
 			falloff_end_mult = 0.85
 		},
-	-- +Stab -Con 
+	-- +Stab -Con
 		muzz_rec_c = {
 			value = 2,
 			recoil = 2,
@@ -789,7 +789,7 @@ local muzzle_device = {
 			recoil = 4,
 			concealment = -2
 		},
-	-- ++Stab --Con 
+	-- ++Stab --Con
 		muzz_rec2_c = {
 			value = 5,
 			recoil = 4,
@@ -856,7 +856,7 @@ local muzzle_device = {
 			falloff_end_mult = 1.2
 		},
 
-	-- +Acc/Range -Con 
+	-- +Acc/Range -Con
 		muzz_acc_c = {
 			value = 2,
 			spread = 1,
@@ -873,7 +873,7 @@ local muzzle_device = {
 			falloff_start_mult = 1.1,
 			falloff_end_mult = 1.1
 		},
-	-- ++Acc/Range --Con 
+	-- ++Acc/Range --Con
 		muzz_acc2_c = {
 			value = 5,
 			spread = 2,
@@ -891,7 +891,7 @@ local muzzle_device = {
 			falloff_end_mult = 1.15
 		},
 
-	-- +Stab +Acc/Range --Con 
+	-- +Stab +Acc/Range --Con
 		muzz_dual_c = {
 			value = 5,
 			spread = 1,
@@ -912,7 +912,7 @@ local muzzle_device = {
 			falloff_end_mult = 1.1,
 			ads_speed_mult = 1.05
 		},
-	-- ++Stab ++Acc/Range ----Con 
+	-- ++Stab ++Acc/Range ----Con
 		muzz_dual2_c = {
 			value = 7,
 			spread = 2,
@@ -1062,11 +1062,11 @@ local grips = {
 					falloff_start_mult = 1,
 					falloff_end_mult = 1.1,
 					damage_min_mult = 6.66667,
-					armor_piercing_add = 1,		
+					armor_piercing_add = 1,
 					rays = 12
 					--[[
 					bullet_class = "BleedBulletBase",
-					dot_data = { 
+					dot_data = {
 						type = "bleed",
 						custom_data = {
 							dot_damage = 0.6,
@@ -1077,7 +1077,7 @@ local grips = {
 					--]]
 				}
 			},
-		
+
 			a_piercing_semi_override = {
 				desc_id = "bm_wp_upg_a_piercing_semi_desc_per_pellet",
 				stats = {
@@ -1102,7 +1102,7 @@ local grips = {
 					rays = 12
 					--[[
 					bullet_class = "BleedBulletBase",
-					dot_data = { 
+					dot_data = {
 						type = "bleed",
 						custom_data = {
 							dot_damage = 0.75,
@@ -1113,7 +1113,7 @@ local grips = {
 					--]]
 				}
 			},
-		
+
 			a_piercing_pump_override = {
 				desc_id = "bm_wp_upg_a_piercing_pump_desc_per_pellet",
 				stats = {
@@ -1138,7 +1138,7 @@ local grips = {
 					rays = 12,
 					--[[
 					bullet_class = "BleedBulletBase",
-					dot_data = { 
+					dot_data = {
 						type = "bleed",
 						custom_data = {
 							dot_damage = 1.125,
@@ -1149,7 +1149,7 @@ local grips = {
 					--]]
 				}
 			},
-	
+
 			a_piercing_heavy_override = {
 				desc_id = "bm_wp_upg_a_piercing_heavy_desc_per_pellet",
 				stats = {
@@ -1171,10 +1171,10 @@ local grips = {
 					falloff_end_mult = 1.1,
 					damage_min_mult = 5,
 					armor_piercing_add = 1,
-					rays = 12,		
+					rays = 12,
 					--[[
 					bullet_class = "BleedBulletBase",
-					dot_data = { 
+					dot_data = {
 						type = "bleed",
 						custom_data = {
 							dot_damage = 1.5,
@@ -1185,7 +1185,7 @@ local grips = {
 					--]]
 				}
 			},
-		
+
 		--Poison
 			a_rip_auto_override = {
 				desc_id = "bm_wp_upg_a_rip_auto_desc_sc",
@@ -1202,7 +1202,7 @@ local grips = {
 					dot_data_name = "ammo_rip_auto"
 				}
 			},
-		
+
 			a_rip_semi_override = {
 				desc_id = "bm_wp_upg_a_rip_semi_desc_sc",
 				stats = {
@@ -1218,7 +1218,7 @@ local grips = {
 					dot_data_name = "ammo_rip"
 				}
 			},
-	
+
 			a_rip_pump_override = {
 				desc_id = "bm_wp_upg_a_rip_pump_desc_sc",
 				stats = {
@@ -1234,7 +1234,7 @@ local grips = {
 					dot_data_name = "ammo_rip_pump"
 				}
 			},
-	
+
 			a_rip_heavy_override = {
 				stats = {
 					value = 9,
@@ -1249,7 +1249,7 @@ local grips = {
 					dot_data_name = "ammo_rip_heavy"
 				}
 			},
-	
+
 		--Dragon's Breath
 			a_dragons_breath_auto_override = {
 				desc_id = "bm_wp_upg_a_dragons_breath_auto_desc_sc",
@@ -1267,7 +1267,7 @@ local grips = {
 					damage_min_mult = 0.2,
 					ignore_statistic = true,
 					bullet_class = "FlameBulletBase",
-					armor_piercing_add = 0.01,								
+					armor_piercing_add = 0.01,
 					can_shoot_through_shield = false,
 					rays = 16,
 					trail_effect = "",
@@ -1275,7 +1275,7 @@ local grips = {
 					dot_data_name = "ammo_dragons_breath_auto"
 				}
 			},
-	
+
 			a_dragons_breath_semi_override = {
 				desc_id = "bm_wp_upg_a_dragons_breath_semi_desc_sc",
 				stats = {
@@ -1292,7 +1292,7 @@ local grips = {
 					damage_min_mult = 0.2,
 					ignore_statistic = true,
 					bullet_class = "FlameBulletBase",
-					armor_piercing_add = 0.01,								
+					armor_piercing_add = 0.01,
 					can_shoot_through_shield = false,
 					rays = 16,
 					trail_effect = "",
@@ -1300,7 +1300,7 @@ local grips = {
 					dot_data_name = "ammo_dragons_breath"
 				}
 			},
-	
+
 			a_dragons_breath_revo_override = {
 				desc_id = "bm_wp_upg_a_dragons_breath_semi_desc_sc",
 				stats = {
@@ -1315,7 +1315,7 @@ local grips = {
 					damage_min_mult = 0.2,
 					ignore_statistic = true,
 					bullet_class = "FlameBulletBase",
-					armor_piercing_add = 0.01,								
+					armor_piercing_add = 0.01,
 					can_shoot_through_shield = false,
 					rays = 16,
 					trail_effect = "",
@@ -1323,7 +1323,7 @@ local grips = {
 					dot_data_name = "ammo_dragons_breath"
 				}
 			},
-	
+
 			a_dragons_breath_pump_override = {
 				desc_id = "bm_wp_upg_a_dragons_breath_pump_desc_sc",
 				supported = true,
@@ -1340,7 +1340,7 @@ local grips = {
 					damage_min_mult = 0.2,
 					ignore_statistic = true,
 					bullet_class = "FlameBulletBase",
-					armor_piercing_add = 0.01,							
+					armor_piercing_add = 0.01,
 					can_shoot_through_shield = false,
 					rays = 16,
 					trail_effect = "",
@@ -1348,7 +1348,7 @@ local grips = {
 					dot_data_name = "ammo_dragons_breath_pump"
 				}
 			},
-	
+
 			a_dragons_breath_heavy_override = {
 				stats = {
 					value = 9,
@@ -1362,7 +1362,7 @@ local grips = {
 					damage_min_mult = 0.2,
 					ignore_statistic = true,
 					bullet_class = "FlameBulletBase",
-					armor_piercing_add = 0.01,				
+					armor_piercing_add = 0.01,
 					can_shoot_through_shield = false,
 					rays = 16,
 					trail_effect = "",
@@ -1370,7 +1370,7 @@ local grips = {
 					dot_data_name = "ammo_dragons_breath_heavy"
 				}
 			},
-	
+
 		--000 Buck
 			a_custom_auto_override = {
 				supported = true,
@@ -1390,7 +1390,7 @@ local grips = {
 					rays = 6
 				}
 			},
-	
+
 			a_custom_semi_override = {
 				supported = true,
 				stats = {
@@ -1409,7 +1409,7 @@ local grips = {
 					rays = 6
 				}
 			},
-	
+
 			a_custom_pump_override = {
 				supported = true,
 				stats = {
@@ -1426,9 +1426,9 @@ local grips = {
 					ammo_pickup_max_mul = 0.75,
 					ammo_pickup_min_mul = 0.75,
 					rays = 6
-				}	
+				}
 			},
-	
+
 			a_custom_heavy_override = {
 				stats = {
 					value = 9,
@@ -1444,9 +1444,9 @@ local grips = {
 					ammo_pickup_max_mul = 0.75,
 					ammo_pickup_min_mul = 0.75,
 					rays = 6
-				}	
+				}
 			},
-	
+
 		--Slugs
 			a_slug_auto_override = {
 				name_id = "bm_wp_upg_a_slug",
@@ -1459,12 +1459,12 @@ local grips = {
 					damage = 0,
 					recoil = -20,
 					spread = 5,
-					spread_multi = {1, 1},	
+					spread_multi = {1, 1},
 					suppression = -1,
 					moving_spread = 0
 				},
 				custom_stats = {
-					muzzleflash = "effects/payday2/particles/weapons/762_auto_fps",														
+					muzzleflash = "effects/payday2/particles/weapons/762_auto_fps",
 					rays = 1,
 					hip_mult = 2,
 					armor_piercing_add = 0.75,
@@ -1478,7 +1478,7 @@ local grips = {
 					ads_speed_mult = 1.025
 				}
 			},
-	
+
 			a_slug_semi_override = {
 				name_id = "bm_wp_upg_a_slug",
 				desc_id = "bm_wp_upg_a_slug_spam_desc",
@@ -1489,13 +1489,13 @@ local grips = {
 					total_ammo_mod = -165,
 					damage = 0,
 					spread = 5,
-					spread_multi = {1, 1},	
+					spread_multi = {1, 1},
 					recoil = -20,
 					moving_spread = 0,
 					suppression = -1
 				},
 				custom_stats = {
-					muzzleflash = "effects/payday2/particles/weapons/762_auto_fps",													
+					muzzleflash = "effects/payday2/particles/weapons/762_auto_fps",
 					rays = 1,
 					hip_mult = 2,
 					armor_piercing_add = 0.75,
@@ -1509,7 +1509,7 @@ local grips = {
 					ads_speed_mult = 1.025
 				}
 			},
-		
+
 			a_slug_pump_override = {
 				supported = true,
 				name_id = "bm_wp_upg_a_slug",
@@ -1521,12 +1521,12 @@ local grips = {
 					damage = 0,
 					recoil = -20,
 					spread = 5,
-					spread_multi = {1, 1},	
+					spread_multi = {1, 1},
 					moving_spread = 0,
 					suppression = -1
 				},
-				custom_stats = {				
-					muzzleflash = "effects/payday2/particles/weapons/762_auto_fps",										
+				custom_stats = {
+					muzzleflash = "effects/payday2/particles/weapons/762_auto_fps",
 					rays = 1,
 					hip_mult = 2,
 					armor_piercing_add = 1,
@@ -1543,21 +1543,21 @@ local grips = {
 					ads_speed_mult = 1.025
 				}
 			},
-	
+
 			a_slug_heavy_override = {
 				stats = {
 					value = 10,
 					concealment = -1,
 					total_ammo_mod = -165,
-					damage = 0,	
+					damage = 0,
 					recoil = -20,
 					spread = 5,
-					spread_multi = {1, 1},	
+					spread_multi = {1, 1},
 					suppression = -1,
 					moving_spread = 0
 				},
 				custom_stats = {
-					muzzleflash = "effects/payday2/particles/weapons/762_auto_fps",												
+					muzzleflash = "effects/payday2/particles/weapons/762_auto_fps",
 					rays = 1,
 					hip_mult = 2,
 					armor_piercing_add = 1,
@@ -1575,7 +1575,7 @@ local grips = {
 					ads_speed_mult = 1.025
 				}
 			},
-	
+
 		--FRAG-12
 			a_explosive_auto_override = {
 				supported = true,
@@ -1597,7 +1597,7 @@ local grips = {
 					bullet_class = "InstantExplosiveBulletBase"
 				}
 			},
-	
+
 			a_explosive_semi_override = {
 				supported = true,
 				stats = {
@@ -1618,7 +1618,7 @@ local grips = {
 					bullet_class = "InstantExplosiveBulletBase"
 				}
 			},
-	
+
 			a_explosive_pump_override = {
 				desc_id = "bm_wp_upg_a_explosive_desc_sc",
 				supported = true,
@@ -1641,7 +1641,7 @@ local grips = {
 					bullet_class = "InstantExplosiveBulletBase"
 				}
 			},
-	
+
 			a_explosive_heavy_override = {
 				stats = {
 					value = 10,
@@ -1659,7 +1659,7 @@ local grips = {
 					ammo_pickup_min_mul = 0.55,
 					ignore_statistic = true,
 					rays = 1,
-					block_b_storm = true,	
+					block_b_storm = true,
 					bullet_class = "InstantExplosiveBulletBase"
 				}
 			}
@@ -1676,7 +1676,7 @@ end)
 
 --Sorted by "Primary Skill Use > Sub-category > Primary/Secondary"
 --Akimbo weapons are sorted under their single-wielded secondary counterpart
-	
+
 --[[     PISTOLS     ]]--
 
 	--[[     LIGHT PISTOLS     ]]
@@ -1707,7 +1707,7 @@ end)
 						concealment = -1,
 						spread = 1
 					}
-					
+
 					--Bounce Slate RX Stock
 					self.parts.wpn_fps_smg_fmg9_stock_padded.pcs = {
 						10,
@@ -1720,8 +1720,8 @@ end)
 						value = 2,
 						concealment = -1,
 						recoil = 2
-					}	
-					
+					}
+
 					--Celerity X9 Mag
 					self.parts.wpn_fps_smg_fmg9_m_speed.pcs = {
 						10,
@@ -1736,7 +1736,7 @@ end)
 						concealment = -1,
 						reload = 3
 					}
-					
+
 					self.parts.wpn_fps_smg_fmg9_conversion_sound_switch = {
 						a_obj = "a_body",
 						type = "ammo",
@@ -1785,15 +1785,15 @@ end)
 						spread = 2,
 						recoil = 2,
 						concealment = -3
-					}	
+					}
 					self.parts.wpn_fps_smg_fmg9_conversion.custom_stats = {
 						muzzleflash = "effects/payday2/particles/weapons/9mm_auto_silence_fps",
 						falloff_start_mult = 1.15,
 						falloff_end_mult = 1.15,
 						ads_speed_mult = 1.05
-					}	
+					}
 					self.parts.wpn_fps_smg_fmg9_conversion.perks = nil
-					self.parts.wpn_fps_smg_fmg9_conversion.override = {	
+					self.parts.wpn_fps_smg_fmg9_conversion.override = {
 						--Hiding Barrel Extensions
 						--MOVED
 						--Body Replacements
@@ -1804,14 +1804,14 @@ end)
 						wpn_fps_smg_fmg9_dh = {
 							third_unit = "units/pd2_dlc_lawp/weapons/wpn_fps_smg_fmg9_pts/wpn_third_smg_fmg9_dh",
 							unit = "units/pd2_dlc_lawp/weapons/wpn_fps_smg_fmg9_pts/wpn_fps_smg_fmg9_dh_conversion"
-						}		
+						}
 					}
 
-					
+
 					--Medved R4 Suppressor, re-enabled :^)
 					self.parts.wpn_fps_upg_ns_pis_putnik.desc_id = "bm_sc_blank"
 					self.parts.wpn_fps_upg_ns_pis_putnik.pcs = {
-						10,	
+						10,
 						20,
 						30,
 						40
@@ -1824,10 +1824,10 @@ end)
 					}
 					self.parts.wpn_fps_upg_ns_pis_putnik.stats = deep_clone(muzzle_device.supp_rec2_a)
 					self.parts.wpn_fps_upg_ns_pis_putnik.custom_stats = deep_clone(muzzle_device.supp_rec2_a)
-						
+
 					--Medved R4 Laser Sight
 					self.parts.wpn_fps_upg_fl_pis_perst.pcs = {
-						10,	
+						10,
 						20,
 						30,
 						40
@@ -1854,7 +1854,7 @@ end)
 						"wpn_fps_upg_o_rmr",
 						"wpn_fps_upg_o_rms",
 						"wpn_fps_upg_o_rikt"
-					}	
+					}
 					self.parts.wpn_fps_pis_beer_b_robo.custom_stats = {
 						falloff_start_mult = 1.25,
 						falloff_end_mult = 1.25,
@@ -1866,7 +1866,7 @@ end)
 						value = 6,
 						concealment = -5
 					}
-					
+
 					--Weller Grip
 					self.parts.wpn_fps_pis_beer_g_robo.pcs = {
 						10,
@@ -1877,7 +1877,7 @@ end)
 					self.parts.wpn_fps_pis_beer_g_robo.supported = true
 					self.parts.wpn_fps_pis_beer_g_robo.stats = deep_clone(grips.quickdraw_1)
 					self.parts.wpn_fps_pis_beer_g_robo.custom_stats = deep_clone(grips.quickdraw_1)
-					
+
 					--Cartel Grip
 					self.parts.wpn_fps_pis_beer_g_lux.pcs = {
 						10,
@@ -1887,7 +1887,7 @@ end)
 					}
 					self.parts.wpn_fps_pis_beer_g_lux.supported = true
 					self.parts.wpn_fps_pis_beer_g_lux.stats = deep_clone(grips.recoil_2)
-					
+
 					--Extended Magazine
 					self.parts.wpn_fps_pis_beer_m_extended.pcs = {
 						10,
@@ -1905,7 +1905,7 @@ end)
 						reload = -3,
 						concealment = -1
 					}
-					
+
 					--Federales Stock
 					self.parts.wpn_fps_pis_beer_s_std.pcs = {
 						10,
@@ -1916,9 +1916,9 @@ end)
 					self.parts.wpn_fps_pis_beer_s_std.supported = true
 					self.parts.wpn_fps_pis_beer_s_std.stats = deep_clone(stocks.add_folder_stats)
 					self.parts.wpn_fps_pis_beer_s_std.custom_stats = deep_clone(stocks.add_folder_stats)
-					
+
 					self.parts.wpn_fps_pis_beer_body_modern.unit = "units/pd2_dlc_afp/weapons/wpn_fps_pis_beer_pts/wpn_fps_pis_beer_body_robo"
-					
+
 					--Overrides
 					self.wpn_fps_pis_beer.override.wpn_fps_pis_beretta_co_co1 = {
 						a_obj = "a_ns",
@@ -1941,14 +1941,14 @@ end)
 								unit = "units/pd2_dlc_afp/weapons/wpn_fps_pis_beer_pts/wpn_fps_pis_beer_body_modern"
 							}
 						end
-					end			
-							
+					end
+
 					table.insert(self.wpn_fps_pis_beer.uses_parts, "wpn_fps_pis_beretta_co_co1")
 					table.insert(self.wpn_fps_pis_beer.uses_parts, "wpn_fps_pis_beretta_co_co2")
 					table.insert(self.wpn_fps_pis_beer.uses_parts, "wpn_fps_upg_i_b93o")
-						
-					self.wpn_fps_pis_beer_npc.override = deep_clone(self.wpn_fps_pis_beer.override)	
-					self.wpn_fps_pis_beer_npc.uses_parts = deep_clone(self.wpn_fps_pis_beer.uses_parts)			
+
+					self.wpn_fps_pis_beer_npc.override = deep_clone(self.wpn_fps_pis_beer.override)
+					self.wpn_fps_pis_beer_npc.uses_parts = deep_clone(self.wpn_fps_pis_beer.uses_parts)
 				end)
 
 		--SECONDARIES
@@ -1965,8 +1965,8 @@ end)
 					}
 					self.parts.wpn_fps_pis_maxim9_b_long.supported = true
 					self.parts.wpn_fps_pis_maxim9_b_long.stats = deep_clone(muzzle_device.muzz_dual_c)
-					self.parts.wpn_fps_pis_maxim9_b_long.custom_stats = deep_clone(muzzle_device.muzz_dual_c)		
-					
+					self.parts.wpn_fps_pis_maxim9_b_long.custom_stats = deep_clone(muzzle_device.muzz_dual_c)
+
 					--Pinnacle Barrel
 					self.parts.wpn_fps_pis_maxim9_b_marksman.pcs = {
 						10,
@@ -1981,7 +1981,7 @@ end)
 					self.parts.wpn_fps_pis_maxim9_m_ext.pcs = {
 						10,
 						20,
-						30, 
+						30,
 						40
 					}
 					self.parts.wpn_fps_pis_maxim9_m_ext.supported = true
@@ -1990,16 +1990,16 @@ end)
 						extra_ammo = 13,
 						concealment = -3,
 						reload = -5
-					}	
+					}
 					self.parts.wpn_fps_pis_maxim9_m_ext.custom_stats = {
 						ads_speed_mult = 1.075
-					}		
-					
+					}
+
 					--Maxim Default body, added to add unique ammo type
 					self.parts.wpn_fps_pis_maxim9_body_upper.adds = {
 						"wpn_fps_pis_maxim9_a_tranq"
 					}
-					
+
 					--Tranq Rounds
 					self.parts.wpn_fps_pis_maxim9_a_tranq = {
 						a_obj = "a_body",
@@ -2041,7 +2041,7 @@ end)
 							}
 						}
 					}
-					
+
 					for i, part_id in pairs(self.wpn_fps_pis_maxim9.uses_parts) do
 						attachment_list = {
 							"wpn_fps_upg_pis_ns_flash",
@@ -2054,12 +2054,12 @@ end)
 							end
 						end
 					end
-					
-					table.insert(self.wpn_fps_pis_maxim9.uses_parts, "wpn_fps_pis_maxim9_a_tranq")	
+
+					table.insert(self.wpn_fps_pis_maxim9.uses_parts, "wpn_fps_pis_maxim9_a_tranq")
 					table.insert(self.wpn_fps_pis_maxim9.uses_parts, "wpn_fps_upg_i_autofire")
 					table.insert(self.wpn_fps_pis_maxim9.uses_parts, "wpn_fps_upg_vg_ass_smg_verticalgrip")
 					table.insert(self.wpn_fps_pis_maxim9.uses_parts, "wpn_fps_upg_vg_ass_smg_stubby")
-					
+
 					self.wpn_fps_pis_maxim9_npc.uses_parts = deep_clone(self.wpn_fps_pis_maxim9.uses_parts)
 				end)
 				Hooks:PostHook(WeaponFactoryTweakData, "_init_x_maxim9", "resmod_x_maxim9", function(self)
@@ -2073,7 +2073,7 @@ end)
 							reload = -5
 						}
 					}
-					
+
 					for i, part_id in pairs(self.wpn_fps_pis_x_maxim9.uses_parts) do
 						attachment_list = {
 							"wpn_fps_upg_pis_ns_flash",
@@ -2086,10 +2086,10 @@ end)
 							end
 						end
 					end
-					
-					table.insert(self.wpn_fps_pis_x_maxim9.uses_parts, "wpn_fps_pis_maxim9_a_tranq")			
-					
-					self.wpn_fps_pis_x_maxim9_npc.uses_parts = deep_clone(self.wpn_fps_pis_x_maxim9.uses_parts)	
+
+					table.insert(self.wpn_fps_pis_x_maxim9.uses_parts, "wpn_fps_pis_maxim9_a_tranq")
+
+					self.wpn_fps_pis_x_maxim9_npc.uses_parts = deep_clone(self.wpn_fps_pis_x_maxim9.uses_parts)
 				end)
 
 			--FIVE-SEVEN
@@ -2108,7 +2108,7 @@ end)
 						spread = 2,
 						concealment = -2
 					}
-					
+
 					--Extended Magazine
 					self.parts.wpn_fps_pis_lemming_m_ext.pcs = {
 						10,
@@ -2118,7 +2118,7 @@ end)
 					}
 					self.parts.wpn_fps_pis_lemming_m_ext.supported = true
 					self.parts.wpn_fps_pis_lemming_m_ext.stats = {
-						value = 1, 
+						value = 1,
 						extra_ammo = 10,
 						concealment = -1,
 						reload = -3
@@ -2126,17 +2126,17 @@ end)
 					self.parts.wpn_fps_pis_lemming_m_ext.custom_stats = {
 						ads_speed_mult = 1.025
 					}
-					
+
 					--Override Table
 					self.wpn_fps_pis_lemming.override.wpn_fps_pis_g18c_co_comp_2 = {parent = "barrel", a_obj = "a_ns"}
 					self.wpn_fps_pis_lemming.override.wpn_fps_pis_g18c_co_1 = {parent = "barrel", a_obj = "a_ns"}
-					
+
 					table.insert(self.wpn_fps_pis_lemming.uses_parts, "wpn_fps_pis_g18c_co_comp_2")
 					table.insert(self.wpn_fps_pis_lemming.uses_parts, "wpn_fps_pis_g18c_co_1")
 					table.insert(self.wpn_fps_pis_lemming.uses_parts, "wpn_fps_upg_vg_ass_smg_verticalgrip")
 					table.insert(self.wpn_fps_pis_lemming.uses_parts, "wpn_fps_upg_vg_ass_smg_stubby")
 
-					self.wpn_fps_pis_lemming_npc.uses_parts = deep_clone(self.wpn_fps_pis_lemming.uses_parts)		
+					self.wpn_fps_pis_lemming_npc.uses_parts = deep_clone(self.wpn_fps_pis_lemming.uses_parts)
 				end)
 
 			--G18C
@@ -2146,34 +2146,34 @@ end)
 					self.parts.wpn_fps_pis_g18c_co_1.pcs = {
 						10,
 						20,
-						30, 
+						30,
 						40
 					}
 					self.parts.wpn_fps_pis_g18c_co_1.supported = true
 					self.parts.wpn_fps_pis_g18c_co_1.stats = deep_clone(muzzle_device.muzz_rec_c)
-					
+
 					--Velocity Compensator
 					self.parts.wpn_fps_pis_g18c_co_comp_2.pcs = {
 						10,
 						20,
-						30, 
+						30,
 						40
 					}
 					self.parts.wpn_fps_pis_g18c_co_comp_2.supported = true
 					self.parts.wpn_fps_pis_g18c_co_comp_2.stats = deep_clone(muzzle_device.muzz_acc_c)
 					self.parts.wpn_fps_pis_g18c_co_comp_2.custom_stats = deep_clone(muzzle_device.muzz_acc_c)
-					
+
 					--Default Mag.
 					self.parts.wpn_fps_pis_g18c_m_mag_17rnd.bullet_objects = {
 						amount = 1,
 						prefix = "g_bullet_"
 					}
-					
+
 					--(STRYK 18c) Extended Mag.
 					self.parts.wpn_fps_pis_g18c_m_mag_33rnd.pcs = {
 						10,
 						20,
-						30, 
+						30,
 						40
 					}
 					self.parts.wpn_fps_pis_g18c_m_mag_33rnd.supported = true
@@ -2195,31 +2195,31 @@ end)
 					self.parts.wpn_fps_pis_g18c_s_stock.pcs = {
 						10,
 						20,
-						30, 
+						30,
 						40
 					}
 					self.parts.wpn_fps_pis_g18c_s_stock.supported = true
 					self.parts.wpn_fps_pis_g18c_s_stock.stats = deep_clone(stocks.add_adj_stats)
 					self.parts.wpn_fps_pis_g18c_s_stock.custom_stats = deep_clone(stocks.add_adj_stats)
-					
+
 					--(STRYK 18c) Ergo Grip
 					self.parts.wpn_fps_pis_g18c_g_ergo.pcs = {
 						10,
 						20,
-						30, 
+						30,
 						40
 					}
 					self.parts.wpn_fps_pis_g18c_g_ergo.supported = true
 					self.parts.wpn_fps_pis_g18c_g_ergo.stats = deep_clone(grips.quickdraw_1)
 					self.parts.wpn_fps_pis_g18c_g_ergo.custom_stats = deep_clone(grips.quickdraw_1)
-					
+
 					self.parts.wpn_fps_pis_g18c_b_standard.animations.fire_steelsight = "recoil"
 
-					
+
 					--STRYK 18c Part Additions
 					--Single/Autofire Locks
 					table.insert(self.wpn_fps_pis_g18c.uses_parts, "wpn_fps_upg_i_singlefire")
-					table.insert(self.wpn_fps_pis_g18c.uses_parts, "wpn_fps_upg_i_autofire")	
+					table.insert(self.wpn_fps_pis_g18c.uses_parts, "wpn_fps_upg_i_autofire")
 					table.insert(self.wpn_fps_pis_g18c.uses_parts, "wpn_fps_upg_vg_ass_smg_verticalgrip")
 					table.insert(self.wpn_fps_pis_g18c.uses_parts, "wpn_fps_upg_vg_ass_smg_stubby")
 					table.insert(self.wpn_fps_pis_g18c.uses_parts, "wpn_fps_smg_schakal_vg_surefire")
@@ -2227,11 +2227,11 @@ end)
 					--Faster/Slower ROF mods (Unused)
 					--[[
 					table.insert(self.wpn_fps_pis_g18c.uses_parts, "wpn_fps_upg_i_slower_rof")
-					table.insert(self.wpn_fps_pis_g18c_npc.uses_parts, "wpn_fps_upg_i_slower_rof")	
+					table.insert(self.wpn_fps_pis_g18c_npc.uses_parts, "wpn_fps_upg_i_slower_rof")
 					table.insert(self.wpn_fps_pis_g18c.uses_parts, "wpn_fps_upg_i_faster_rof")
-					table.insert(self.wpn_fps_pis_g18c_npc.uses_parts, "wpn_fps_upg_i_faster_rof")	
+					table.insert(self.wpn_fps_pis_g18c_npc.uses_parts, "wpn_fps_upg_i_faster_rof")
 					]]--
-					
+
 					self.wpn_fps_pis_g18c_npc.uses_parts = deep_clone(self.wpn_fps_pis_g18c.uses_parts)
 
 					self.wpn_fps_pis_g18c_primary = nil
@@ -2254,7 +2254,7 @@ end)
 							reload = -4
 						}
 					}
-					
+
 					self.wpn_fps_pis_x_g18c.override.wpn_fps_pis_g18c_b_standard.animations = {
 						reload_left = "reload_left",
 						fire = "recoil",
@@ -2267,7 +2267,7 @@ end)
 
 					table.insert(self.wpn_fps_pis_x_g18c.uses_parts, "wpn_fps_pis_g18c_s_stock")
 
-					self.wpn_fps_pis_x_g18c_npc.uses_parts = deep_clone(self.wpn_fps_pis_x_g18c.uses_parts)	
+					self.wpn_fps_pis_x_g18c_npc.uses_parts = deep_clone(self.wpn_fps_pis_x_g18c.uses_parts)
 				end)
 
 			--CZ ACCUSHADOW
@@ -2303,7 +2303,7 @@ end)
 					self.parts.wpn_fps_pis_czech_b_long.supported = true
 					self.parts.wpn_fps_pis_czech_b_long.stats = deep_clone(barrels.long_b1_stats)
 					self.parts.wpn_fps_pis_czech_b_long.custom_stats = deep_clone(barrels.long_b1_stats)
-					
+
 					--Sicario Grip
 					self.parts.wpn_fps_pis_czech_g_sport.pcs = {
 						10,
@@ -2317,7 +2317,7 @@ end)
 						value = 2,
 						concealment = -2
 					}
-					
+
 					--Cartel_Grip
 					self.parts.wpn_fps_pis_czech_g_luxury.pcs = {
 						10,
@@ -2327,7 +2327,7 @@ end)
 					}
 					self.parts.wpn_fps_pis_czech_g_luxury.supported = true
 					self.parts.wpn_fps_pis_czech_g_luxury.stats = deep_clone(grips.acc_recoil)
-					
+
 					--Extended Mag
 					--CZECH EM
 					self.parts.wpn_fps_pis_czech_m_extended.pcs = {
@@ -2343,7 +2343,7 @@ end)
 						extra_ammo = 7,
 						concealment = -2
 					}
-					
+
 					--Tirador Stock
 					self.parts.wpn_fps_pis_czech_s_standard.pcs = {
 						10,
@@ -2354,7 +2354,7 @@ end)
 					self.parts.wpn_fps_pis_czech_s_standard.supported = true
 					self.parts.wpn_fps_pis_czech_s_standard.stats = deep_clone(stocks.add_folder_stats)
 					self.parts.wpn_fps_pis_czech_s_standard.custom_stats = deep_clone(stocks.add_folder_stats)
-					
+
 					--Overrides
 					self.wpn_fps_pis_czech.override.wpn_fps_pis_g18c_co_1 = {
 						a_obj = "a_ns",
@@ -2391,14 +2391,14 @@ end)
 						stats = deep_clone(self.parts.wpn_fps_upg_vg_ass_smg_verticalgrip.stats)
 					}
 
-					table.insert(self.wpn_fps_pis_czech.uses_parts, "wpn_fps_pis_g18c_co_1")	
+					table.insert(self.wpn_fps_pis_czech.uses_parts, "wpn_fps_pis_g18c_co_1")
 					table.insert(self.wpn_fps_pis_czech.uses_parts, "wpn_fps_pis_g18c_co_comp_2")
 					table.insert(self.wpn_fps_pis_czech.uses_parts, "wpn_fps_upg_vg_ass_smg_verticalgrip")
 					table.insert(self.wpn_fps_pis_czech.uses_parts, "wpn_fps_upg_vg_ass_smg_stubby")
 					table.insert(self.wpn_fps_pis_czech.uses_parts, "wpn_fps_smg_schakal_vg_surefire")
 
-					self.wpn_fps_pis_czech_npc.override = deep_clone(self.wpn_fps_pis_czech.override)	
-					self.wpn_fps_pis_czech_npc.uses_parts = deep_clone(self.wpn_fps_pis_czech.uses_parts)	
+					self.wpn_fps_pis_czech_npc.override = deep_clone(self.wpn_fps_pis_czech.override)
+					self.wpn_fps_pis_czech_npc.uses_parts = deep_clone(self.wpn_fps_pis_czech.uses_parts)
 				end)
 				Hooks:PostHook(WeaponFactoryTweakData, "_init_x_czech", "resmod_x_czech", function(self)
 
@@ -2409,7 +2409,7 @@ end)
 					self.wpn_fps_pis_x_czech.override.wpn_fps_pis_g18c_co_comp_2 = {
 						a_obj = "a_ns",
 						parent = "barrel"
-					}			
+					}
 					self.wpn_fps_pis_x_czech.override.wpn_fps_pis_czech_m_extended = {
 						supported = true,
 						stats = {
@@ -2419,13 +2419,13 @@ end)
 							concealment = -2
 						}
 					}
-					
+
 					table.insert(self.wpn_fps_pis_x_czech.uses_parts, "wpn_fps_pis_g18c_co_1")
 					table.insert(self.wpn_fps_pis_x_czech.uses_parts, "wpn_fps_pis_g18c_co_comp_2")
 					table.insert(self.wpn_fps_pis_x_czech.uses_parts, "wpn_fps_pis_czech_s_standard")
 
-					self.wpn_fps_pis_x_czech_npc.override = deep_clone(self.wpn_fps_pis_x_czech.override)	
-					self.wpn_fps_pis_x_czech_npc.uses_parts = deep_clone(self.wpn_fps_pis_x_czech.uses_parts)		
+					self.wpn_fps_pis_x_czech_npc.override = deep_clone(self.wpn_fps_pis_x_czech.override)
+					self.wpn_fps_pis_x_czech_npc.uses_parts = deep_clone(self.wpn_fps_pis_x_czech.uses_parts)
 				end)
 
 			--STECHKIN
@@ -2448,7 +2448,7 @@ end)
 						falloff_start_mult = 1.075,
 						falloff_end_mult = 1.075,
 						ads_speed_mult = 1.025
-					}	
+					}
 
 					--Cartel Grip
 					self.parts.wpn_fps_pis_stech_g_luxury.pcs = {
@@ -2459,7 +2459,7 @@ end)
 					}
 					self.parts.wpn_fps_pis_stech_g_luxury.supported = true
 					self.parts.wpn_fps_pis_stech_g_luxury.stats = deep_clone(grips.recoil_1)
-					
+
 					--Federales Grip
 					self.parts.wpn_fps_pis_stech_g_tactical.pcs = {
 						10,
@@ -2470,7 +2470,7 @@ end)
 					self.parts.wpn_fps_pis_stech_g_tactical.supported = true
 					self.parts.wpn_fps_pis_stech_g_tactical.stats = deep_clone(grips.quickdraw_1)
 					self.parts.wpn_fps_pis_stech_g_tactical.custom_stats = deep_clone(grips.quickdraw_1)
-					
+
 					--Extended Mag
 					self.parts.wpn_fps_pis_stech_m_extended.pcs = {
 						10,
@@ -2488,7 +2488,7 @@ end)
 					self.parts.wpn_fps_pis_stech_m_extended.custom_stats = {
 						ads_speed_mult = 1.05
 					}
-					
+
 					--Federales Stock
 					self.parts.wpn_fps_pis_stech_s_standard.pcs = {
 						10,
@@ -2523,7 +2523,7 @@ end)
 					self.wpn_fps_pis_stech.override.wpn_fps_pis_g18c_co_comp_2 = {
 						a_obj = "a_ns",
 						parent = "barrel"
-					}		
+					}
 
 					for i, part_id in pairs(self.wpn_fps_pis_stech.uses_parts) do
 						if self.parts and self.parts[part_id] and self.parts[part_id].type and self.parts[part_id].type == "gadget" then
@@ -2537,16 +2537,16 @@ end)
 								"wpn_fps_pis_stech_body_standard_rail"
 							}
 						end
-					end	
+					end
 
 					table.insert(self.wpn_fps_pis_stech.uses_parts, "wpn_fps_pis_g18c_co_1")
 					table.insert(self.wpn_fps_pis_stech.uses_parts, "wpn_fps_pis_g18c_co_comp_2")
 					table.insert(self.wpn_fps_pis_stech.uses_parts, "wpn_fps_upg_vg_ass_smg_verticalgrip")
 					table.insert(self.wpn_fps_pis_stech.uses_parts, "wpn_fps_upg_vg_ass_smg_stubby")
 					table.insert(self.wpn_fps_pis_stech.uses_parts, "wpn_fps_smg_schakal_vg_surefire")
-						
-					self.wpn_fps_pis_stech_npc.override = deep_clone(self.wpn_fps_pis_stech.override)	
-					self.wpn_fps_pis_stech_npc.uses_parts = deep_clone(self.wpn_fps_pis_stech.uses_parts)		
+
+					self.wpn_fps_pis_stech_npc.override = deep_clone(self.wpn_fps_pis_stech.override)
+					self.wpn_fps_pis_stech_npc.uses_parts = deep_clone(self.wpn_fps_pis_stech.uses_parts)
 				end)
 				Hooks:PostHook(WeaponFactoryTweakData, "_init_x_stech", "resmod_x_stech", function(self)
 
@@ -2566,7 +2566,7 @@ end)
 					self.wpn_fps_pis_x_stech.override.wpn_fps_pis_g18c_co_comp_2 = {
 						a_obj = "a_ns",
 						parent = "barrel"
-					}			
+					}
 					self.wpn_fps_pis_x_stech.override.wpn_fps_pis_stech_m_extended = {
 						supported = true,
 						stats = {
@@ -2594,23 +2594,23 @@ end)
 								"wpn_fps_pis_stech_body_standard_rail"
 							}
 						end
-					end	
-					
+					end
+
 					self.wpn_fps_pis_x_stech.adds.wpn_fps_pis_stech_s_standard = {
 						"wpn_fps_pis_x_stech_s_mount"
 					}
 
-					table.insert(self.wpn_fps_pis_x_stech.uses_parts, "wpn_fps_pis_g18c_co_1")	
+					table.insert(self.wpn_fps_pis_x_stech.uses_parts, "wpn_fps_pis_g18c_co_1")
 					table.insert(self.wpn_fps_pis_x_stech.uses_parts, "wpn_fps_pis_g18c_co_comp_2")
 					table.insert(self.wpn_fps_pis_x_stech.uses_parts, "wpn_fps_pis_stech_s_standard")
-						
-					self.wpn_fps_pis_x_stech_npc.override = deep_clone(self.wpn_fps_pis_x_stech.override)	
-					self.wpn_fps_pis_x_stech_npc.uses_parts = deep_clone(self.wpn_fps_pis_x_stech.uses_parts)		
+
+					self.wpn_fps_pis_x_stech_npc.override = deep_clone(self.wpn_fps_pis_x_stech.override)
+					self.wpn_fps_pis_x_stech_npc.uses_parts = deep_clone(self.wpn_fps_pis_x_stech.uses_parts)
 				end)
 
 			--PPK
 				Hooks:PostHook(WeaponFactoryTweakData, "_init_ppk", "resmod_ppk", function(self)
-					
+
 					--Long Slide
 					self.parts.wpn_fps_pis_ppk_b_long.pcs = {
 						10,
@@ -2633,15 +2633,15 @@ end)
 					self.parts.wpn_fps_pis_ppk_g_laser.desc_id = "bm_wp_upg_fl_laser"
 					self.parts.wpn_fps_pis_ppk_g_laser.stats = {value = 1}
 					self.parts.wpn_fps_pis_ppk_g_laser.perks = {"gadget"}
-					
+
 					--Gruber Kurz Part Additions
 					table.insert(self.wpn_fps_pis_ppk.uses_parts, "wpn_fps_pis_g18c_co_comp_2")
-					table.insert(self.wpn_fps_pis_ppk.uses_parts, "wpn_fps_pis_g18c_co_1")	
+					table.insert(self.wpn_fps_pis_ppk.uses_parts, "wpn_fps_pis_g18c_co_1")
 					table.insert(self.wpn_fps_pis_ppk.uses_parts, "wpn_fps_upg_vg_ass_smg_verticalgrip")
 					table.insert(self.wpn_fps_pis_ppk.uses_parts, "wpn_fps_upg_vg_ass_smg_stubby")
 					table.insert(self.wpn_fps_pis_ppk.uses_parts, "wpn_fps_smg_schakal_vg_surefire")
-					
-					self.wpn_fps_pis_ppk_npc.uses_parts = deep_clone(self.wpn_fps_pis_ppk.uses_parts)		
+
+					self.wpn_fps_pis_ppk_npc.uses_parts = deep_clone(self.wpn_fps_pis_ppk.uses_parts)
 				end)
 
 			--G26
@@ -2653,7 +2653,7 @@ end)
 						fire_steelsight = "recoil",
 						magazine_empty = "last_recoil"
 					}
-					
+
 					--Striking Slide
 					self.parts.wpn_fps_pis_g26_b_custom.pcs = {
 						10,
@@ -2673,7 +2673,7 @@ end)
 						fire_steelsight = "recoil",
 						magazine_empty = "last_recoil"
 					}
-					
+
 					--Striking Body Kit
 					self.parts.wpn_fps_pis_g26_body_custom.pcs = {
 						10,
@@ -2687,7 +2687,7 @@ end)
 						recoil = 2,
 						concealment = -1
 					}
-					
+
 					--Platypus Grip
 					self.parts.wpn_fps_pis_g26_g_gripforce.pcs = {
 						10,
@@ -2697,7 +2697,7 @@ end)
 					}
 					self.parts.wpn_fps_pis_g26_g_gripforce.supported = true
 					self.parts.wpn_fps_pis_g26_g_gripforce.stats = deep_clone(grips.recoil_1)
-					
+
 					--Laser Grip
 					self.parts.wpn_fps_pis_g26_g_laser.pcs = {
 						10,
@@ -2711,7 +2711,7 @@ end)
 						value = 4
 					}
 					self.parts.wpn_fps_pis_g26_g_laser.perks = {"gadget"}
-					
+
 					--Striking Mag
 					self.parts.wpn_fps_pis_g26_m_contour.pcs = {
 						10,
@@ -2725,7 +2725,7 @@ end)
 						extra_ammo = 2,
 						concealment = -1
 					}
-					
+
 					--Micro Laser
 					self.parts.wpn_fps_upg_fl_pis_crimson.pcs = {
 						10,
@@ -2738,7 +2738,7 @@ end)
 					self.parts.wpn_fps_upg_fl_pis_crimson.stats = {
 						value = 4
 					}
-					
+
 					--Combined Module
 					self.parts.wpn_fps_upg_fl_pis_x400v.pcs = {
 						10,
@@ -2752,7 +2752,7 @@ end)
 						value = 5
 					}
 					self.parts.wpn_fps_upg_fl_pis_x400v.perks = {"gadget"}
-					
+
 					--Champion's Suppressor
 					self.parts.wpn_fps_upg_ns_pis_large_kac.pcs = {
 						10,
@@ -2765,7 +2765,7 @@ end)
 					self.parts.wpn_fps_upg_ns_pis_large_kac.desc_id = "bm_wp_upg_suppressor"
 					self.parts.wpn_fps_upg_ns_pis_large_kac.stats = deep_clone(muzzle_device.supp_rec2_c)
 					self.parts.wpn_fps_upg_ns_pis_large_kac.perks = {"silencer"}
-					
+
 					--Roctec Suppressor
 					self.parts.wpn_fps_upg_ns_pis_medium_gem.pcs = {
 						10,
@@ -2779,7 +2779,7 @@ end)
 					self.parts.wpn_fps_upg_ns_pis_medium_gem.stats = deep_clone(muzzle_device.supp_acc_c)
 					self.parts.wpn_fps_upg_ns_pis_medium_gem.custom_stats = deep_clone(muzzle_device.supp_acc_c)
 					self.parts.wpn_fps_upg_ns_pis_medium_gem.perks = {"silencer"}
-					
+
 					--Facepunch Compensator
 					self.parts.wpn_fps_upg_ns_pis_meatgrinder.pcs = {
 						10,
@@ -2789,7 +2789,7 @@ end)
 					}
 					self.parts.wpn_fps_upg_ns_pis_meatgrinder.supported = true
 					self.parts.wpn_fps_upg_ns_pis_meatgrinder.stats = deep_clone(muzzle_device.muzz_rec2_c)
-					
+
 					--IPSC Compensator
 					self.parts.wpn_fps_upg_ns_pis_ipsccomp.pcs = {
 						10,
@@ -2800,7 +2800,7 @@ end)
 					self.parts.wpn_fps_upg_ns_pis_ipsccomp.supported = true
 					self.parts.wpn_fps_upg_ns_pis_ipsccomp.stats = deep_clone(muzzle_device.muzz_acc2_c)
 					self.parts.wpn_fps_upg_ns_pis_ipsccomp.custom_stats = deep_clone(muzzle_device.muzz_acc2_c)
-					
+
 					self.wpn_fps_pis_g26.override.wpn_fps_pis_g18c_m_mag_33rnd = {
 						supported = true,
 						stats = {
@@ -2813,16 +2813,16 @@ end)
 							ads_speed_mult = 1.075
 						}
 					}
-					
+
 					--Parts
 					table.insert(self.wpn_fps_pis_g26.uses_parts, "wpn_fps_pis_g18c_co_1")
 					table.insert(self.wpn_fps_pis_g26.uses_parts, "wpn_fps_pis_g18c_co_comp_2")
-					table.insert(self.wpn_fps_pis_g26.uses_parts, "wpn_fps_pis_g18c_m_mag_33rnd")	
+					table.insert(self.wpn_fps_pis_g26.uses_parts, "wpn_fps_pis_g18c_m_mag_33rnd")
 					table.insert(self.wpn_fps_pis_g26.uses_parts, "wpn_fps_upg_vg_ass_smg_verticalgrip")
 					table.insert(self.wpn_fps_pis_g26.uses_parts, "wpn_fps_upg_vg_ass_smg_stubby")
 					table.insert(self.wpn_fps_pis_g26.uses_parts, "wpn_fps_smg_schakal_vg_surefire")
-					
-					self.wpn_fps_pis_g26_npc.uses_parts = deep_clone(self.wpn_fps_pis_g26.uses_parts)	
+
+					self.wpn_fps_pis_g26_npc.uses_parts = deep_clone(self.wpn_fps_pis_g26.uses_parts)
 				end)
 				Hooks:PostHook(WeaponFactoryTweakData, "_init_jowi", "resmod_jowi", function(self)
 
@@ -2861,28 +2861,28 @@ end)
 					}
 					self.wpn_fps_jowi.override.wpn_fps_pis_g26_b_standard = {
 						animations = {
-							reload = "reload_right", 
-							reload_left = "reload_left", 
-							fire = "recoil", 
+							reload = "reload_right",
+							reload_left = "reload_left",
+							fire = "recoil",
 							fire_steelsight = "recoil"}
 					}
 					self.wpn_fps_jowi.override.wpn_fps_pis_g26_b_custom = {
 						animations = {
-							reload = "reload_right", 
-							reload_left = "reload_left", 
-							fire = "recoil", 
+							reload = "reload_right",
+							reload_left = "reload_left",
+							fire = "recoil",
 							fire_steelsight = "recoil"}
 					}
-					
+
 					--Parts
 					table.insert(self.wpn_fps_jowi.uses_parts, "wpn_fps_pis_g18c_co_1")
-					table.insert(self.wpn_fps_jowi_npc.uses_parts, "wpn_fps_pis_g18c_co_1")	
+					table.insert(self.wpn_fps_jowi_npc.uses_parts, "wpn_fps_pis_g18c_co_1")
 					table.insert(self.wpn_fps_jowi.uses_parts, "wpn_fps_pis_g18c_co_comp_2")
-					table.insert(self.wpn_fps_jowi_npc.uses_parts, "wpn_fps_pis_g18c_co_comp_2")	
+					table.insert(self.wpn_fps_jowi_npc.uses_parts, "wpn_fps_pis_g18c_co_comp_2")
 					table.insert(self.wpn_fps_jowi.uses_parts, "wpn_fps_pis_g18c_m_mag_33rnd")
-					table.insert(self.wpn_fps_jowi_npc.uses_parts, "wpn_fps_pis_g18c_m_mag_33rnd")		
-					
-					self.wpn_fps_jowi_npc.uses_parts = deep_clone(self.wpn_fps_jowi.uses_parts)	
+					table.insert(self.wpn_fps_jowi_npc.uses_parts, "wpn_fps_pis_g18c_m_mag_33rnd")
+
+					self.wpn_fps_jowi_npc.uses_parts = deep_clone(self.wpn_fps_jowi.uses_parts)
 				end)
 
 			--G17
@@ -2897,7 +2897,7 @@ end)
 					}
 					self.parts.wpn_fps_pis_g17_ck.custom_stats = {}
 					self.parts.wpn_fps_pis_g17_ck.forbids = {}
-					
+
 					self.parts.wpn_fps_pis_g17_s_mount = {
 						type = "shitass",
 						name_id = "none",
@@ -2916,7 +2916,7 @@ end)
 							value = 1
 						}
 					}
-						
+
 					--Chimano 88 Part Additions
 					table.insert(self.wpn_fps_pis_g17.uses_parts, "wpn_fps_pis_g18c_g_ergo")
 					table.insert(self.wpn_fps_pis_g17.uses_parts, "wpn_fps_pis_g18c_co_comp_2")
@@ -2949,7 +2949,7 @@ end)
 						concealment = -2,
 						reload = -4
 					}
-					
+
 					self.wpn_fps_pis_x_g17.override.wpn_fps_pis_g18c_s_stock = {
 						adds = {"wpn_fps_pis_g17_s_mount"},
 						parent = "shitass"
@@ -2966,12 +2966,12 @@ end)
 					table.insert(self.wpn_fps_pis_x_g17.uses_parts, "wpn_fps_pis_g18c_s_stock")
 
 					self.wpn_fps_pis_x_g17_npc.override = deep_clone(self.wpn_fps_pis_x_g17.override)
-					self.wpn_fps_pis_x_g17_npc.uses_parts = deep_clone(self.wpn_fps_pis_x_g17.uses_parts)	
+					self.wpn_fps_pis_x_g17_npc.uses_parts = deep_clone(self.wpn_fps_pis_x_g17.uses_parts)
 				end)
 
 			--M9
 				Hooks:PostHook(WeaponFactoryTweakData, "_init_b92fs", "resmod_b92fs", function(self)
-						
+
 					--The Professional Compensator
 					self.parts.wpn_fps_pis_beretta_co_co1.pcs = {
 						10,
@@ -2981,7 +2981,7 @@ end)
 					}
 					self.parts.wpn_fps_pis_beretta_co_co1.supported = true
 					self.parts.wpn_fps_pis_beretta_co_co1.stats = deep_clone(muzzle_device.muzz_rec_c)
-					
+
 					--The Competitor Compensator
 					self.parts.wpn_fps_pis_beretta_co_co2.pcs = {
 						10,
@@ -2992,7 +2992,7 @@ end)
 					self.parts.wpn_fps_pis_beretta_co_co2.supported = true
 					self.parts.wpn_fps_pis_beretta_co_co2.stats = deep_clone(muzzle_device.muzz_acc_c)
 					self.parts.wpn_fps_pis_beretta_co_co2.custom_stats = deep_clone(muzzle_device.muzz_acc_c)
-					
+
 					--Ergo Grip
 					self.parts.wpn_fps_pis_beretta_g_ergo.pcs = {
 						10,
@@ -3035,16 +3035,16 @@ end)
 						spread = 2,
 						concealment = -2
 					}
-					
+
 					--Bernetti 9 Part Additions
 					table.insert(self.wpn_fps_pis_beretta.uses_parts, "wpn_fps_upg_i_93r")
 					table.insert(self.wpn_fps_pis_beretta.uses_parts, "wpn_fps_upg_vg_ass_smg_verticalgrip")
 					table.insert(self.wpn_fps_pis_beretta.uses_parts, "wpn_fps_upg_vg_ass_smg_stubby")
 					table.insert(self.wpn_fps_pis_beretta.uses_parts, "wpn_fps_smg_schakal_vg_surefire")
 					--table.insert(self.wpn_fps_pis_beretta.uses_parts, "wpn_fps_pis_beer_m_extended")
-					
+
 					self.wpn_fps_pis_beretta_npc.uses_parts = deep_clone(self.wpn_fps_pis_beretta.uses_parts)
-						
+
 					self.wpn_fps_pis_beretta_primary = nil
 					self.wpn_fps_pis_beretta_primary_npc = nil
 				end)
@@ -3067,8 +3067,8 @@ end)
 						}
 					}
 
-					self.wpn_fps_x_b92fs_npc.override = deep_clone(self.wpn_fps_x_b92fs.override)	
-					self.wpn_fps_x_b92fs_npc.uses_parts = deep_clone(self.wpn_fps_x_b92fs.uses_parts)	
+					self.wpn_fps_x_b92fs_npc.override = deep_clone(self.wpn_fps_x_b92fs.override)
+					self.wpn_fps_x_b92fs_npc.uses_parts = deep_clone(self.wpn_fps_x_b92fs.uses_parts)
 				end)
 
 			--PL-14
@@ -3088,7 +3088,7 @@ end)
 						concealment = -3
 					}
 					self.parts.wpn_fps_pis_pl14_b_comp.forbids = {}
-					
+
 					--Extended Magazine
 					self.parts.wpn_fps_pis_pl14_m_extended.pcs = {
 						10,
@@ -3102,7 +3102,7 @@ end)
 						extra_ammo = 2,
 						concealment = -1
 					}
-					
+
 					self.wpn_fps_pis_pl14.override.wpn_fps_pis_g18c_co_1 = {parent = "barrel", a_obj = "a_ns"}
 					self.wpn_fps_pis_pl14.override.wpn_fps_pis_g18c_co_comp_2 = {parent = "barrel", a_obj = "a_ns"}
 
@@ -3111,7 +3111,7 @@ end)
 					table.insert(self.wpn_fps_pis_pl14.uses_parts, "wpn_fps_upg_vg_ass_smg_verticalgrip")
 					table.insert(self.wpn_fps_pis_pl14.uses_parts, "wpn_fps_upg_vg_ass_smg_stubby")
 					table.insert(self.wpn_fps_pis_pl14.uses_parts, "wpn_fps_smg_schakal_vg_surefire")
-					
+
 					self.wpn_fps_pis_pl14_npc.uses_parts = deep_clone(self.wpn_fps_pis_pl14.uses_parts)
 				end)
 				Hooks:PostHook(WeaponFactoryTweakData, "_init_x_pl14", "resmod_x_pl14", function(self)
@@ -3140,7 +3140,7 @@ end)
 					self.parts.wpn_fps_pis_packrat_m_extended.custom_stats = {
 						ads_speed_mult = 1.05
 					}
-					
+
 					--Contractor Compensator
 					self.parts.wpn_fps_pis_packrat_ns_wick.pcs = {}
 					self.parts.wpn_fps_pis_packrat_ns_wick.supported = true
@@ -3150,12 +3150,12 @@ end)
 						recoil = -2,
 						concealment = -2
 					}
-					
+
 					--Tritanium Sights
 					self.parts.wpn_fps_pis_packrat_o_expert.pcs = {}
 					self.parts.wpn_fps_pis_packrat_o_expert.supported = true
 					self.parts.wpn_fps_pis_packrat_o_expert.stats = {value = 0}
-					
+
 					--Overrides
 					self.wpn_fps_pis_packrat.override.wpn_fps_pis_g18c_co_1 = {parent = "barrel", a_obj = "a_ns"}
 					self.wpn_fps_pis_packrat.override.wpn_fps_pis_g18c_co_comp_2 = {parent = "barrel", a_obj = "a_ns"}
@@ -3174,7 +3174,7 @@ end)
 
 					--Override Table
 					self.wpn_fps_x_packrat.override.wpn_fps_pis_g18c_co_1 = {parent = "barrel", a_obj = "a_ns"}
-					self.wpn_fps_x_packrat.override.wpn_fps_pis_g18c_co_comp_2 = {parent = "barrel", a_obj = "a_ns"}		
+					self.wpn_fps_x_packrat.override.wpn_fps_pis_g18c_co_comp_2 = {parent = "barrel", a_obj = "a_ns"}
 					self.wpn_fps_x_packrat.override.wpn_fps_pis_packrat_m_extended = {
 						supported = true,
 						stats = {
@@ -3184,16 +3184,16 @@ end)
 							reload = -4
 						}
 					}
-					
+
 					--New Parts
 					table.insert(self.wpn_fps_x_packrat.uses_parts, "wpn_fps_pis_g18c_co_1")
-					table.insert(self.wpn_fps_x_packrat_npc.uses_parts, "wpn_fps_pis_g18c_co_1")	
+					table.insert(self.wpn_fps_x_packrat_npc.uses_parts, "wpn_fps_pis_g18c_co_1")
 
 					table.insert(self.wpn_fps_x_packrat.uses_parts, "wpn_fps_pis_g18c_co_comp_2")
-					table.insert(self.wpn_fps_x_packrat_npc.uses_parts, "wpn_fps_pis_g18c_co_comp_2")	
+					table.insert(self.wpn_fps_x_packrat_npc.uses_parts, "wpn_fps_pis_g18c_co_comp_2")
 
-					self.wpn_fps_x_packrat_npc.override = deep_clone(self.wpn_fps_x_packrat.override)	
-					self.wpn_fps_x_packrat_npc.uses_parts = deep_clone(self.wpn_fps_x_packrat.uses_parts)	
+					self.wpn_fps_x_packrat_npc.override = deep_clone(self.wpn_fps_x_packrat.override)
+					self.wpn_fps_x_packrat_npc.uses_parts = deep_clone(self.wpn_fps_x_packrat.uses_parts)
 				end)
 
 			--HUDSON H9
@@ -3208,7 +3208,7 @@ end)
 					}
 					self.parts.wpn_fps_pis_holt_g_bling.supported = true
 					self.parts.wpn_fps_pis_holt_g_bling.stats = deep_clone(grips.acc_1)
-					
+
 					--Ergo Grip
 					self.parts.wpn_fps_pis_holt_g_ergo.pcs = {
 						10,
@@ -3219,7 +3219,7 @@ end)
 					self.parts.wpn_fps_pis_holt_g_ergo.supported = true
 					self.parts.wpn_fps_pis_holt_g_ergo.stats = deep_clone(grips.quickdraw_1)
 					self.parts.wpn_fps_pis_holt_g_ergo.custom_stats = deep_clone(grips.quickdraw_1)
-					
+
 					--Extended Mag
 					self.parts.wpn_fps_pis_holt_m_extended.pcs = {
 						10,
@@ -3237,7 +3237,7 @@ end)
 					self.parts.wpn_fps_pis_holt_m_extended.custom_stats = {
 						ads_speed_mult = 1.025
 					}
-					
+
 					--Override Table
 					self.wpn_fps_pis_holt.override.wpn_fps_pis_g18c_co_comp_2 = {
 						a_obj = "a_ns",
@@ -3246,18 +3246,18 @@ end)
 					self.wpn_fps_pis_holt.override.wpn_fps_pis_g18c_co_1 = {
 						a_obj = "a_ns",
 						parent = "barrel"
-					}	
+					}
 
-					table.insert(self.wpn_fps_pis_holt.uses_parts, "wpn_fps_pis_g18c_co_comp_2")	
+					table.insert(self.wpn_fps_pis_holt.uses_parts, "wpn_fps_pis_g18c_co_comp_2")
 					table.insert(self.wpn_fps_pis_holt.uses_parts, "wpn_fps_pis_g18c_co_1")
 					table.insert(self.wpn_fps_pis_holt.uses_parts, "wpn_fps_upg_vg_ass_smg_verticalgrip")
 					table.insert(self.wpn_fps_pis_holt.uses_parts, "wpn_fps_upg_vg_ass_smg_stubby")
-					
-					self.wpn_fps_pis_holt_npc.override = deep_clone(self.wpn_fps_pis_holt.override)	
-					self.wpn_fps_pis_holt_npc.uses_parts = deep_clone(self.wpn_fps_pis_holt.uses_parts)			
+
+					self.wpn_fps_pis_holt_npc.override = deep_clone(self.wpn_fps_pis_holt.override)
+					self.wpn_fps_pis_holt_npc.uses_parts = deep_clone(self.wpn_fps_pis_holt.uses_parts)
 				end)
 				Hooks:PostHook(WeaponFactoryTweakData, "_init_x_holt", "resmod_x_holt", function(self)
-					
+
 					--Override Table
 					self.wpn_fps_pis_x_holt.override.wpn_fps_pis_holt_m_extended = {
 						supported = true,
@@ -3267,7 +3267,7 @@ end)
 							concealment = -1,
 							reload = -3
 						}
-					}	
+					}
 					self.wpn_fps_pis_x_holt.override.wpn_fps_pis_g18c_co_comp_2 = {
 						a_obj = "a_ns",
 						parent = "barrel"
@@ -3275,16 +3275,16 @@ end)
 					self.wpn_fps_pis_x_holt.override.wpn_fps_pis_g18c_co_1 = {
 						a_obj = "a_ns",
 						parent = "barrel"
-					}	
+					}
 
 					table.insert(self.wpn_fps_pis_x_holt.uses_parts, "wpn_fps_pis_g18c_co_comp_2")
-					table.insert(self.wpn_fps_pis_x_holt_npc.uses_parts, "wpn_fps_pis_g18c_co_comp_2")	
+					table.insert(self.wpn_fps_pis_x_holt_npc.uses_parts, "wpn_fps_pis_g18c_co_comp_2")
 
 					table.insert(self.wpn_fps_pis_x_holt.uses_parts, "wpn_fps_pis_g18c_co_1")
-					table.insert(self.wpn_fps_pis_x_holt_npc.uses_parts, "wpn_fps_pis_g18c_co_1")	
-					
-					self.wpn_fps_pis_x_holt_npc.override = deep_clone(self.wpn_fps_pis_x_holt.override)	
-					self.wpn_fps_pis_x_holt_npc.uses_parts = deep_clone(self.wpn_fps_pis_x_holt.uses_parts)			
+					table.insert(self.wpn_fps_pis_x_holt_npc.uses_parts, "wpn_fps_pis_g18c_co_1")
+
+					self.wpn_fps_pis_x_holt_npc.override = deep_clone(self.wpn_fps_pis_x_holt.override)
+					self.wpn_fps_pis_x_holt_npc.uses_parts = deep_clone(self.wpn_fps_pis_x_holt.uses_parts)
 				end)
 
 			--P08
@@ -3314,7 +3314,7 @@ end)
 					self.parts.wpn_fps_pis_breech_b_short.supported = true
 					self.parts.wpn_fps_pis_breech_b_short.stats = deep_clone(barrels.short_b1_stats)
 					self.parts.wpn_fps_pis_breech_b_short.custom_stats = deep_clone(barrels.short_b1_stats)
-					
+
 					--Engraved Grip
 					self.parts.wpn_fps_pis_breech_g_custom.pcs = {
 						10,
@@ -3412,8 +3412,8 @@ end)
 					table.insert(self.wpn_fps_pis_breech.uses_parts, "wpn_fps_pis_g18c_co_comp_2")
 					table.insert(self.wpn_fps_pis_breech.uses_parts, "wpn_fps_upg_ns_pis_typhoon")
 
-					self.wpn_fps_pis_breech_npc.uses_parts = deep_clone(self.wpn_fps_pis_breech.uses_parts)	
-					self.wpn_fps_pis_breech_npc.override = deep_clone(self.wpn_fps_pis_breech.override)	
+					self.wpn_fps_pis_breech_npc.uses_parts = deep_clone(self.wpn_fps_pis_breech.uses_parts)
+					self.wpn_fps_pis_breech_npc.override = deep_clone(self.wpn_fps_pis_breech.override)
 				end)
 				Hooks:PostHook(WeaponFactoryTweakData, "_init_x_breech", "resmod_x_breech", function(self)
 
@@ -3485,8 +3485,8 @@ end)
 					table.insert(self.wpn_fps_pis_x_breech.uses_parts, "wpn_fps_pis_g18c_co_comp_2")
 					table.insert(self.wpn_fps_pis_x_breech.uses_parts, "wpn_fps_upg_ns_pis_typhoon")
 
-					self.wpn_fps_pis_x_breech_npc.uses_parts = deep_clone(self.wpn_fps_pis_x_breech.uses_parts)	
-					self.wpn_fps_pis_x_breech_npc.override = deep_clone(self.wpn_fps_pis_x_breech.override)	
+					self.wpn_fps_pis_x_breech_npc.uses_parts = deep_clone(self.wpn_fps_pis_x_breech.uses_parts)
+					self.wpn_fps_pis_x_breech_npc.override = deep_clone(self.wpn_fps_pis_x_breech.override)
 				end)
 
 			--M13
@@ -3512,7 +3512,7 @@ end)
 					}
 					self.parts.wpn_fps_pis_legacy_g_wood.supported = true
 					self.parts.wpn_fps_pis_legacy_g_wood.stats = deep_clone(grips.acc_1)
-					
+
 					self.wpn_fps_pis_legacy.override = self.wpn_fps_pis_legacy.override or {}
 					self.wpn_fps_pis_legacy.override.wpn_fps_pis_g18c_co_1 = {
 						a_obj = "a_ns",
@@ -3521,15 +3521,15 @@ end)
 					self.wpn_fps_pis_legacy.override.wpn_fps_pis_g18c_co_comp_2 = {
 						a_obj = "a_ns",
 						parent = "barrel"
-					}				
-					
+					}
+
 					table.insert(self.wpn_fps_pis_legacy.uses_parts, "wpn_fps_pis_g18c_co_1")
 					table.insert(self.wpn_fps_pis_legacy.uses_parts, "wpn_fps_pis_g18c_co_comp_2")
 					table.insert(self.wpn_fps_pis_legacy.uses_parts, "wpn_fps_upg_vg_ass_smg_verticalgrip")
 					table.insert(self.wpn_fps_pis_legacy.uses_parts, "wpn_fps_upg_vg_ass_smg_stubby")
 
-					self.wpn_fps_pis_legacy_npc.override = deep_clone(self.wpn_fps_pis_legacy.override)	
-					self.wpn_fps_pis_legacy_npc.uses_parts = deep_clone(self.wpn_fps_pis_legacy.uses_parts)	
+					self.wpn_fps_pis_legacy_npc.override = deep_clone(self.wpn_fps_pis_legacy.override)
+					self.wpn_fps_pis_legacy_npc.uses_parts = deep_clone(self.wpn_fps_pis_legacy.uses_parts)
 				end)
 
 			--P226
@@ -3548,7 +3548,7 @@ end)
 						spread = -1,
 						concealment = 1
 					}
-					
+
 					--Long Slide
 					self.parts.wpn_fps_pis_p226_b_long.pcs = {
 						10,
@@ -3559,7 +3559,7 @@ end)
 					self.parts.wpn_fps_pis_p226_b_long.supported = true
 					self.parts.wpn_fps_pis_p226_b_long.stats = deep_clone(barrels.long_b2_stats)
 					self.parts.wpn_fps_pis_p226_b_long.custom_stats = deep_clone(barrels.long_b2_stats)
-					
+
 					--Ergo Grip
 					self.parts.wpn_fps_pis_p226_g_ergo.pcs = {
 						10,
@@ -3598,7 +3598,7 @@ end)
 					}
 					self.parts.wpn_fps_pis_p226_co_comp_1.supported = true
 					self.parts.wpn_fps_pis_p226_co_comp_1.stats = deep_clone(muzzle_device.muzz_rec_c)
-					
+
 					--Velocity .40
 					self.parts.wpn_fps_pis_p226_co_comp_2.pcs = {
 						10,
@@ -3609,7 +3609,7 @@ end)
 					self.parts.wpn_fps_pis_p226_co_comp_2.supported = true
 					self.parts.wpn_fps_pis_p226_co_comp_2.stats = deep_clone(muzzle_device.muzz_acc_c)
 					self.parts.wpn_fps_pis_p226_co_comp_2.custom_stats = deep_clone(muzzle_device.muzz_acc_c)
-					
+
 					table.insert(self.wpn_fps_pis_p226.uses_parts, "wpn_fps_upg_vg_ass_smg_verticalgrip")
 					table.insert(self.wpn_fps_pis_p226.uses_parts, "wpn_fps_upg_vg_ass_smg_stubby")
 					table.insert(self.wpn_fps_pis_p226.uses_parts, "wpn_fps_smg_schakal_vg_surefire")
@@ -3629,7 +3629,7 @@ end)
 
 			--G22C
 				Hooks:PostHook(WeaponFactoryTweakData, "_init_g22c", "resmod_g22c", function(self)
-					
+
 					--Long Slide
 					self.parts.wpn_fps_pis_g22c_b_long.pcs = {
 						10,
@@ -3640,12 +3640,12 @@ end)
 					self.parts.wpn_fps_pis_g22c_b_long.supported = true
 					self.parts.wpn_fps_pis_g22c_b_long.stats = deep_clone(barrels.long_b2_stats)
 					self.parts.wpn_fps_pis_g22c_b_long.custom_stats = deep_clone(barrels.long_b2_stats)
-					
+
 					table.insert(self.wpn_fps_pis_g22c.uses_parts, "wpn_fps_upg_vg_ass_smg_verticalgrip")
 					table.insert(self.wpn_fps_pis_g22c.uses_parts, "wpn_fps_upg_vg_ass_smg_stubby")
 					table.insert(self.wpn_fps_pis_g22c.uses_parts, "wpn_fps_smg_schakal_vg_surefire")
 
-					self.wpn_fps_pis_g22c_npc.uses_parts = deep_clone(self.wpn_fps_pis_g22c.uses_parts)	
+					self.wpn_fps_pis_g22c_npc.uses_parts = deep_clone(self.wpn_fps_pis_g22c.uses_parts)
 				end)
 				Hooks:PostHook(WeaponFactoryTweakData, "_init_x_g22c", "resmod_x_g22c", function(self)
 
@@ -3671,7 +3671,7 @@ end)
 					self.parts.wpn_fps_pis_sparrow_b_comp.supported = true
 					self.parts.wpn_fps_pis_sparrow_b_comp.stats = {
 						value = 5,
-						recoil = 2, 
+						recoil = 2,
 						concealment = -1
 					}
 					self.parts.wpn_fps_pis_sparrow_b_comp.forbids = {}
@@ -3685,7 +3685,7 @@ end)
 					}
 					self.parts.wpn_fps_pis_sparrow_b_threaded.supported = true
 					self.parts.wpn_fps_pis_sparrow_b_threaded.stats = {value = 2, spread = 1, concealment = -1}
-					
+
 					--Spike Kit
 					self.parts.wpn_fps_pis_sparrow_body_941.pcs = {
 						10,
@@ -3699,7 +3699,7 @@ end)
 						concealment = 1,
 						recoil = -2
 					}
-					
+
 					--Spike Grip
 					self.parts.wpn_fps_pis_sparrow_g_cowboy.pcs = {
 						10,
@@ -3711,24 +3711,24 @@ end)
 					self.parts.wpn_fps_pis_sparrow_g_cowboy.has_description = true
 					self.parts.wpn_fps_pis_sparrow_g_cowboy.desc_id = "bm_w_sparrow_sc_g_cowboy_desc"
 					self.parts.wpn_fps_pis_sparrow_g_cowboy.stats = deep_clone(grips.acc_1)
-					
+
 					--Overrides for Glock comps
 					self.wpn_fps_pis_sparrow.override.wpn_fps_pis_g18c_co_comp_2 = {
-						parent = "barrel", 
+						parent = "barrel",
 						a_obj = "a_ns"
 					}
 					self.wpn_fps_pis_sparrow.override.wpn_fps_pis_g18c_co_1 = {
-						parent = "barrel", 
+						parent = "barrel",
 						a_obj = "a_ns"
 					}
-						
+
 					table.insert(self.wpn_fps_pis_sparrow.uses_parts, "wpn_fps_pis_g18c_co_comp_2")
-					table.insert(self.wpn_fps_pis_sparrow.uses_parts, "wpn_fps_pis_g18c_co_1")	
+					table.insert(self.wpn_fps_pis_sparrow.uses_parts, "wpn_fps_pis_g18c_co_1")
 					table.insert(self.wpn_fps_pis_sparrow.uses_parts, "wpn_fps_upg_vg_ass_smg_verticalgrip")
 					table.insert(self.wpn_fps_pis_sparrow.uses_parts, "wpn_fps_upg_vg_ass_smg_stubby")
 					table.insert(self.wpn_fps_pis_sparrow.uses_parts, "wpn_fps_smg_schakal_vg_surefire")
-					
-					self.wpn_fps_pis_sparrow_npc.uses_parts = deep_clone(self.wpn_fps_pis_sparrow.uses_parts)	
+
+					self.wpn_fps_pis_sparrow_npc.uses_parts = deep_clone(self.wpn_fps_pis_sparrow.uses_parts)
 				end)
 				Hooks:PostHook(WeaponFactoryTweakData, "_init_x_sparrow", "resmod_x_sparrow", function(self)
 
@@ -3742,13 +3742,13 @@ end)
 							end
 						end
 					end
-					
+
 					self.wpn_fps_pis_x_sparrow_npc.uses_parts = deep_clone(self.wpn_fps_pis_x_sparrow.uses_parts)
 				end)
 
 			--HS2000
 				Hooks:PostHook(WeaponFactoryTweakData, "_init_hs2000", "resmod_hs2000", function(self)
-					
+
 					--Custom Slide
 					self.parts.wpn_fps_pis_hs2000_sl_custom.pcs = {
 						10,
@@ -3759,7 +3759,7 @@ end)
 					self.parts.wpn_fps_pis_hs2000_sl_custom.supported = true
 					self.parts.wpn_fps_pis_hs2000_sl_custom.stats = deep_clone(barrels.short_b1_stats)
 					self.parts.wpn_fps_pis_hs2000_sl_custom.custom_stats = deep_clone(barrels.short_b1_stats)
-					
+
 					--Long Slide
 					self.parts.wpn_fps_pis_hs2000_sl_long.pcs = {
 						10,
@@ -3770,7 +3770,7 @@ end)
 					self.parts.wpn_fps_pis_hs2000_sl_long.supported = true
 					self.parts.wpn_fps_pis_hs2000_sl_long.stats = deep_clone(barrels.long_b2_stats)
 					self.parts.wpn_fps_pis_hs2000_sl_long.custom_stats = deep_clone(barrels.long_b2_stats)
-					
+
 					--Extended Mag
 					self.parts.wpn_fps_pis_hs2000_m_extended.pcs = {
 						10,
@@ -3788,7 +3788,7 @@ end)
 					self.parts.wpn_fps_pis_hs2000_m_extended.custom_stats = {
 						ads_speed_mult = 1.05
 					}
-					
+
 					--Override Table
 					self.wpn_fps_pis_hs2000.override.wpn_fps_pis_g18c_co_comp_2 = {
 						a_obj = "a_ns",
@@ -3798,14 +3798,14 @@ end)
 						a_obj = "a_ns",
 						parent = "barrel"
 					}
-					
+
 					table.insert(self.wpn_fps_pis_hs2000.uses_parts, "wpn_fps_pis_g18c_co_comp_2")
 					table.insert(self.wpn_fps_pis_hs2000.uses_parts, "wpn_fps_pis_g18c_co_1")
 					table.insert(self.wpn_fps_pis_hs2000.uses_parts, "wpn_fps_upg_vg_ass_smg_verticalgrip")
 					table.insert(self.wpn_fps_pis_hs2000.uses_parts, "wpn_fps_upg_vg_ass_smg_stubby")
 					table.insert(self.wpn_fps_pis_hs2000.uses_parts, "wpn_fps_smg_schakal_vg_surefire")
-					
-					self.wpn_fps_pis_hs2000_npc.uses_parts = deep_clone(self.wpn_fps_pis_hs2000.uses_parts)		
+
+					self.wpn_fps_pis_hs2000_npc.uses_parts = deep_clone(self.wpn_fps_pis_hs2000.uses_parts)
 				end)
 
 	--[[     HEAVY PISTOLS     ]]
@@ -3823,7 +3823,7 @@ end)
 						recoil = -2,
 						concealment = 1
 					}
-					
+
 					--Delabarre Foregrip
 					self.parts.wpn_fps_ass_sub2000_fg_railed.pcs = {}
 					self.parts.wpn_fps_ass_sub2000_fg_railed.supported = true
@@ -3832,7 +3832,7 @@ end)
 						recoil = 4,
 						concealment = -2
 					}
-					
+
 					--Tooth Fairy Suppressor
 					self.parts.wpn_fps_ass_sub2000_fg_suppressed.pcs = {}
 					self.parts.wpn_fps_ass_sub2000_fg_suppressed.supported = true
@@ -3878,20 +3878,20 @@ end)
 						end
 					end
 
-					self.wpn_fps_ass_sub2000_npc.override = deep_clone(self.wpn_fps_ass_sub2000.override)	
-					self.wpn_fps_ass_sub2000_npc.uses_parts = deep_clone(self.wpn_fps_ass_sub2000.uses_parts)	
-					self.wpn_fps_ass_sub2000_npc.adds = deep_clone(self.wpn_fps_ass_sub2000.adds)	
+					self.wpn_fps_ass_sub2000_npc.override = deep_clone(self.wpn_fps_ass_sub2000.override)
+					self.wpn_fps_ass_sub2000_npc.uses_parts = deep_clone(self.wpn_fps_ass_sub2000.uses_parts)
+					self.wpn_fps_ass_sub2000_npc.adds = deep_clone(self.wpn_fps_ass_sub2000.adds)
 				end)
 
 			--C96
 				Hooks:PostHook(WeaponFactoryTweakData, "_init_c96", "resmod_c96", function(self)
-					
+
 					--Precision Barrel
 					self.parts.wpn_fps_pis_c96_b_long.pcs = {}
 					self.parts.wpn_fps_pis_c96_b_long.supported = true
 					self.parts.wpn_fps_pis_c96_b_long.stats = deep_clone(barrels.long_b3_stats)
 					self.parts.wpn_fps_pis_c96_b_long.custom_stats = deep_clone(barrels.long_b3_stats)
-					
+
 					--Damper.L 44 Nozzle
 					self.parts.wpn_fps_pis_c96_nozzle.pcs = {}
 					self.parts.wpn_fps_pis_c96_nozzle.supported = true
@@ -3902,12 +3902,12 @@ end)
 						recoil = 4,
 						extra_ammo = 2
 					}
-					self.parts.wpn_fps_pis_c96_nozzle.custom_stats = { 
+					self.parts.wpn_fps_pis_c96_nozzle.custom_stats = {
 						muzzleflash = "effects/payday2/particles/weapons/9mm_auto_silence_fps",
 						starwars = {
-							regen_ammo_time = 2, 
+							regen_ammo_time = 2,
 							regen_rate = 3,
-							overheat_pen = 2, 
+							overheat_pen = 2,
 							regen_rate_overheat = 1.5,
 						},
 						rof_mult = 0.35,
@@ -3918,7 +3918,7 @@ end)
 					self.parts.wpn_fps_pis_c96_nozzle.forbids = {"wpn_fps_pis_c96_m_extended"}
 					self.parts.wpn_fps_pis_c96_nozzle.sub_type = nil--"silencer"
 					self.parts.wpn_fps_pis_c96_nozzle.perks = { "fire_mode_single" }
-					
+
 					--Barrel Sight 44
 					self.parts.wpn_fps_pis_c96_sight.pcs = {}
 					self.parts.wpn_fps_pis_c96_sight.has_description = true
@@ -3954,7 +3954,7 @@ end)
 					self.parts.wpn_fps_pis_c96_s_solid.supported = true
 					self.parts.wpn_fps_pis_c96_s_solid.stats = deep_clone(stocks.add_fixed_stats)
 					self.parts.wpn_fps_pis_c96_s_solid.custom_stats = deep_clone(stocks.add_fixed_stats)
-					
+
 					--Extra Barrel Extensions
 					table.insert(self.wpn_fps_pis_c96.uses_parts, "wpn_fps_pis_g18c_co_comp_2")
 					table.insert(self.wpn_fps_pis_c96.uses_parts, "wpn_fps_pis_g18c_co_1")
@@ -3962,8 +3962,8 @@ end)
 					table.insert(self.wpn_fps_pis_c96.uses_parts, "wpn_fps_upg_vg_ass_smg_stubby")
 					table.insert(self.wpn_fps_pis_c96.uses_parts, "wpn_fps_smg_schakal_vg_surefire")
 					table.insert(self.wpn_fps_pis_c96.uses_parts, "wpn_fps_pis_c96_cnuy_satsuki")
-					
-					self.wpn_fps_pis_c96_npc.uses_parts = deep_clone(self.wpn_fps_pis_c96.uses_parts)		
+
+					self.wpn_fps_pis_c96_npc.uses_parts = deep_clone(self.wpn_fps_pis_c96.uses_parts)
 				end)
 
 			--RSH-12
@@ -3993,7 +3993,7 @@ end)
 					table.insert(self.parts.wpn_fps_pis_rsh12_b_comp.forbids, "wpn_fps_upg_ns_pis_large")
 					table.insert(self.parts.wpn_fps_pis_rsh12_b_comp.forbids, "wpn_fps_upg_ns_pis_large_kac")
 					table.insert(self.parts.wpn_fps_pis_rsh12_b_comp.forbids, "wpn_fps_upg_ns_pis_jungle")
-					
+
 					--Short Barrel
 					self.parts.wpn_fps_pis_rsh12_b_short.pcs = {
 						10,
@@ -4006,13 +4006,13 @@ end)
 						value = 3,
 						spread = -1,
 						concealment = 1
-					}	
+					}
 					self.parts.wpn_fps_pis_rsh12_b_short.custom_stats = {
 						falloff_start_mult = 0.925,
 						falloff_end_mult = 0.925,
 						ads_speed_mult = 0.975
-					}		
-					
+					}
+
 					--Wood Grip
 					self.parts.wpn_fps_pis_rsh12_g_wood.pcs = {
 						10,
@@ -4022,7 +4022,7 @@ end)
 					}
 					self.parts.wpn_fps_pis_rsh12_g_wood.supported = true
 					self.parts.wpn_fps_pis_rsh12_g_wood.stats = deep_clone(grips.recoil_1)
-					
+
 					--Overrides for Glock comps
 					self.wpn_fps_pis_rsh12.override.wpn_fps_pis_g18c_co_comp_2 = { parent = "barrel",  a_obj = "a_ns" }
 					self.wpn_fps_pis_rsh12.override.wpn_fps_pis_g18c_co_1 = { parent = "barrel",  a_obj = "a_ns" }
@@ -4069,7 +4069,7 @@ end)
 					}
 
 					table.insert(self.wpn_fps_pis_rsh12.uses_parts, "wpn_fps_pis_g18c_co_comp_2")
-					table.insert(self.wpn_fps_pis_rsh12.uses_parts, "wpn_fps_pis_g18c_co_1")	
+					table.insert(self.wpn_fps_pis_rsh12.uses_parts, "wpn_fps_pis_g18c_co_1")
 					table.insert(self.wpn_fps_pis_rsh12.uses_parts, "wpn_fps_upg_ns_ass_filter")
 					table.insert(self.wpn_fps_pis_rsh12.uses_parts, "wpn_fps_upg_ns_pis_small")
 					table.insert(self.wpn_fps_pis_rsh12.uses_parts, "wpn_fps_upg_ns_pis_medium")
@@ -4079,12 +4079,12 @@ end)
 					table.insert(self.wpn_fps_pis_rsh12.uses_parts, "wpn_fps_upg_ns_pis_large_kac")
 					table.insert(self.wpn_fps_pis_rsh12.uses_parts, "wpn_fps_upg_ns_pis_jungle")
 
-					table.insert(self.wpn_fps_pis_rsh12.uses_parts, "wpn_fps_upg_i_iw_hailstorm")		
-					table.insert(self.wpn_fps_pis_rsh12.uses_parts, "wpn_fps_upg_vg_ass_smg_verticalgrip")		
-					table.insert(self.wpn_fps_pis_rsh12.uses_parts, "wpn_fps_upg_vg_ass_smg_stubby")		
-					
+					table.insert(self.wpn_fps_pis_rsh12.uses_parts, "wpn_fps_upg_i_iw_hailstorm")
+					table.insert(self.wpn_fps_pis_rsh12.uses_parts, "wpn_fps_upg_vg_ass_smg_verticalgrip")
+					table.insert(self.wpn_fps_pis_rsh12.uses_parts, "wpn_fps_upg_vg_ass_smg_stubby")
+
 					self.wpn_fps_pis_rsh12_npc.override = deep_clone(self.wpn_fps_pis_rsh12.override)
-					self.wpn_fps_pis_rsh12_npc.uses_parts = deep_clone(self.wpn_fps_pis_rsh12.uses_parts)		
+					self.wpn_fps_pis_rsh12_npc.uses_parts = deep_clone(self.wpn_fps_pis_rsh12.uses_parts)
 				end)
 
 		--SECONDARIES
@@ -4104,13 +4104,13 @@ end)
 						value = 5,
 						spread = 1,
 						concealment = -1
-					}		
+					}
 					self.parts.wpn_fps_pis_type54_b_long.custom_stats = {
 						falloff_start_mult = 1.075,
 						falloff_end_mult = 1.075,
 						ads_speed_mult = 1.025
-					}				
-					
+					}
+
 					--Extended magazine
 					self.parts.wpn_fps_pis_type54_m_ext.pcs = {
 						10,
@@ -4124,35 +4124,35 @@ end)
 						extra_ammo = 5,
 						reload = -4,
 						concealment = -2
-					}		
+					}
 					self.parts.wpn_fps_pis_type54_m_ext.custom_stats = {
 						ads_speed_mult = 1.05
-					}	
-					
+					}
+
 					--Underbarrel Shotgun
 					self.parts.wpn_fps_pis_type54_underbarrel.pcs = {}
 					self.parts.wpn_fps_pis_type54_underbarrel.supported = true
 					self.parts.wpn_fps_pis_type54_underbarrel.stats = {
 						value = 8,
-						total_ammo_mod = -82, 
+						total_ammo_mod = -82,
 						concealment = -4
-					}		
-					
+					}
+
 					--Overrides for Glock comps
 					self.wpn_fps_pis_type54.override.wpn_fps_pis_g18c_co_comp_2 = {
-						parent = "barrel", 
+						parent = "barrel",
 						a_obj = "a_ns"
 					}
 					self.wpn_fps_pis_type54.override.wpn_fps_pis_1911_co_1 = {
-						parent = "barrel", 
+						parent = "barrel",
 						a_obj = "a_ns"
 					}
-						
+
 					table.insert(self.wpn_fps_pis_type54.uses_parts, "wpn_fps_pis_g18c_co_comp_2")
 					table.insert(self.wpn_fps_pis_type54.uses_parts, "wpn_fps_pis_1911_co_1")
-					
+
 					self.wpn_fps_pis_type54_npc.override = deep_clone(self.wpn_fps_pis_type54.override)
-					self.wpn_fps_pis_type54_npc.uses_parts = deep_clone(self.wpn_fps_pis_type54.uses_parts)		
+					self.wpn_fps_pis_type54_npc.uses_parts = deep_clone(self.wpn_fps_pis_type54.uses_parts)
 				end)
 				Hooks:PostHook(WeaponFactoryTweakData, "_init_x_type54", "resmod_x_type54", function(self)
 
@@ -4161,17 +4161,17 @@ end)
 					self.parts.wpn_fps_pis_x_type54_underbarrel.supported = true
 					self.parts.wpn_fps_pis_x_type54_underbarrel.stats = {
 						value = 8,
-						total_ammo_mod = -82, 
+						total_ammo_mod = -82,
 						concealment = -4
-					}	
+					}
 
 					--Overrides for Glock comps
 					self.wpn_fps_pis_x_type54.override.wpn_fps_pis_g18c_co_comp_2 = {
-						parent = "barrel", 
+						parent = "barrel",
 						a_obj = "a_ns"
 					}
 					self.wpn_fps_pis_x_type54.override.wpn_fps_pis_1911_co_1 = {
-						parent = "barrel", 
+						parent = "barrel",
 						a_obj = "a_ns"
 					}
 					self.wpn_fps_pis_x_type54.override.wpn_fps_pis_type54_m_ext = {
@@ -4182,13 +4182,13 @@ end)
 							concealment = -2
 						},
 						supported = true
-					}	
-						
+					}
+
 					table.insert(self.wpn_fps_pis_x_type54.uses_parts, "wpn_fps_pis_g18c_co_comp_2")
 					table.insert(self.wpn_fps_pis_x_type54.uses_parts, "wpn_fps_pis_1911_co_1")
-					
-					self.wpn_fps_pis_x_type54_npc.override = deep_clone(self.wpn_fps_pis_x_type54.override)	
-					self.wpn_fps_pis_x_type54_npc.uses_parts = deep_clone(self.wpn_fps_pis_x_type54.uses_parts)	
+
+					self.wpn_fps_pis_x_type54_npc.override = deep_clone(self.wpn_fps_pis_x_type54.override)
+					self.wpn_fps_pis_x_type54_npc.uses_parts = deep_clone(self.wpn_fps_pis_x_type54.uses_parts)
 				end)
 
 			--1911 DEFENDER
@@ -4203,9 +4203,9 @@ end)
 					}
 					self.parts.wpn_fps_pis_shrew_g_bling.supported = true
 					self.parts.wpn_fps_pis_shrew_g_bling.has_description = true
-					self.parts.wpn_fps_pis_shrew_g_bling.desc_id = "bm_shrew_g_bling_sc_desc"	
+					self.parts.wpn_fps_pis_shrew_g_bling.desc_id = "bm_shrew_g_bling_sc_desc"
 					self.parts.wpn_fps_pis_shrew_g_bling.stats = deep_clone(grips.acc_1)
-					
+
 					--Ergo Grip
 					self.parts.wpn_fps_pis_shrew_g_ergo.pcs = {
 						10,
@@ -4216,7 +4216,7 @@ end)
 					self.parts.wpn_fps_pis_shrew_g_ergo.supported = true
 					self.parts.wpn_fps_pis_shrew_g_ergo.stats = deep_clone(grips.quickdraw_1)
 					self.parts.wpn_fps_pis_shrew_g_ergo.custom_stats = deep_clone(grips.quickdraw_1)
-					
+
 					--Extended Magazine
 					self.parts.wpn_fps_pis_shrew_m_extended.pcs = {
 						10,
@@ -4231,7 +4231,7 @@ end)
 						concealment = -1,
 						value = 1
 					}
-					
+
 					--Milled Slide
 					self.parts.wpn_fps_pis_shrew_sl_milled.pcs = {
 						10,
@@ -4245,16 +4245,16 @@ end)
 						recoil = -2,
 						concealment = 1
 					}
-					
+
 					self.wpn_fps_pis_shrew.override.wpn_fps_pis_1911_co_1 = {parent = "barrel"}
 					self.wpn_fps_pis_shrew.override.wpn_fps_pis_1911_co_2 = {parent = "barrel"}
-					
+
 					table.insert(self.wpn_fps_pis_shrew.uses_parts, "wpn_fps_pis_1911_co_1")
 					table.insert(self.wpn_fps_pis_shrew.uses_parts, "wpn_fps_pis_1911_co_2")
 					table.insert(self.wpn_fps_pis_shrew.uses_parts, "wpn_fps_upg_vg_ass_smg_verticalgrip")
 					table.insert(self.wpn_fps_pis_shrew.uses_parts, "wpn_fps_upg_vg_ass_smg_stubby")
 
-					self.wpn_fps_pis_shrew_npc.uses_parts = deep_clone(self.wpn_fps_pis_shrew.uses_parts)		
+					self.wpn_fps_pis_shrew_npc.uses_parts = deep_clone(self.wpn_fps_pis_shrew.uses_parts)
 				end)
 				Hooks:PostHook(WeaponFactoryTweakData, "_init_x_shrew", "resmod_x_shrew", function(self)
 
@@ -4269,13 +4269,13 @@ end)
 							value = 1
 						}
 					}
-					
-					table.insert(self.wpn_fps_pis_x_shrew.uses_parts, "wpn_fps_pis_1911_co_1")
-					table.insert(self.wpn_fps_pis_x_shrew_npc.uses_parts, "wpn_fps_pis_1911_co_1")		
-					table.insert(self.wpn_fps_pis_x_shrew.uses_parts, "wpn_fps_pis_1911_co_2")
-					table.insert(self.wpn_fps_pis_x_shrew_npc.uses_parts, "wpn_fps_pis_1911_co_2")	
 
-					self.wpn_fps_pis_x_shrew_npc.uses_parts = deep_clone(self.wpn_fps_pis_x_shrew.uses_parts)	
+					table.insert(self.wpn_fps_pis_x_shrew.uses_parts, "wpn_fps_pis_1911_co_1")
+					table.insert(self.wpn_fps_pis_x_shrew_npc.uses_parts, "wpn_fps_pis_1911_co_1")
+					table.insert(self.wpn_fps_pis_x_shrew.uses_parts, "wpn_fps_pis_1911_co_2")
+					table.insert(self.wpn_fps_pis_x_shrew_npc.uses_parts, "wpn_fps_pis_1911_co_2")
+
+					self.wpn_fps_pis_x_shrew_npc.uses_parts = deep_clone(self.wpn_fps_pis_x_shrew.uses_parts)
 				end)
 
 			--1911 OPERATOR
@@ -4315,7 +4315,7 @@ end)
 					}
 					self.parts.wpn_fps_pis_1911_co_1.supported = true
 					self.parts.wpn_fps_pis_1911_co_1.stats = deep_clone(muzzle_device.muzz_rec_c)
-					
+
 					--Aggressor Compensator
 					self.parts.wpn_fps_pis_1911_co_2.pcs = {
 						10,
@@ -4326,7 +4326,7 @@ end)
 					self.parts.wpn_fps_pis_1911_co_2.supported = true
 					self.parts.wpn_fps_pis_1911_co_2.stats = deep_clone(muzzle_device.muzz_acc_c)
 					self.parts.wpn_fps_pis_1911_co_2.custom_stats = deep_clone(muzzle_device.muzz_acc_c)
-					
+
 					--Bling Grip
 					self.parts.wpn_fps_pis_1911_g_bling.pcs = {
 						10,
@@ -4336,7 +4336,7 @@ end)
 					}
 					self.parts.wpn_fps_pis_1911_g_bling.supported = true
 					self.parts.wpn_fps_pis_1911_g_bling.stats = deep_clone(grips.recoil_1)
-					
+
 					--Ergo Grip
 					self.parts.wpn_fps_pis_1911_g_ergo.pcs = {
 						10,
@@ -4362,22 +4362,22 @@ end)
 						extra_ammo = 4,
 						reload = -3
 					}
-					
+
 					--fix for static ironsights while ADS
 					self.wpn_fps_pis_1911.animations = {
-						reload = "reload", 
-						fire = "recoil", 
-						fire_steelsight = "recoil", 
+						reload = "reload",
+						fire = "recoil",
+						fire_steelsight = "recoil",
 						magazine_empty = "last_recoil"
 					}
 
 					table.insert(self.wpn_fps_pis_1911.uses_parts, "wpn_fps_upg_vg_ass_smg_verticalgrip")
 					table.insert(self.wpn_fps_pis_1911.uses_parts, "wpn_fps_upg_vg_ass_smg_stubby")
 					table.insert(self.wpn_fps_pis_1911.uses_parts, "wpn_fps_smg_schakal_vg_surefire")
-					
+
 					table.insert(self.wpn_fps_pis_1911.uses_parts, "wpn_fps_upg_santa_slayers_legend")
 
-					self.wpn_fps_pis_1911_npc.uses_parts = deep_clone(self.wpn_fps_pis_1911.uses_parts)	
+					self.wpn_fps_pis_1911_npc.uses_parts = deep_clone(self.wpn_fps_pis_1911.uses_parts)
 
 					self.wpn_fps_pis_1911_primary = nil
 					self.wpn_fps_pis_1911_primary_npc = nil
@@ -4411,15 +4411,15 @@ end)
 						stats = {
 							value = 2,
 							concealment = -2,
-							extra_ammo = 12,		
+							extra_ammo = 12,
 							reload = -4
 						}
 					}
 
 					table.insert(self.wpn_fps_x_1911.uses_parts, "wpn_fps_upg_santa_slayers_legend")
 
-					self.wpn_fps_x_1911_npc.override = deep_clone(self.wpn_fps_x_1911.override)	
-					self.wpn_fps_x_1911_npc.uses_parts = deep_clone(self.wpn_fps_x_1911.uses_parts)	
+					self.wpn_fps_x_1911_npc.override = deep_clone(self.wpn_fps_x_1911.override)
+					self.wpn_fps_x_1911_npc.uses_parts = deep_clone(self.wpn_fps_x_1911.uses_parts)
 				end)
 
 			--M1911
@@ -4442,7 +4442,7 @@ end)
 					self.parts.wpn_fps_pis_m1911_m_extended.custom_stats = {
 						ads_speed_mult = 0.975
 					}
-					
+
 					--Crosskill Platinum Bull Slide
 					self.parts.wpn_fps_pis_m1911_sl_match.pcs = {
 						10,
@@ -4456,7 +4456,7 @@ end)
 						recoil = 2,
 						concealment = -1
 					}
-					
+
 					--Chunky Hunter Slide
 					self.parts.wpn_fps_pis_m1911_sl_hardballer.pcs = {
 						10,
@@ -4467,7 +4467,7 @@ end)
 					self.parts.wpn_fps_pis_m1911_sl_hardballer.supported = true
 					self.parts.wpn_fps_pis_m1911_sl_hardballer.stats = deep_clone(barrels.long_b2_stats)
 					self.parts.wpn_fps_pis_m1911_sl_hardballer.custom_stats = deep_clone(barrels.long_b2_stats)
-					
+
 					self.wpn_fps_pis_m1911.override.wpn_fps_pis_1911_co_1 = {
 						a_obj = "a_ns",
 						parent = "barrel"
@@ -4476,18 +4476,18 @@ end)
 						a_obj = "a_ns",
 						parent = "barrel"
 					}
-						
+
 					table.insert(self.wpn_fps_pis_m1911.uses_parts, "wpn_fps_pis_1911_co_1")
 					table.insert(self.wpn_fps_pis_m1911.uses_parts, "wpn_fps_pis_1911_co_2")
 					table.insert(self.wpn_fps_pis_m1911.uses_parts, "wpn_fps_upg_vg_ass_smg_verticalgrip")
 					table.insert(self.wpn_fps_pis_m1911.uses_parts, "wpn_fps_upg_vg_ass_smg_stubby")
 
 					self.wpn_fps_pis_m1911_npc.override = deep_clone(self.wpn_fps_pis_m1911.override)
-					self.wpn_fps_pis_m1911_npc.uses_parts = deep_clone(self.wpn_fps_pis_m1911.uses_parts)	
+					self.wpn_fps_pis_m1911_npc.uses_parts = deep_clone(self.wpn_fps_pis_m1911.uses_parts)
 				end)
 				Hooks:PostHook(WeaponFactoryTweakData, "_init_x_m1911", "resmod_x_m1911", function(self)
 
-					self.wpn_fps_pis_x_m1911.override.wpn_fps_pis_m1911_m_extended = { 
+					self.wpn_fps_pis_x_m1911.override.wpn_fps_pis_m1911_m_extended = {
 						stats = {
 							value = 3,
 							concealment = -1,
@@ -4504,16 +4504,16 @@ end)
 						a_obj = "a_ns",
 						parent = "barrel"
 					}
-						
+
 					table.insert(self.wpn_fps_pis_x_m1911.uses_parts, "wpn_fps_pis_1911_co_1")
 					table.insert(self.wpn_fps_pis_x_m1911.uses_parts, "wpn_fps_pis_1911_co_2")
 
-					self.wpn_fps_pis_x_m1911_npc.uses_parts = deep_clone(self.wpn_fps_pis_x_m1911.uses_parts)	
+					self.wpn_fps_pis_x_m1911_npc.uses_parts = deep_clone(self.wpn_fps_pis_x_m1911.uses_parts)
 				end)
 
 			--USP
 				Hooks:PostHook(WeaponFactoryTweakData, "_init_usp", "resmod_usp", function(self)
-					
+
 					--Expert Slide
 					self.parts.wpn_fps_pis_usp_b_expert.pcs = {
 						10,
@@ -4524,7 +4524,7 @@ end)
 					self.parts.wpn_fps_pis_usp_b_expert.supported = true
 					self.parts.wpn_fps_pis_usp_b_expert.stats = deep_clone(barrels.long_b1_stats)
 					self.parts.wpn_fps_pis_usp_b_expert.custom_stats = deep_clone(barrels.long_b1_stats)
-					
+
 					--Match Slide
 					self.parts.wpn_fps_pis_usp_b_match.pcs = {
 						10,
@@ -4553,7 +4553,7 @@ end)
 					self.parts.wpn_fps_pis_usp_m_extended.custom_stats = {
 						ads_speed_mult = 1.025
 					}
-					
+
 					--Ventilated .45
 					self.parts.wpn_fps_pis_usp_co_comp_1.pcs = {
 						10,
@@ -4563,7 +4563,7 @@ end)
 					}
 					self.parts.wpn_fps_pis_usp_co_comp_1.supported = true
 					self.parts.wpn_fps_pis_usp_co_comp_1.stats = deep_clone(muzzle_device.muzz_rec_c)
-					
+
 					--Velocity .45
 					self.parts.wpn_fps_pis_usp_co_comp_2.pcs = {
 						10,
@@ -4580,10 +4580,10 @@ end)
 					table.insert(self.wpn_fps_pis_usp.uses_parts, "wpn_fps_upg_vg_ass_smg_stubby")
 					table.insert(self.wpn_fps_pis_usp.uses_parts, "wpn_fps_smg_schakal_vg_surefire")
 
-					self.wpn_fps_pis_usp_npc.uses_parts = deep_clone(self.wpn_fps_pis_usp.uses_parts)	
+					self.wpn_fps_pis_usp_npc.uses_parts = deep_clone(self.wpn_fps_pis_usp.uses_parts)
 				end)
 				Hooks:PostHook(WeaponFactoryTweakData, "_init_x_usp", "resmod_x_usp", function(self)
-					
+
 					--Override Tables
 					self.wpn_fps_pis_x_usp.override.wpn_fps_pis_usp_m_extended = {
 						animations = {
@@ -4625,7 +4625,7 @@ end)
 						10,
 						20,
 						30,
-						40	
+						40
 					}
 					self.parts.wpn_fps_pis_model3_b_short.supported = true
 					self.parts.wpn_fps_pis_model3_b_short.stats = {
@@ -4637,7 +4637,7 @@ end)
 						falloff_start_mult = 0.925,
 						falloff_end_mult = 0.925,
 						ads_speed_mult = 0.975
-					}		
+					}
 
 					--Long barrel
 					self.parts.wpn_fps_pis_model3_b_long.pcs = {
@@ -4656,8 +4656,8 @@ end)
 						falloff_start_mult = 1.075,
 						falloff_end_mult = 1.075,
 						ads_speed_mult = 1.025
-					}	
-						
+					}
+
 					--Bling Grip
 					self.parts.wpn_fps_pis_model3_g_bling.pcs = {
 						10,
@@ -4684,7 +4684,7 @@ end)
 					self.parts.wpn_fps_pis_2006m_b_long.supported = true
 					self.parts.wpn_fps_pis_2006m_b_long.stats = deep_clone(barrels.long_b2_stats)
 					self.parts.wpn_fps_pis_2006m_b_long.custom_stats = deep_clone(barrels.long_b2_stats)
-					
+
 					--Medio Barrel
 					self.parts.wpn_fps_pis_2006m_b_medium.pcs = {
 						10,
@@ -4695,7 +4695,7 @@ end)
 					self.parts.wpn_fps_pis_2006m_b_medium.supported = true
 					self.parts.wpn_fps_pis_2006m_b_medium.stats = deep_clone(barrels.short_b1_stats)
 					self.parts.wpn_fps_pis_2006m_b_medium.custom_stats = deep_clone(barrels.short_b1_stats)
-					
+
 					--Piccolo Barrel
 					self.parts.wpn_fps_pis_2006m_b_short.pcs = {
 						10,
@@ -4723,7 +4723,7 @@ end)
 					table.insert(self.wpn_fps_pis_2006m.uses_parts, "wpn_fps_upg_vg_ass_smg_stubby")
 					table.insert(self.wpn_fps_pis_2006m.uses_parts, "wpn_fps_smg_schakal_vg_surefire")
 
-					self.wpn_fps_pis_2006m_npc.uses_parts = deep_clone(self.wpn_fps_pis_2006m.uses_parts)		
+					self.wpn_fps_pis_2006m_npc.uses_parts = deep_clone(self.wpn_fps_pis_2006m.uses_parts)
 				end)
 				Hooks:PostHook(WeaponFactoryTweakData, "_init_x_2006m", "resmod_x_2006m", function(self)
 					--Nada!
@@ -4805,7 +4805,7 @@ end)
 					self.parts.wpn_fps_pis_korth_conversionkit.supported = true
 					self.parts.wpn_fps_pis_korth_conversionkit.has_description = true
 					self.parts.wpn_fps_pis_korth_conversionkit.desc_id = "bm_ap_weapon_sc_desc"
-					self.parts.wpn_fps_pis_korth_conversionkit.stats = { 
+					self.parts.wpn_fps_pis_korth_conversionkit.stats = {
 						value = 10,
 						recoil = -6,
 						spread = 3,
@@ -4885,7 +4885,7 @@ end)
 					self.parts.wpn_fps_pis_chinchilla_b_satan.supported = true
 					self.parts.wpn_fps_pis_chinchilla_b_satan.stats = deep_clone(barrels.long_b3_stats)
 					self.parts.wpn_fps_pis_chinchilla_b_satan.custom_stats = deep_clone(barrels.long_b3_stats)
-					
+
 					--Carnival Grip
 					self.parts.wpn_fps_pis_chinchilla_g_black.pcs = {
 						10,
@@ -4896,7 +4896,7 @@ end)
 					self.parts.wpn_fps_pis_chinchilla_g_black.supported = true
 					self.parts.wpn_fps_pis_chinchilla_g_black.stats = deep_clone(grips.quickdraw_1)
 					self.parts.wpn_fps_pis_chinchilla_g_black.custom_stats = deep_clone(grips.quickdraw_1)
-					
+
 					--Cruz Grip
 					self.parts.wpn_fps_pis_chinchilla_g_death.pcs = {
 						10,
@@ -4951,7 +4951,7 @@ end)
 
 			--RAGING BULL
 				Hooks:PostHook(WeaponFactoryTweakData, "_init_raging_bull", "resmod_raging_bull", function(self)
-					
+
 					--Aggressor Barrel
 					self.parts.wpn_fps_pis_rage_b_comp1.pcs = {
 						10,
@@ -4962,7 +4962,7 @@ end)
 					self.parts.wpn_fps_pis_rage_b_comp1.supported = true
 					self.parts.wpn_fps_pis_rage_b_comp1.stats = deep_clone(muzzle_device.muzz_acc_c)
 					self.parts.wpn_fps_pis_rage_b_comp1.custom_stats = deep_clone(muzzle_device.muzz_acc_c)
-					
+
 					--Ventilated Barrel
 					self.parts.wpn_fps_pis_rage_b_comp2.pcs = {
 						10,
@@ -4984,7 +4984,7 @@ end)
 					self.parts.wpn_fps_pis_rage_b_long.supported = true
 					self.parts.wpn_fps_pis_rage_b_long.stats = deep_clone(barrels.long_b2_stats)
 					self.parts.wpn_fps_pis_rage_b_long.custom_stats = deep_clone(barrels.long_b2_stats)
-					
+
 					--Pocket Surprise Barrel
 					self.parts.wpn_fps_pis_rage_b_short.pcs = {
 						10,
@@ -5029,7 +5029,7 @@ end)
 							value = 1
 						}
 					}
-					
+
 					--Bronco .44 Part Additions
 					table.insert(self.wpn_fps_pis_rage.uses_parts, "wpn_fps_pis_g18c_co_comp_2")
 					table.insert(self.wpn_fps_pis_rage.uses_parts, "wpn_fps_upg_fl_pis_m3x")
@@ -5048,9 +5048,9 @@ end)
 						parent = "shitass",
 						a_obj = "a_vg"
 					}
-					
-					self.wpn_fps_pis_rage_npc.override = deep_clone(self.wpn_fps_pis_rage.override)	
-					self.wpn_fps_pis_rage_npc.uses_parts = deep_clone(self.wpn_fps_pis_rage.uses_parts)	
+
+					self.wpn_fps_pis_rage_npc.override = deep_clone(self.wpn_fps_pis_rage.override)
+					self.wpn_fps_pis_rage_npc.uses_parts = deep_clone(self.wpn_fps_pis_rage.uses_parts)
 
 					self.wpn_fps_pis_rage_primary = nil
 					self.wpn_fps_pis_rage_primary_npc = nil
@@ -5070,7 +5070,7 @@ end)
 
 					self.wpn_fps_pis_x_rage.override = {
 						wpn_fps_pis_rage_body_standard = {
-							animations = {		
+							animations = {
 								reload_left = "reload",
 								fire = "recoil",
 								fire_steelsight = "recoil",
@@ -5103,7 +5103,7 @@ end)
 					table.insert(self.wpn_fps_pis_x_rage.uses_parts, "wpn_fps_upg_fl_pis_laser")
 					table.insert(self.wpn_fps_pis_x_rage.uses_parts, "wpn_fps_upg_fl_pis_tlr1")
 					table.insert(self.wpn_fps_pis_x_rage.uses_parts, "wpn_fps_upg_fl_pis_perst")
-						
+
 					self.wpn_fps_pis_x_rage_npc.adds = deep_clone(self.wpn_fps_pis_x_rage.adds)
 					self.wpn_fps_pis_x_rage_npc.override = deep_clone(self.wpn_fps_pis_x_rage.override)
 					self.wpn_fps_pis_x_rage_npc.uses_parts = deep_clone(self.wpn_fps_pis_x_rage.uses_parts)
@@ -5133,7 +5133,7 @@ end)
 					self.parts.wpn_fps_pis_deagle_co_long.supported = true
 					self.parts.wpn_fps_pis_deagle_co_long.stats = deep_clone(muzzle_device.muzz_dual_c)
 					self.parts.wpn_fps_pis_deagle_co_long.custom_stats = deep_clone(muzzle_device.muzz_dual_c)
-					
+
 					--La Femme Compensator
 					self.parts.wpn_fps_pis_deagle_co_short.pcs = {
 						10,
@@ -5153,7 +5153,7 @@ end)
 					}
 					self.parts.wpn_fps_pis_deagle_g_bling.supported = true
 					self.parts.wpn_fps_pis_deagle_g_bling.stats = deep_clone(grips.recoil_1)
-					
+
 					--(Deagle) Ergo Grip
 					self.parts.wpn_fps_pis_deagle_g_ergo.pcs = {
 						10,
@@ -5183,7 +5183,7 @@ end)
 					}
 
 					self.parts.wpn_fps_pis_deagle_ck.supported = true
-					self.parts.wpn_fps_pis_deagle_ck.stats = { 
+					self.parts.wpn_fps_pis_deagle_ck.stats = {
 						value = 9,
 						recoil = 6,
 						spread = 1,
@@ -5237,7 +5237,7 @@ end)
 							third_unit = "units/payday2/weapons/wpn_upg_dummy/wpn_upg_dummy"
 						}
 					}
-					
+
 					self.wpn_fps_pis_deagle.override = self.wpn_fps_pis_deagle.override or {}
 					self.wpn_fps_pis_deagle.override.wpn_fps_upg_i_autofire = {
 						stats = {
@@ -5249,7 +5249,7 @@ end)
 							rof_mult = 1.470588,
 							falloff_start_mult = 0.25,
 							falloff_end_mult = 0.75
-						}			
+						}
 					}
 
 					--Dunno what this does but it makes the game explode
@@ -5258,7 +5258,7 @@ end)
 
 					self.wpn_fps_pis_deagle_npc.override = deep_clone(self.wpn_fps_pis_deagle.override)
 
-					--Deagle Additional Parts	
+					--Deagle Additional Parts
 					table.insert(self.wpn_fps_pis_deagle.uses_parts, "wpn_fps_upg_midas_touch_legend")
 					table.insert(self.wpn_fps_pis_deagle.uses_parts, "wpn_fps_pis_g18c_co_comp_2")
 					table.insert(self.wpn_fps_pis_deagle.uses_parts, "wpn_fps_upg_i_autofire")
@@ -5288,12 +5288,12 @@ end)
 							extra_ammo = 10
 						}
 					}
-					
+
 					--Extra Barrel Extensions
 					table.insert(self.wpn_fps_x_deagle.uses_parts, "wpn_fps_pis_g18c_co_comp_2")
-					
-					self.wpn_fps_x_deagle_npc.override = deep_clone(self.wpn_fps_x_deagle.override)	
-					self.wpn_fps_x_deagle_npc.uses_parts = deep_clone(self.wpn_fps_x_deagle.uses_parts)	
+
+					self.wpn_fps_x_deagle_npc.override = deep_clone(self.wpn_fps_x_deagle.override)
+					self.wpn_fps_x_deagle_npc.uses_parts = deep_clone(self.wpn_fps_x_deagle.uses_parts)
 				end)
 
 			--SINGLE ACTION ARMY
@@ -5309,7 +5309,7 @@ end)
 					self.parts.wpn_fps_pis_peacemaker_b_long.supported = true
 					self.parts.wpn_fps_pis_peacemaker_b_long.stats = deep_clone(barrels.long_b3_stats)
 					self.parts.wpn_fps_pis_peacemaker_b_long.custom_stats = deep_clone(barrels.long_b3_stats)
-					
+
 					--Shootout Barrel
 					self.parts.wpn_fps_pis_peacemaker_b_short.pcs = {
 						10,
@@ -5330,7 +5330,7 @@ end)
 					}
 					self.parts.wpn_fps_pis_peacemaker_g_bling.supported = true
 					self.parts.wpn_fps_pis_peacemaker_g_bling.stats = deep_clone(grips.recoil_1)
-					
+
 					--Ol´ Ben's Stock
 					self.parts.wpn_fps_pis_peacemaker_s_skeletal.pcs = {
 						10,
@@ -5374,7 +5374,7 @@ end)
 					self.parts.wpn_fps_hailstorm_b_extended.supported = true
 					self.parts.wpn_fps_hailstorm_b_extended.stats = deep_clone(barrels.long_b2_stats)
 					self.parts.wpn_fps_hailstorm_b_extended.custom_stats = deep_clone(barrels.long_b2_stats)
-						
+
 					--Suppressed Barrel
 					self.parts.wpn_fps_hailstorm_b_suppressed.supported = true
 					self.parts.wpn_fps_hailstorm_b_suppressed.perks = {"silencer"}
@@ -5420,7 +5420,7 @@ end)
 					--Exclusive Set
 					self.parts.wpn_fps_hailstorm_conversion.supported = true
 					self.parts.wpn_fps_hailstorm_conversion.has_description = false
-					self.parts.wpn_fps_hailstorm_conversion.stats = { 
+					self.parts.wpn_fps_hailstorm_conversion.stats = {
 						value = 8,
 						recoil = 4,
 					}
@@ -5500,8 +5500,8 @@ end)
 					self.wpn_fps_hailstorm.override = self.wpn_fps_hailstorm.override or {}
 
 					--table.insert(self.wpn_fps_hailstorm.uses_parts, "wpn_fps_upg_o_arbiter_irons_dmc")
-							
-					self.wpn_fps_hailstorm_npc.uses_parts = deep_clone(self.wpn_fps_hailstorm.uses_parts)	
+
+					self.wpn_fps_hailstorm_npc.uses_parts = deep_clone(self.wpn_fps_hailstorm.uses_parts)
 				end)
 
 			--PP19 BIZON
@@ -5572,22 +5572,22 @@ end)
 					}
 
 					--New Parts
-					table.insert(self.wpn_fps_smg_coal.uses_parts, "wpn_upg_ak_s_psl")	
+					table.insert(self.wpn_fps_smg_coal.uses_parts, "wpn_upg_ak_s_psl")
 					table.insert(self.wpn_fps_smg_coal.uses_parts, "wpn_fps_upg_ak_g_rk3")
 					table.insert(self.wpn_fps_smg_coal.uses_parts, "wpn_fps_upg_m4_s_ubr")
-					table.insert(self.wpn_fps_smg_coal.uses_parts, "wpn_fps_upg_m4_s_crane")	
+					table.insert(self.wpn_fps_smg_coal.uses_parts, "wpn_fps_upg_m4_s_crane")
 					table.insert(self.wpn_fps_smg_coal.uses_parts, "wpn_fps_upg_m4_s_mk46")
 					table.insert(self.wpn_fps_smg_coal.uses_parts, "wpn_fps_snp_victor_s_mod0")
-					table.insert(self.wpn_fps_smg_coal.uses_parts, "wpn_fps_upg_m4_s_standard")		
-					table.insert(self.wpn_fps_smg_coal.uses_parts, "wpn_fps_upg_m4_s_pts")		
-					table.insert(self.wpn_fps_smg_coal.uses_parts, "wpn_fps_snp_tti_s_vltor")	
+					table.insert(self.wpn_fps_smg_coal.uses_parts, "wpn_fps_upg_m4_s_standard")
+					table.insert(self.wpn_fps_smg_coal.uses_parts, "wpn_fps_upg_m4_s_pts")
+					table.insert(self.wpn_fps_smg_coal.uses_parts, "wpn_fps_snp_tti_s_vltor")
 					table.insert(self.wpn_fps_smg_coal.uses_parts, "wpn_fps_lmg_rpk_s_standard")
 					table.insert(self.wpn_fps_smg_coal.uses_parts, "wpn_fps_upg_ak_s_solidstock")
 					table.insert(self.wpn_fps_smg_coal.uses_parts, "wpn_fps_upg_i_singlefire")
 					table.insert(self.wpn_fps_smg_coal.uses_parts, "wpn_fps_upg_i_autofire")
 
-					self.wpn_fps_smg_coal_npc.override = deep_clone(self.wpn_fps_smg_coal.override)	
-					self.wpn_fps_smg_coal_npc.uses_parts = deep_clone(self.wpn_fps_smg_coal.uses_parts)	
+					self.wpn_fps_smg_coal_npc.override = deep_clone(self.wpn_fps_smg_coal.override)
+					self.wpn_fps_smg_coal_npc.uses_parts = deep_clone(self.wpn_fps_smg_coal.uses_parts)
 				end)
 
 			--PM9
@@ -5624,9 +5624,9 @@ end)
 							prefix = "g_bullet_"
 						},
 						stats = {
-							value = 4, 
-							extra_ammo = 7, 
-							reload = -3, 
+							value = 4,
+							extra_ammo = 7,
+							reload = -3,
 							concealment = -1
 						},
 						custom_stats = { ads_speed_mult = 1.025},
@@ -5635,7 +5635,7 @@ end)
 							reload = "reload"
 						}
 					}
-					
+
 					--Short Barrel
 					self.parts.wpn_fps_smg_pm9_b_short.pcs = {
 						10,
@@ -5645,8 +5645,8 @@ end)
 					}
 					self.parts.wpn_fps_smg_pm9_b_short.supported = true
 					self.parts.wpn_fps_smg_pm9_b_short.stats = deep_clone(barrels.short_b1_stats)
-					self.parts.wpn_fps_smg_pm9_b_short.custom_stats = deep_clone(barrels.short_b1_stats)		
-					
+					self.parts.wpn_fps_smg_pm9_b_short.custom_stats = deep_clone(barrels.short_b1_stats)
+
 					--Wood Grip
 					self.parts.wpn_fps_smg_pm9_g_wood.pcs = {
 						10,
@@ -5656,7 +5656,7 @@ end)
 					}
 					self.parts.wpn_fps_smg_pm9_g_wood.supported = true
 					self.parts.wpn_fps_smg_pm9_g_wood.stats = deep_clone(grips.recoil_1)
-					
+
 					--Tac Stock
 					self.parts.wpn_fps_smg_pm9_s_tactical.pcs = {
 						10,
@@ -5665,16 +5665,16 @@ end)
 						40
 					}
 					self.parts.wpn_fps_smg_pm9_s_tactical.supported = true
-					self.parts.wpn_fps_smg_pm9_s_tactical.stats = deep_clone(stocks.add_fixed_stats)	
-					self.parts.wpn_fps_smg_pm9_s_tactical.custom_stats = deep_clone(stocks.add_fixed_stats)	
+					self.parts.wpn_fps_smg_pm9_s_tactical.stats = deep_clone(stocks.add_fixed_stats)
+					self.parts.wpn_fps_smg_pm9_s_tactical.custom_stats = deep_clone(stocks.add_fixed_stats)
 
 
 					table.insert(self.wpn_fps_smg_pm9.uses_parts, "wpn_fps_smg_pm9_m_extended")
 					table.insert(self.wpn_fps_smg_pm9.uses_parts, "wpn_fps_upg_vg_ass_smg_verticalgrip")
 					table.insert(self.wpn_fps_smg_pm9.uses_parts, "wpn_fps_upg_vg_ass_smg_stubby")
 					table.insert(self.wpn_fps_smg_pm9.uses_parts, "wpn_fps_smg_schakal_vg_surefire")
-					
-					self.wpn_fps_smg_pm9_npc.uses_parts = deep_clone(self.wpn_fps_smg_pm9.uses_parts)	
+
+					self.wpn_fps_smg_pm9_npc.uses_parts = deep_clone(self.wpn_fps_smg_pm9.uses_parts)
 				end)
 
 			--MPX
@@ -5696,7 +5696,7 @@ end)
 					self.parts.wpn_fps_smg_shepheard_body_short.supported = true
 					self.parts.wpn_fps_smg_shepheard_body_short.stats = deep_clone(barrels.short_b1_stats)
 					self.parts.wpn_fps_smg_shepheard_body_short.custom_stats = deep_clone(barrels.short_b1_stats)
-					
+
 					--Standard Magazine Swap
 					self.parts.wpn_fps_smg_shepheard_mag_standard.unit = "units/pd2_dlc_joy/weapons/wpn_fps_smg_shepheard_pts/wpn_fps_smg_shepheard_mag_extended"
 					self.parts.wpn_fps_smg_shepheard_mag_standard.bullet_objects = {
@@ -5704,7 +5704,7 @@ end)
 						prefix = "g_bullet_"
 					}
 					self.parts.wpn_fps_smg_shepheard_mag_standard.third_unit = "units/pd2_dlc_joy/weapons/wpn_fps_smg_shepheard_pts/wpn_third_smg_shepheard_mag_extended"
-					
+
 					--Short Mag (Formerly Extended Magazine)
 					self.parts.wpn_fps_smg_shepheard_mag_extended.name_id = "bm_wp_sterling_m_short"
 					self.parts.wpn_fps_smg_shepheard_mag_extended.unit = "units/pd2_dlc_joy/weapons/wpn_fps_smg_shepheard_pts/wpn_fps_smg_shepheard_mag_standard"
@@ -5729,7 +5729,7 @@ end)
 					self.parts.wpn_fps_smg_shepheard_mag_extended.custom_stats = {
 						ads_speed_mult = 0.95
 					}
-					
+
 					--No Stock
 					self.parts.wpn_fps_smg_shepheard_s_no.pcs = {
 						10,
@@ -5777,7 +5777,7 @@ end)
 						stats = deep_clone(stocks.nocheeks_to_hvy_acc2_rec1_stats),
 						custom_stats = deep_clone(stocks.nocheeks_to_hvy_acc2_rec1_stats)
 					}
-					
+
 					table.insert(self.wpn_fps_smg_shepheard.uses_parts, "wpn_fps_upg_m4_s_standard")
 					table.insert(self.wpn_fps_smg_shepheard.uses_parts, "wpn_fps_snp_tti_s_vltor")
 					table.insert(self.wpn_fps_smg_shepheard.uses_parts, "wpn_fps_smg_shepheard_cnuy_yuuka")
@@ -5837,7 +5837,7 @@ end)
 					self.parts.wpn_fps_smg_p90_b_long.supported = true
 					self.parts.wpn_fps_smg_p90_b_long.stats = deep_clone(barrels.long_b2_stats)
 					self.parts.wpn_fps_smg_p90_b_long.custom_stats = deep_clone(barrels.long_b2_stats)
-					
+
 					--(Kobus 90) Tan Body
 					self.parts.wpn_fps_smg_p90_body_p90_tan = {
 						pcs = {},
@@ -5856,7 +5856,7 @@ end)
 						forbids = { "wpn_fps_addon_ris" }
 					}
 					self.parts.wpn_fps_smg_p90_body_p90_tan.third_unit = "units/payday2/weapons/wpn_third_smg_p90_pts/wpn_third_smg_p90_body_p90"
-					
+
 					--Kobus 90 Part Additions
 					--Tan Body
 					table.insert(self.wpn_fps_smg_p90.uses_parts, "wpn_fps_upg_salad_legend")
@@ -5874,7 +5874,7 @@ end)
 							big_scope = true
 						}
 					}
-					
+
 					self.wpn_fps_smg_p90_npc.override = deep_clone(self.wpn_fps_smg_p90.override)
 					self.wpn_fps_smg_p90_npc.uses_parts = deep_clone(self.wpn_fps_smg_p90.uses_parts)
 				end)
@@ -5892,7 +5892,7 @@ end)
 								self.wpn_fps_smg_x_p90.uses_parts[i] = "wpn_fps_upg_vg_ass_smg_stubby_vanilla"
 							end
 						end
-					end	
+					end
 
 					--Kobus 90 Part Additions
 					table.insert(self.wpn_fps_smg_x_p90.uses_parts, "wpn_fps_smg_p90_body_p90_tan")
@@ -5900,7 +5900,7 @@ end)
 					table.insert(self.wpn_fps_smg_x_p90.uses_parts, "wpn_fps_upg_o_schmidt_magnified")
 
 					self.wpn_fps_smg_x_p90.override = self.wpn_fps_smg_x_p90.override or {}
-					
+
 					self.wpn_fps_smg_x_p90_npc.override = deep_clone(self.wpn_fps_smg_x_p90.override)
 					self.wpn_fps_smg_x_p90_npc.uses_parts = deep_clone(self.wpn_fps_smg_x_p90.uses_parts)
 				end)
@@ -6027,13 +6027,13 @@ end)
 					self.parts.wpn_fps_smg_tec9_b_standard.supported = true
 					self.parts.wpn_fps_smg_tec9_b_standard.stats = deep_clone(barrels.short_b1_stats)
 					self.parts.wpn_fps_smg_tec9_b_standard.custom_stats = deep_clone(barrels.short_b1_stats)
-					
+
 					--Ghetto Blaster
 					self.parts.wpn_fps_smg_tec9_ns_ext.pcs = {}
 					self.parts.wpn_fps_smg_tec9_ns_ext.supported = true
 					self.parts.wpn_fps_smg_tec9_ns_ext.stats = deep_clone(barrels.long_b2_stats)
 					self.parts.wpn_fps_smg_tec9_ns_ext.custom_stats = deep_clone(barrels.long_b2_stats)
-					
+
 					--Extended Mag
 					self.parts.wpn_fps_smg_tec9_m_extended.pcs = {}
 					self.parts.wpn_fps_smg_tec9_m_extended.supported = true
@@ -6046,7 +6046,7 @@ end)
 						reload = -5,
 						concealment = -3
 					}
-					
+
 					--Just Bend It
 					self.parts.wpn_fps_smg_tec9_s_unfolded.pcs = {}
 					self.parts.wpn_fps_smg_tec9_s_unfolded.supported = true
@@ -6056,7 +6056,7 @@ end)
 					--[
 					self.wpn_fps_smg_tec9.stock_adapter = "wpn_fps_smg_shepheard_s_adapter"
 					self.wpn_fps_smg_tec9_npc.stock_adapter = "wpn_fps_smg_shepheard_s_adapter"
-					
+
 					self.wpn_fps_smg_tec9.override = self.wpn_fps_smg_tec9.override or {}
 					self.wpn_fps_smg_tec9.override.wpn_fps_upg_o_specter = { forbids = {"wpn_fps_gre_arbiter_o_standard_no_forbid"} }
 					self.wpn_fps_smg_tec9.override.wpn_fps_upg_o_aimpoint = { forbids = {"wpn_fps_gre_arbiter_o_standard_no_forbid"} }
@@ -6127,8 +6127,8 @@ end)
 						custom_stats = deep_clone(stocks.add_hvy_acc_stats),
 						adds = { "wpn_fps_shot_r870_ris_special", "wpn_fps_gre_arbiter_o_standard_no_forbid" },
 						forbids = {}
-					}	
-					self.wpn_fps_smg_tec9.override.wpn_fps_gre_arbiter_o_standard_no_forbid = { 
+					}
+					self.wpn_fps_smg_tec9.override.wpn_fps_gre_arbiter_o_standard_no_forbid = {
 						stance_mod = {
 							wpn_fps_smg_tec9 = {
 								translation = Vector3(0, -3, -4.6)
@@ -6169,10 +6169,10 @@ end)
 					self.parts.wpn_fps_smg_mp9_m_extended.custom_stats = {
 						ads_speed_mult = 1.025
 					}
-					
+
 					--(CMP) Skeletal Stock
 					self.parts.wpn_fps_smg_mp9_s_skel.pcs = {
-						10,		
+						10,
 						20,
 						30,
 						40
@@ -6190,7 +6190,7 @@ end)
 						}
 					}
 
-					--CMP Part Table	
+					--CMP Part Table
 					for i, part_id in pairs(self.wpn_fps_smg_mp9.uses_parts) do
 						attachment_list = {
 							"wpn_fps_upg_vg_ass_smg_stubby"
@@ -6200,7 +6200,7 @@ end)
 								self.wpn_fps_smg_mp9.uses_parts[i] = "wpn_fps_upg_vg_ass_smg_stubby_vanilla"
 							end
 						end
-					end	
+					end
 
 					table.insert(self.wpn_fps_smg_mp9.uses_parts, "wpn_fps_smg_mac10_s_no")
 					table.insert(self.wpn_fps_smg_mp9.uses_parts, "wpn_fps_upg_vg_ass_smg_verticalgrip")
@@ -6254,21 +6254,21 @@ end)
 						stats = deep_clone(stocks.remove_folder_stats),
 						custom_stats = deep_clone(stocks.remove_folder_stats)
 					}
-					
+
 					self.wpn_fps_smg_mp9_npc.override = deep_clone(self.wpn_fps_smg_mp9.override)
 					self.wpn_fps_smg_mp9_npc.uses_parts = deep_clone(self.wpn_fps_smg_mp9.uses_parts)
 				end)
 
 			--M11/9
 				Hooks:PostHook(WeaponFactoryTweakData, "_init_cobray", "resmod_cobray", function(self)
-					
+
 					--80's Calling
 					self.parts.wpn_fps_smg_cobray_body_upper_jacket.pcs = {}
 					self.parts.wpn_fps_smg_cobray_body_upper_jacket.supported = true
 					self.parts.wpn_fps_smg_cobray_body_upper_jacket.stats = {
 						value = 0
 					}
-					
+
 					--Slotted Barrel Extension
 					self.parts.wpn_fps_smg_cobray_ns_barrelextension.pcs = {
 						10,
@@ -6279,7 +6279,7 @@ end)
 					self.parts.wpn_fps_smg_cobray_ns_barrelextension.supported = true
 					self.parts.wpn_fps_smg_cobray_ns_barrelextension.stats = deep_clone(barrels.long_b2_stats)
 					self.parts.wpn_fps_smg_cobray_ns_barrelextension.custom_stats = deep_clone(barrels.long_b2_stats)
-					
+
 					--Werbell's Suppressor
 					self.parts.wpn_fps_smg_cobray_ns_silencer.pcs = {
 						10,
@@ -6346,12 +6346,12 @@ end)
 								self.wpn_fps_smg_cobray.uses_parts[i] = "wpn_fps_upg_vg_ass_smg_stubby_vanilla"
 							end
 						end
-					end	
-					
+					end
+
 					table.insert(self.wpn_fps_smg_cobray.uses_parts, "wpn_fps_smg_mac10_s_skel")
-					table.insert(self.wpn_fps_smg_cobray.uses_parts, "wpn_fps_smg_mac10_s_no")	
-						
-					self.wpn_fps_smg_cobray_npc.uses_parts = deep_clone(self.wpn_fps_smg_cobray.uses_parts)		
+					table.insert(self.wpn_fps_smg_cobray.uses_parts, "wpn_fps_smg_mac10_s_no")
+
+					self.wpn_fps_smg_cobray_npc.uses_parts = deep_clone(self.wpn_fps_smg_cobray.uses_parts)
 				end)
 				Hooks:PostHook(WeaponFactoryTweakData, "_init_x_cobray", "resmod_cobray", function(self)
 					--Disabling Vertical Grip Mods
@@ -6366,17 +6366,17 @@ end)
 								self.wpn_fps_smg_x_cobray.uses_parts[i] = "wpn_fps_upg_vg_ass_smg_stubby_vanilla"
 							end
 						end
-					end	
-					
+					end
+
 					table.insert(self.wpn_fps_smg_x_cobray.uses_parts, "wpn_fps_smg_mac10_s_skel")
-					table.insert(self.wpn_fps_smg_x_cobray.uses_parts, "wpn_fps_smg_mac10_s_no")	
-						
-					self.wpn_fps_smg_x_cobray_npc.uses_parts = deep_clone(self.wpn_fps_smg_x_cobray.uses_parts)		
+					table.insert(self.wpn_fps_smg_x_cobray.uses_parts, "wpn_fps_smg_mac10_s_no")
+
+					self.wpn_fps_smg_x_cobray_npc.uses_parts = deep_clone(self.wpn_fps_smg_x_cobray.uses_parts)
 				end)
 
 			--SR2M
 				Hooks:PostHook(WeaponFactoryTweakData, "_init_sr2", "resmod_sr2", function(self)
-					
+
 					--Unfolded Stock
 					self.parts.wpn_fps_smg_sr2_s_unfolded.pcs = {
 						10,
@@ -6388,7 +6388,7 @@ end)
 					self.parts.wpn_fps_smg_sr2_s_unfolded.stats = deep_clone(stocks.unfold_nocheeks_stats)
 					self.parts.wpn_fps_smg_sr2_s_unfolded.stats.value = 0
 					self.parts.wpn_fps_smg_sr2_s_unfolded.custom_stats = deep_clone(stocks.unfold_nocheeks_stats)
-					
+
 					--Tishina Suppressor
 					self.parts.wpn_fps_smg_sr2_ns_silencer.pcs = {
 						10,
@@ -6412,7 +6412,7 @@ end)
 						stats = deep_clone(stocks.remove_folded_stats),
 						custom_stats = deep_clone(stocks.remove_folded_stats)
 					}
-					
+
 					table.insert(self.wpn_fps_smg_sr2.uses_parts, "wpn_fps_smg_mac10_s_no")
 
 					for i, part_id in pairs(self.wpn_fps_smg_sr2.uses_parts) do
@@ -6424,10 +6424,10 @@ end)
 								self.wpn_fps_smg_sr2.uses_parts[i] = "wpn_fps_upg_vg_ass_smg_stubby_vanilla"
 							end
 						end
-					end	
+					end
 
-					self.wpn_fps_smg_sr2_npc.override = deep_clone(self.wpn_fps_smg_sr2.override)	
-					self.wpn_fps_smg_sr2_npc.uses_parts = deep_clone(self.wpn_fps_smg_sr2.uses_parts)	
+					self.wpn_fps_smg_sr2_npc.override = deep_clone(self.wpn_fps_smg_sr2.override)
+					self.wpn_fps_smg_sr2_npc.uses_parts = deep_clone(self.wpn_fps_smg_sr2.uses_parts)
 				end)
 				Hooks:PostHook(WeaponFactoryTweakData, "_init_x_sr2", "resmod_x_sr2", function(self)
 
@@ -6436,17 +6436,17 @@ end)
 						stats = deep_clone(stocks.remove_folded_stats),
 						custom_stats = deep_clone(stocks.remove_folded_stats)
 					}
-					
-					table.insert(self.wpn_fps_smg_x_sr2.uses_parts, "wpn_fps_smg_sr2_s_unfolded")	
-					table.insert(self.wpn_fps_smg_x_sr2.uses_parts, "wpn_fps_smg_mac10_s_no")	
-					
-					self.wpn_fps_smg_x_sr2_npc.override = deep_clone(self.wpn_fps_smg_x_sr2.override)	
-					self.wpn_fps_smg_x_sr2_npc.uses_parts = deep_clone(self.wpn_fps_smg_x_sr2.uses_parts)	
+
+					table.insert(self.wpn_fps_smg_x_sr2.uses_parts, "wpn_fps_smg_sr2_s_unfolded")
+					table.insert(self.wpn_fps_smg_x_sr2.uses_parts, "wpn_fps_smg_mac10_s_no")
+
+					self.wpn_fps_smg_x_sr2_npc.override = deep_clone(self.wpn_fps_smg_x_sr2.override)
+					self.wpn_fps_smg_x_sr2_npc.uses_parts = deep_clone(self.wpn_fps_smg_x_sr2.uses_parts)
 				end)
 
 			--MICRO UZI
 				Hooks:PostHook(WeaponFactoryTweakData, "_init_baka", "resmod_baka", function(self)
-					
+
 					--Custom Barrel
 					self.parts.wpn_fps_smg_baka_b_comp.pcs = {
 						10,
@@ -6460,7 +6460,7 @@ end)
 						spread = -1,
 						concealment = 1,
 					}
-					
+
 					--Maki Suppressor
 					self.parts.wpn_fps_smg_baka_b_midsupp.pcs = {
 						10,
@@ -6474,7 +6474,7 @@ end)
 						suppression = 12,
 						alert_size = -1
 					}
-					
+
 					--Spring Suppressor
 					self.parts.wpn_fps_smg_baka_b_smallsupp.pcs = {
 						10,
@@ -6488,7 +6488,7 @@ end)
 						suppression = 12,
 						alert_size = -1
 					}
-					
+
 					--Futomaki Suppressor
 					self.parts.wpn_fps_smg_baka_b_longsupp.pcs = {
 						10,
@@ -6502,7 +6502,7 @@ end)
 						suppression = 12,
 						alert_size = -1
 					}
-					
+
 					--No Stock
 					self.parts.wpn_fps_smg_baka_s_standard.pcs = {
 						10,
@@ -6514,7 +6514,7 @@ end)
 					self.parts.wpn_fps_smg_baka_s_standard.stats = deep_clone(stocks.remove_folded_stats)
 					self.parts.wpn_fps_smg_baka_s_standard.stats.value = 0
 					self.parts.wpn_fps_smg_baka_s_standard.custom_stats = deep_clone(stocks.remove_folded_stats)
-					
+
 					--Unfolded Stock
 					self.parts.wpn_fps_smg_baka_s_unfolded.pcs = {
 						10,
@@ -6530,14 +6530,14 @@ end)
 					table.insert(self.wpn_fps_smg_baka.uses_parts, "wpn_fps_upg_vg_ass_smg_verticalgrip")
 					table.insert(self.wpn_fps_smg_baka.uses_parts, "wpn_fps_upg_vg_ass_smg_stubby")
 					table.insert(self.wpn_fps_smg_baka.uses_parts, "wpn_fps_smg_schakal_vg_surefire")
-					
+
 					self.wpn_fps_smg_baka_npc.uses_parts = deep_clone(self.wpn_fps_smg_baka.uses_parts)
 				end)
 				Hooks:PostHook(WeaponFactoryTweakData, "_init_x_baka", "resmod_x_baka", function(self)
-					
+
 					table.insert(self.wpn_fps_smg_x_baka.uses_parts, "wpn_fps_smg_baka_s_standard")
 					table.insert(self.wpn_fps_smg_x_baka.uses_parts, "wpn_fps_smg_baka_s_unfolded")
-							
+
 					self.wpn_fps_smg_x_baka_npc.uses_parts = deep_clone(self.wpn_fps_smg_x_baka.uses_parts)
 				end)
 
@@ -6555,18 +6555,18 @@ end)
 						alert_size = -1
 					}
 					self.parts.wpn_fps_smg_scorpion_b_suppressed.perks = {"silencer"}
-					
+
 					--Wooden Grip
 					self.parts.wpn_fps_smg_scorpion_g_wood.pcs = {}
 					self.parts.wpn_fps_smg_scorpion_g_wood.supported = true
 					self.parts.wpn_fps_smg_scorpion_g_wood.stats = deep_clone(grips.recoil_1)
-					
+
 					--Ergo Grip
 					self.parts.wpn_fps_smg_scorpion_g_ergo.pcs = {}
 					self.parts.wpn_fps_smg_scorpion_g_ergo.supported = true
 					self.parts.wpn_fps_smg_scorpion_g_ergo.stats = deep_clone(grips.quickdraw_1)
 					self.parts.wpn_fps_smg_scorpion_g_ergo.custom_stats = deep_clone(grips.quickdraw_1)
-					
+
 					--Extended Mag (Fucking channelling the "extended" mag of the MP40 in CoD:WaW, lmao)
 					self.parts.wpn_fps_smg_scorpion_m_extended.pcs = {}
 					self.parts.wpn_fps_smg_scorpion_m_extended.supported = true
@@ -6576,7 +6576,7 @@ end)
 						spread = -1,
 						reload = 3
 					}
-					
+
 					--No Stock
 					self.parts.wpn_fps_smg_scorpion_s_nostock.pcs = {}
 					self.parts.wpn_fps_smg_scorpion_s_nostock.supported = true
@@ -6611,7 +6611,7 @@ end)
 					--[
 					self.wpn_fps_smg_scorpion.stock_adapter = "wpn_fps_gre_m32_stock_adapter"
 					self.wpn_fps_smg_scorpion_npc.stock_adapter = "wpn_fps_gre_m32_stock_adapter"
-					
+
 					table.insert(self.wpn_fps_smg_scorpion.uses_parts, "wpn_fps_upg_m4_s_standard")
 					table.insert(self.wpn_fps_smg_scorpion.uses_parts, "wpn_fps_upg_m4_s_pts")
 					table.insert(self.wpn_fps_smg_scorpion.uses_parts, "wpn_fps_upg_m4_s_crane")
@@ -6619,7 +6619,7 @@ end)
 					table.insert(self.wpn_fps_smg_scorpion.uses_parts, "wpn_fps_snp_victor_s_mod0")
 					table.insert(self.wpn_fps_smg_scorpion.uses_parts, "wpn_fps_upg_m4_s_ubr")
 					table.insert(self.wpn_fps_smg_scorpion.uses_parts, "wpn_fps_snp_tti_s_vltor")
-					table.insert(self.wpn_fps_smg_scorpion.uses_parts, "wpn_fps_smg_scorpion_s_nostock")	
+					table.insert(self.wpn_fps_smg_scorpion.uses_parts, "wpn_fps_smg_scorpion_s_nostock")
 					table.insert(self.wpn_fps_smg_scorpion.uses_parts, "wpn_fps_smg_scorpion_s_unfolded")
 					table.insert(self.wpn_fps_smg_scorpion.uses_parts, "wpn_fps_upg_vg_ass_smg_verticalgrip")
 					table.insert(self.wpn_fps_smg_scorpion.uses_parts, "wpn_fps_upg_vg_ass_smg_stubby")
@@ -6673,7 +6673,7 @@ end)
 						adds = {"wpn_fps_smg_scorpion_extra_rail", "wpn_fps_gre_arbiter_o_standard_no_forbid" },
 						forbids = {}
 					}
-					self.wpn_fps_smg_scorpion.override.wpn_fps_gre_arbiter_o_standard_no_forbid = { 
+					self.wpn_fps_smg_scorpion.override.wpn_fps_gre_arbiter_o_standard_no_forbid = {
 						stance_mod = {
 							wpn_fps_smg_scorpion = {
 								translation = Vector3(-0.005, -5, -4.7)
@@ -6707,7 +6707,7 @@ end)
 						end
 					end
 
-					table.insert(self.wpn_fps_smg_x_scorpion.uses_parts, "wpn_fps_smg_mac10_s_no")	
+					table.insert(self.wpn_fps_smg_x_scorpion.uses_parts, "wpn_fps_smg_mac10_s_no")
 
 					self.wpn_fps_smg_x_scorpion_npc.override = deep_clone(self.wpn_fps_smg_x_scorpion.override)
 					self.wpn_fps_smg_x_scorpion_npc.uses_parts = deep_clone(self.wpn_fps_smg_x_scorpion.uses_parts)
@@ -6727,7 +6727,7 @@ end)
 							self.wpn_fps_smg_scorpion.override[part_id].forbids = (self.parts[part_id].forbids and deep_clone(self.parts[part_id].forbids)) or self.wpn_fps_smg_scorpion.override[part_id].forbids or {}
 							table.insert(self.wpn_fps_smg_scorpion.override[part_id].forbids , "wpn_fps_gre_arbiter_o_standard_no_forbid")
 						end
-					end	
+					end
 					self.wpn_fps_smg_scorpion_npc.override = deep_clone(self.wpn_fps_smg_scorpion.override)
 					self.wpn_fps_smg_scorpion_npc.adds = deep_clone(self.wpn_fps_smg_scorpion.adds)
 
@@ -6737,7 +6737,7 @@ end)
 							self.wpn_fps_smg_x_scorpion.adds[part_id] = self.wpn_fps_smg_x_scorpion.adds[part_id] or {}
 							table.insert(self.wpn_fps_smg_x_scorpion.adds[part_id], "wpn_fps_smg_scorpion_body_standard_rail")
 						end
-					end	
+					end
 					self.wpn_fps_smg_x_scorpion_npc.adds = deep_clone(self.wpn_fps_smg_x_scorpion.adds)
 				end)
 
@@ -6756,7 +6756,7 @@ end)
 					self.parts.wpn_fps_smg_mp5_fg_m5k.stats.recoil = -4
 					self.parts.wpn_fps_smg_mp5_fg_m5k.custom_stats = deep_clone(barrels.short_b2_stats)
 					self.parts.wpn_fps_smg_mp5_fg_m5k.custom_stats.rof_mult = 1.125
-					
+
 					--Polizei Tactical Barrel
 					self.parts.wpn_fps_smg_mp5_fg_mp5a5.pcs = {
 						10,
@@ -6770,7 +6770,7 @@ end)
 						recoil = 2,
 						concealment = -1
 					}
-					
+
 					--The Ninja Barrel
 					self.parts.wpn_fps_smg_mp5_fg_mp5sd.pcs = {
 						10,
@@ -6791,7 +6791,7 @@ end)
 					self.parts.wpn_fps_smg_mp5_fg_mp5sd.custom_stats = {
 						rof_mult = 0.875
 					}
-					
+
 					--(Compact-5) Drum Mag
 					self.parts.wpn_fps_smg_mp5_m_drum = {
 						pcs = {},
@@ -6814,7 +6814,7 @@ end)
 						}
 					}
 					self.parts.wpn_fps_smg_mp5_m_drum.third_unit = "units/payday2/weapons/wpn_third_smg_mp5_pts/wpn_third_smg_mp5_m_drum"
-					
+
 					--(Compact-5) Adjustable Stock
 					self.parts.wpn_fps_smg_mp5_s_adjust.pcs = {
 						10,
@@ -6825,10 +6825,10 @@ end)
 					self.parts.wpn_fps_smg_mp5_s_adjust.supported = true
 					self.parts.wpn_fps_smg_mp5_s_adjust.stats = deep_clone(stocks.fixed_to_nocheeks_stats)
 					self.parts.wpn_fps_smg_mp5_s_adjust.custom_stats = deep_clone(stocks.fixed_to_nocheeks_stats)
-					
+
 					--(Compact-5) Bare Essentials Stock
 					self.parts.wpn_fps_smg_mp5_s_ring.pcs = {
-						10,		
+						10,
 						20,
 						30,
 						40
@@ -7001,7 +7001,7 @@ end)
 					self.parts.wpn_fps_smg_vityaz_b_long.supported = true
 					self.parts.wpn_fps_smg_vityaz_b_long.stats = deep_clone(barrels.long_b2_stats)
 					self.parts.wpn_fps_smg_vityaz_b_long.custom_stats = deep_clone(barrels.long_b2_stats)
-					
+
 					--Short Stock
 					self.parts.wpn_fps_smg_vityaz_s_short.pcs = {
 						10,
@@ -7010,8 +7010,8 @@ end)
 						40
 					}
 					self.parts.wpn_fps_smg_vityaz_s_short.supported = true
-					self.parts.wpn_fps_smg_vityaz_s_short.stats = deep_clone(stocks.remove_folder_stats)		
-					self.parts.wpn_fps_smg_vityaz_s_short.custom_stats = deep_clone(stocks.remove_folder_stats)	
+					self.parts.wpn_fps_smg_vityaz_s_short.stats = deep_clone(stocks.remove_folder_stats)
+					self.parts.wpn_fps_smg_vityaz_s_short.custom_stats = deep_clone(stocks.remove_folder_stats)
 
 					self.parts.wpn_fps_smg_vityaz_s_filler = {
 						texture_bundle_folder = "fawp",
@@ -7053,8 +7053,8 @@ end)
 
 					self.wpn_fps_smg_vityaz.stock_adapter = "wpn_fps_snp_victor_s_adapter"
 					self.wpn_fps_smg_vityaz_npc.stock_adapter = self.wpn_fps_smg_vityaz.stock_adapter
-					self.wpn_fps_smg_vityaz_npc.override = deep_clone(self.wpn_fps_smg_vityaz.override)	
-					self.wpn_fps_smg_vityaz_npc.uses_parts = deep_clone(self.wpn_fps_smg_vityaz.uses_parts)	
+					self.wpn_fps_smg_vityaz_npc.override = deep_clone(self.wpn_fps_smg_vityaz.override)
+					self.wpn_fps_smg_vityaz_npc.uses_parts = deep_clone(self.wpn_fps_smg_vityaz.uses_parts)
 				end)
 
 			--MP40
@@ -7071,7 +7071,7 @@ end)
 					self.parts.wpn_fps_smg_erma_s_folded.stats = deep_clone(stocks.fold_nocheeks_stats)
 					self.parts.wpn_fps_smg_erma_s_folded.stats.value = 0
 					self.parts.wpn_fps_smg_erma_s_folded.custom_stats = deep_clone(stocks.fold_nocheeks_stats)
-					
+
 					--Fix for missing anims
 					self.wpn_fps_smg_erma.animations = {
 						reload_not_empty = "reload_not_empty",
@@ -7081,7 +7081,7 @@ end)
 						magazine_empty = "last_recoil"
 					}
 
-					self.wpn_fps_smg_erma.override = self.wpn_fps_smg_erma.override or {} 
+					self.wpn_fps_smg_erma.override = self.wpn_fps_smg_erma.override or {}
 					self.wpn_fps_smg_erma.override.wpn_fps_smg_mac10_s_no = {
 						stats = deep_clone(stocks.remove_nocheeks_stats),
 						custom_stats = deep_clone(stocks.remove_nocheeks_stats)
@@ -7089,7 +7089,7 @@ end)
 
 					table.insert(self.wpn_fps_smg_erma.uses_parts, "wpn_fps_smg_mac10_s_no")
 
-					self.wpn_fps_smg_erma_npc.uses_parts = deep_clone(self.wpn_fps_smg_erma.uses_parts)	
+					self.wpn_fps_smg_erma_npc.uses_parts = deep_clone(self.wpn_fps_smg_erma.uses_parts)
 				end)
 
 			--UMP45
@@ -7099,7 +7099,7 @@ end)
 					self.parts.wpn_fps_smg_schakal_b_civil.supported = true
 					self.parts.wpn_fps_smg_schakal_b_civil.stats = deep_clone(barrels.long_b3_stats)
 					self.parts.wpn_fps_smg_schakal_b_civil.custom_stats = deep_clone(barrels.long_b3_stats)
-					
+
 					--Long Magazine
 					self.parts.wpn_fps_smg_schakal_m_long.pcs = {}
 					self.parts.wpn_fps_smg_schakal_m_long.supported = true
@@ -7112,7 +7112,7 @@ end)
 					self.parts.wpn_fps_smg_schakal_m_long.custom_stats = {
 						ads_speed_mult = 1.1
 					}
-					
+
 					--Short Magazine
 					self.parts.wpn_fps_smg_schakal_m_short.pcs = {}
 					self.parts.wpn_fps_smg_schakal_m_short.supported = true
@@ -7125,7 +7125,7 @@ end)
 					self.parts.wpn_fps_smg_schakal_m_short.custom_stats = {
 						ads_speed_mult = 0.95
 					}
-					
+
 					--Silentgear Silencer
 					self.parts.wpn_fps_smg_schakal_ns_silencer.pcs = {}
 					self.parts.wpn_fps_smg_schakal_ns_silencer.supported = true
@@ -7134,20 +7134,20 @@ end)
 					self.parts.wpn_fps_smg_schakal_ns_silencer.stats = deep_clone(muzzle_device.supp_acc_c)
 					self.parts.wpn_fps_smg_schakal_ns_silencer.custom_stats = deep_clone(muzzle_device.supp_acc_c)
 					self.parts.wpn_fps_smg_schakal_ns_silencer.perks = {"silencer"}
-					
+
 					--Civilian Stock
 					self.parts.wpn_fps_smg_schakal_s_civil.pcs = {}
 					self.parts.wpn_fps_smg_schakal_s_civil.supported = true
 					self.parts.wpn_fps_smg_schakal_s_civil.stats = deep_clone(stocks.folder_to_thumb_stats)
 					self.parts.wpn_fps_smg_schakal_s_civil.custom_stats = deep_clone(stocks.folder_to_thumb_stats)
-					
+
 					--Folded Stock
 					self.parts.wpn_fps_smg_schakal_s_folded.pcs = {}
 					self.parts.wpn_fps_smg_schakal_s_folded.supported = true
 					self.parts.wpn_fps_smg_schakal_s_folded.stats = deep_clone(stocks.fold_folder_stats)
 					self.parts.wpn_fps_smg_schakal_s_folded.stats.value = 0
 					self.parts.wpn_fps_smg_schakal_s_folded.custom_stats = deep_clone(stocks.fold_folder_stats)
-					
+
 					--Twinkle Grip
 					self.parts.wpn_fps_smg_schakal_vg_surefire.pcs = {}
 					self.parts.wpn_fps_smg_schakal_vg_surefire.supported = true
@@ -7170,7 +7170,7 @@ end)
 						stats = deep_clone(stocks.remove_folder_stats),
 						custom_stats = deep_clone(stocks.remove_folder_stats)
 					}
-					
+
 					for i, part_id in pairs(self.wpn_fps_smg_schakal.default_blueprint) do
 						attachment_list = {
 							"wpn_fps_upg_vg_ass_smg_verticalgrip"
@@ -7180,7 +7180,7 @@ end)
 								self.wpn_fps_smg_schakal.default_blueprint[i] = "wpn_fps_upg_vg_ass_smg_verticalgrip_vanilla"
 							end
 						end
-					end	
+					end
 
 					for i, part_id in pairs(self.wpn_fps_smg_schakal.uses_parts) do
 						attachment_list = {
@@ -7192,10 +7192,10 @@ end)
 								self.wpn_fps_smg_schakal.uses_parts[i] = "wpn_fps_upg_vg_ass_smg_verticalgrip_vanilla"
 							end
 						end
-					end	
+					end
 
-					table.insert(self.wpn_fps_smg_schakal.uses_parts, "wpn_fps_smg_mac10_s_no")	
-					
+					table.insert(self.wpn_fps_smg_schakal.uses_parts, "wpn_fps_smg_mac10_s_no")
+
 					self.wpn_fps_smg_schakal_npc.default_blueprint = deep_clone(self.wpn_fps_smg_schakal.default_blueprint)
 					self.wpn_fps_smg_schakal_npc.override = deep_clone(self.wpn_fps_smg_schakal.override)
 					self.wpn_fps_smg_schakal_npc.uses_parts = deep_clone(self.wpn_fps_smg_schakal.uses_parts)
@@ -7203,7 +7203,7 @@ end)
 
 			--VECTOR
 				Hooks:PostHook(WeaponFactoryTweakData, "_init_polymer", "resmod_polymer", function(self)
-					
+
 					--Precision Barrel
 					self.parts.wpn_fps_smg_polymer_barrel_precision.pcs = {
 						10,
@@ -7214,7 +7214,7 @@ end)
 					self.parts.wpn_fps_smg_polymer_barrel_precision.supported = true
 					self.parts.wpn_fps_smg_polymer_barrel_precision.stats = deep_clone(barrels.long_b2_stats)
 					self.parts.wpn_fps_smg_polymer_barrel_precision.custom_stats = deep_clone(barrels.long_b2_stats)
-					
+
 					--HPS Suppressor
 					self.parts.wpn_fps_smg_polymer_ns_silencer.pcs = {
 						10,
@@ -7287,9 +7287,9 @@ end)
 						end
 					end
 
-					table.insert(self.wpn_fps_smg_polymer.uses_parts, "wpn_fps_smg_mac10_s_no")	
+					table.insert(self.wpn_fps_smg_polymer.uses_parts, "wpn_fps_smg_mac10_s_no")
 
-					self.wpn_fps_smg_polymer_npc.uses_parts = deep_clone(self.wpn_fps_smg_polymer.uses_parts)		
+					self.wpn_fps_smg_polymer_npc.uses_parts = deep_clone(self.wpn_fps_smg_polymer.uses_parts)
 				end)
 
 		--SECONDARIES
@@ -7390,10 +7390,10 @@ end)
 					self.wpn_fps_smg_mac10.override = self.wpn_fps_smg_mac10.override or {}
 
 					for i, part_id in pairs(self.wpn_fps_smg_mac10.uses_parts) do
-						if part_id ~= "wpn_upg_o_marksmansight_rear_vanilla" and self.parts[part_id] and self.parts[part_id].type and self.parts[part_id].type == "sight" then	
-							self.wpn_fps_smg_mac10.override[part_id] = { 
+						if part_id ~= "wpn_upg_o_marksmansight_rear_vanilla" and self.parts[part_id] and self.parts[part_id].type and self.parts[part_id].type == "sight" then
+							self.wpn_fps_smg_mac10.override[part_id] = {
 								forbids = table.list_add(self.parts[part_id].forbids, {"wpn_upg_o_marksmansight_rear_vanilla"})
-							}	
+							}
 						end
 					end
 
@@ -7404,10 +7404,10 @@ end)
 					table.insert(self.wpn_fps_smg_mac10.uses_parts, "wpn_fps_smg_mac10_s_no")
 					table.insert(self.wpn_fps_smg_mac10.uses_parts, "wpn_fps_smg_schakal_vg_surefire")
 					--table.insert(self.wpn_fps_smg_mac10.uses_parts, "wpn_fps_upg_i_eye")
-					
-					self.wpn_fps_smg_mac10_npc.adds = deep_clone(self.wpn_fps_smg_mac10.adds)	
-					self.wpn_fps_smg_mac10_npc.override = deep_clone(self.wpn_fps_smg_mac10.override)	
-					self.wpn_fps_smg_mac10_npc.uses_parts = deep_clone(self.wpn_fps_smg_mac10.uses_parts)	
+
+					self.wpn_fps_smg_mac10_npc.adds = deep_clone(self.wpn_fps_smg_mac10.adds)
+					self.wpn_fps_smg_mac10_npc.override = deep_clone(self.wpn_fps_smg_mac10.override)
+					self.wpn_fps_smg_mac10_npc.uses_parts = deep_clone(self.wpn_fps_smg_mac10.uses_parts)
 				end)
 				Hooks:PostHook(WeaponFactoryTweakData, "_init_x_mac10", "resmod_x_mac10", function(self)
 
@@ -7438,7 +7438,7 @@ end)
 					}
 					self.wpn_fps_smg_x_mac10.override.wpn_fps_smg_pm9_fl_adapter = { a_obj = "a_vg" }
 					self.wpn_fps_smg_x_mac10.override.wpn_fps_smg_schakal_vg_surefire = { stats = deep_clone(self.parts.wpn_fps_upg_vg_ass_smg_verticalgrip.stats) }
-					
+
 					self.wpn_fps_smg_x_mac10.adds = self.wpn_fps_smg_x_mac10.adds or {}
 
 					self.wpn_fps_smg_x_mac10.adds.wpn_fps_upg_vg_ass_smg_stubby = { "wpn_fps_smg_pm9_fl_adapter" }
@@ -7449,14 +7449,14 @@ end)
 					table.insert(self.wpn_fps_smg_x_mac10.uses_parts, "wpn_fps_smg_schakal_vg_surefire")
 					table.insert(self.wpn_fps_smg_x_mac10.uses_parts, "wpn_fps_smg_mac10_s_no")
 
-					self.wpn_fps_smg_x_mac10_npc.adds = deep_clone(self.wpn_fps_smg_x_mac10.adds)	
-					self.wpn_fps_smg_x_mac10_npc.override = deep_clone(self.wpn_fps_smg_x_mac10.override)	
-					self.wpn_fps_smg_x_mac10_npc.uses_parts = deep_clone(self.wpn_fps_smg_x_mac10.uses_parts)	
+					self.wpn_fps_smg_x_mac10_npc.adds = deep_clone(self.wpn_fps_smg_x_mac10.adds)
+					self.wpn_fps_smg_x_mac10_npc.override = deep_clone(self.wpn_fps_smg_x_mac10.override)
+					self.wpn_fps_smg_x_mac10_npc.uses_parts = deep_clone(self.wpn_fps_smg_x_mac10.uses_parts)
 				end)
 
 			--M/45
 				Hooks:PostHook(WeaponFactoryTweakData, "_init_m45", "resmod_m45", function(self)
-					
+
 					--Extended Mag.
 					self.parts.wpn_fps_smg_m45_m_extended.pcs = {
 						10,
@@ -7474,7 +7474,7 @@ end)
 					self.parts.wpn_fps_smg_m45_m_extended.custom_stats = {
 						ads_speed_mult = 1.075
 					}
-					
+
 					--Swedish Barrel
 					self.parts.wpn_fps_smg_m45_b_green.pcs = {
 						10,
@@ -7488,7 +7488,7 @@ end)
 						recoil = 2,
 						concealment = -1
 					}
-					
+
 					--Grease Barrel
 					self.parts.wpn_fps_smg_m45_b_small.pcs = {
 						10,
@@ -7507,7 +7507,7 @@ end)
 						falloff_end_mult = 0.925,
 						ads_speed_mult = 0.975
 					}
-					
+
 					--Swedish Body
 					self.parts.wpn_fps_smg_m45_body_green.pcs = {
 						10,
@@ -7534,7 +7534,7 @@ end)
 					self.parts.wpn_fps_smg_m45_s_folded.stats = deep_clone(stocks.fold_folder_stats)
 					self.parts.wpn_fps_smg_m45_s_folded.stats.value = 0
 					self.parts.wpn_fps_smg_m45_s_folded.custom_stats = deep_clone(stocks.fold_folder_stats)
-					
+
 					--Ergo Grip
 					self.parts.wpn_fps_smg_m45_g_ergo.pcs = {
 						10,
@@ -7545,7 +7545,7 @@ end)
 					self.parts.wpn_fps_smg_m45_g_ergo.supported = true
 					self.parts.wpn_fps_smg_m45_g_ergo.stats = deep_clone(grips.quickdraw_1)
 					self.parts.wpn_fps_smg_m45_g_ergo.custom_stats = deep_clone(grips.quickdraw_1)
-					
+
 					--Bling Grip
 					self.parts.wpn_fps_smg_m45_g_bling.pcs = {
 						10,
@@ -7583,27 +7583,27 @@ end)
 						custom_stats = deep_clone(stocks.remove_folder_stats)
 					}
 
-					table.insert(self.wpn_fps_smg_m45.uses_parts, "wpn_fps_smg_mac10_s_no")	
-					
-					self.wpn_fps_smg_m45_npc.override = deep_clone(self.wpn_fps_smg_m45.override)	
-					self.wpn_fps_smg_m45_npc.uses_parts = deep_clone(self.wpn_fps_smg_m45.uses_parts)	
+					table.insert(self.wpn_fps_smg_m45.uses_parts, "wpn_fps_smg_mac10_s_no")
+
+					self.wpn_fps_smg_m45_npc.override = deep_clone(self.wpn_fps_smg_m45.override)
+					self.wpn_fps_smg_m45_npc.uses_parts = deep_clone(self.wpn_fps_smg_m45.uses_parts)
 				end)
 
 			--STERLING
 				Hooks:PostHook(WeaponFactoryTweakData, "_init_sterling", "resmod_sterling", function(self)
-					
+
 					--Long Barrel
 					self.parts.wpn_fps_smg_sterling_b_long.pcs = {}
 					self.parts.wpn_fps_smg_sterling_b_long.supported = true
 					self.parts.wpn_fps_smg_sterling_b_long.stats = deep_clone(barrels.long_b3_stats)
 					self.parts.wpn_fps_smg_sterling_b_long.custom_stats = deep_clone(barrels.long_b3_stats)
-					
+
 					--Short Barrel
 					self.parts.wpn_fps_smg_sterling_b_short.pcs = {}
 					self.parts.wpn_fps_smg_sterling_b_short.supported = true
 					self.parts.wpn_fps_smg_sterling_b_short.stats = deep_clone(barrels.short_b3_stats)
 					self.parts.wpn_fps_smg_sterling_b_short.custom_stats = deep_clone(barrels.short_b3_stats)
-					
+
 					--Suppressed Barrel
 					self.parts.wpn_fps_smg_sterling_b_suppressed.pcs = {}
 					self.parts.wpn_fps_smg_sterling_b_suppressed.supported = true
@@ -7625,7 +7625,7 @@ end)
 					table.insert(self.parts.wpn_fps_smg_sterling_b_suppressed.forbids, "wpn_fps_snp_msr_ns_suppressor")
 					table.insert(self.parts.wpn_fps_smg_sterling_b_suppressed.forbids, "wpn_fps_snp_victor_ns_omega")
 					table.insert(self.parts.wpn_fps_smg_sterling_b_suppressed.forbids, "wpn_fps_upg_ns_ass_filter")
-					
+
 					--Heatsinked Suppressed Barrel
 					self.parts.wpn_fps_smg_sterling_b_e11.pcs = {}
 					self.parts.wpn_fps_smg_sterling_b_e11.supported = true
@@ -7639,8 +7639,8 @@ end)
 					self.parts.wpn_fps_smg_sterling_b_e11.custom_stats = {
 						muzzleflash = "effects/payday2/particles/weapons/9mm_auto_silence_fps",
 						starwars = {
-							regen_ammo_time = 1.4, 
-							regen_rate = 6, 
+							regen_ammo_time = 1.4,
+							regen_rate = 6,
 							overheat_pen = 2,
 							regen_rate_overheat = 3,
 						},
@@ -7648,7 +7648,7 @@ end)
 						falloff_start_mult = 1.25,
 						falloff_end_mult = 1.25,
 						armor_piercing_override = 0.25
-					}	
+					}
 					self.parts.wpn_fps_smg_sterling_b_e11.sub_type = nil
 					self.parts.wpn_fps_smg_sterling_b_e11.perks = nil --{"silencer"}
 					self.parts.wpn_fps_smg_sterling_b_e11.forbids = deep_clone(self.parts.wpn_fps_smg_sterling_b_suppressed.forbids)
@@ -7657,7 +7657,7 @@ end)
 					self.parts.wpn_fps_smg_sterling_b_e11.override = {
 						wpn_fps_smg_sterling_m_medium = { unit = "units/pd2_dlc_gage_historical/weapons/wpn_fps_smg_sterling_pts/wpn_fps_smg_sterling_m_short" }
 					}
-					
+
 					--Extended Mag
 					self.parts.wpn_fps_smg_sterling_m_long.pcs = {}
 					self.parts.wpn_fps_smg_sterling_m_long.supported = true
@@ -7670,7 +7670,7 @@ end)
 					self.parts.wpn_fps_smg_sterling_m_long.custom_stats = {
 						ads_speed_mult = 1.025
 					}
-					
+
 					--Short Mag
 					self.parts.wpn_fps_smg_sterling_m_short.pcs = {}
 					self.parts.wpn_fps_smg_sterling_m_short.supported = true
@@ -7680,24 +7680,24 @@ end)
 						reload = 3,
 						concealment = 1
 					}
-					self.parts.wpn_fps_smg_sterling_m_short.custom_stats = { 
+					self.parts.wpn_fps_smg_sterling_m_short.custom_stats = {
 						ads_speed_mult = 0.975
 					}
-					
+
 					--Folded Stock
 					self.parts.wpn_fps_smg_sterling_s_folded.pcs = {}
 					self.parts.wpn_fps_smg_sterling_s_folded.supported = true
 					self.parts.wpn_fps_smg_sterling_s_folded.stats = deep_clone(stocks.fold_folder_stats)
 					self.parts.wpn_fps_smg_sterling_s_folded.stats.value = 0
 					self.parts.wpn_fps_smg_sterling_s_folded.custom_stats = deep_clone(stocks.fold_folder_stats)
-					
+
 					--No Stock
 					self.parts.wpn_fps_smg_sterling_s_nostock.pcs = {}
 					self.parts.wpn_fps_smg_sterling_s_nostock.supported = true
 					self.parts.wpn_fps_smg_sterling_s_nostock.stats = deep_clone(stocks.remove_folder_stats)
 					self.parts.wpn_fps_smg_sterling_s_nostock.stats.value = 0
 					self.parts.wpn_fps_smg_sterling_s_nostock.custom_stats = deep_clone(stocks.remove_folder_stats)
-					
+
 					--Solid Stock
 					self.parts.wpn_fps_smg_sterling_s_solid.pcs = {}
 					self.parts.wpn_fps_smg_sterling_s_solid.supported = true
@@ -7715,7 +7715,7 @@ end)
 					self.wpn_fps_smg_sterling_npc.stock_adapter = "wpn_fps_smg_shepheard_s_adapter"
 
 					self.wpn_fps_smg_sterling.override = self.wpn_fps_smg_sterling.override or {}
-					
+
 					self.wpn_fps_smg_sterling.override.wpn_fps_upg_o_specter = { forbids = {"wpn_fps_gre_arbiter_o_standard"} }
 					self.wpn_fps_smg_sterling.override.wpn_fps_upg_o_aimpoint = { forbids = {"wpn_fps_gre_arbiter_o_standard"} }
 					self.wpn_fps_smg_sterling.override.wpn_fps_upg_o_aimpoint_2 = { forbids = {"wpn_fps_gre_arbiter_o_standard"} }
@@ -7737,7 +7737,7 @@ end)
 					self.wpn_fps_smg_sterling.override.wpn_fps_upg_o_poe = { forbids = {"wpn_fps_gre_arbiter_o_standard"} }
 					-- VMP sight(s)
 					self.wpn_fps_smg_sterling.override.wpn_fps_upg_o_cqb = { forbids = {"wpn_fps_gre_arbiter_o_standard"} }
-					
+
 					self.wpn_fps_smg_sterling.override.wpn_fps_upg_m4_s_standard = {
 						stats = deep_clone(stocks.folder_to_adj_acc1_stats),
 						custom_stats = deep_clone(stocks.folder_to_adj_acc1_stats),
@@ -7786,7 +7786,7 @@ end)
 						adds = {"wpn_fps_smg_sterling_s_nostock_dummy","wpn_fps_smg_sterling_o_adapter", "wpn_fps_gre_arbiter_o_standard" },
 						forbids = {}
 					}
-					self.wpn_fps_smg_sterling.override.wpn_fps_gre_arbiter_o_standard = { 
+					self.wpn_fps_smg_sterling.override.wpn_fps_gre_arbiter_o_standard = {
 						stance_mod = {
 							wpn_fps_smg_sterling = {
 								translation = Vector3(-0.005, -13, -3.2)
@@ -7805,7 +7805,7 @@ end)
 							end
 						end
 					end
-					
+
 					table.insert(self.wpn_fps_smg_sterling.uses_parts, "wpn_fps_upg_m4_s_standard")
 					table.insert(self.wpn_fps_smg_sterling.uses_parts, "wpn_fps_upg_m4_s_pts")
 					table.insert(self.wpn_fps_smg_sterling.uses_parts, "wpn_fps_upg_m4_s_crane")
@@ -7852,19 +7852,19 @@ end)
 					self.parts.wpn_fps_smg_uzi_fg_rail.adds = {
 						"wpn_fps_upg_vg_ass_smg_verticalgrip_vanilla"
 					}
-					
+
 					--Ergonomic Stock
 					self.parts.wpn_fps_smg_uzi_s_leather.pcs = {}
 					self.parts.wpn_fps_smg_uzi_s_leather.supported = true
 					self.parts.wpn_fps_smg_uzi_s_leather.stats = deep_clone(stocks.nocheeks_to_fixed_acc2_rec2_stats)
 					self.parts.wpn_fps_smg_uzi_s_leather.custom_stats = deep_clone(stocks.nocheeks_to_fixed_acc2_rec2_stats)
-					
+
 					--Solid Stock
 					self.parts.wpn_fps_smg_uzi_s_solid.pcs = {}
 					self.parts.wpn_fps_smg_uzi_s_solid.supported = true
 					self.parts.wpn_fps_smg_uzi_s_solid.stats = deep_clone(stocks.nocheeks_to_fixed_rec3_stats)
 					self.parts.wpn_fps_smg_uzi_s_solid.custom_stats = deep_clone(stocks.nocheeks_to_fixed_rec3_stats)
-					
+
 					--Folded Stock
 					self.parts.wpn_fps_smg_uzi_s_standard.pcs = {}
 					self.parts.wpn_fps_smg_uzi_s_standard.supported = true
@@ -7876,7 +7876,7 @@ end)
 					self.parts.wpn_fps_smg_uzi_body_standard.animations = {
 						reload_not_empty = "reload_not_empty",
 						reload = "reload"
-					}	
+					}
 
 					self.wpn_fps_smg_uzi.override = self.wpn_fps_smg_uzi.override or {}
 
@@ -7964,7 +7964,7 @@ end)
 
 			--M1928
 				Hooks:PostHook(WeaponFactoryTweakData, "_init_m1928", "resmod_m1928", function(self)
-					
+
 					--Long Barrel
 					self.parts.wpn_fps_smg_thompson_barrel_long.pcs = {
 						10,
@@ -7975,7 +7975,7 @@ end)
 					self.parts.wpn_fps_smg_thompson_barrel_long.supported = true
 					self.parts.wpn_fps_smg_thompson_barrel_long.stats = deep_clone(barrels.long_b2_stats)
 					self.parts.wpn_fps_smg_thompson_barrel_long.custom_stats = deep_clone(barrels.long_b2_stats)
-					
+
 					--Stubby Barrel
 					self.parts.wpn_fps_smg_thompson_barrel_short.pcs = {
 						10,
@@ -8000,7 +8000,7 @@ end)
 						recoil = -2,
 						concealment = 1
 					}
-					
+
 					--Discrete Grip
 					self.parts.wpn_fps_smg_thompson_grip_discrete.pcs = {
 						10,
@@ -8011,7 +8011,7 @@ end)
 					self.parts.wpn_fps_smg_thompson_grip_discrete.supported = true
 					self.parts.wpn_fps_smg_thompson_grip_discrete.stats = deep_clone(grips.quickdraw_1)
 					self.parts.wpn_fps_smg_thompson_grip_discrete.custom_stats = deep_clone(grips.quickdraw_1)
-					
+
 					--Discrete Stock
 					self.parts.wpn_fps_smg_thompson_stock_discrete.pcs = {
 						10,
@@ -8025,7 +8025,7 @@ end)
 						recoil = -2,
 						concealment = 1
 					}
-					
+
 					--QD Sling Stock
 					self.parts.wpn_fps_smg_thompson_stock_nostock.pcs = {
 						10,
@@ -8061,7 +8061,7 @@ end)
 					falloff_end_mult = 1.225,
 					ads_speed_mult = 1.075,
 				}
-				
+
 				--Bootstrap Compensator
 				self.parts.wpn_fps_ass_tecci_ns_special.pcs = {
 					10,
@@ -8072,7 +8072,7 @@ end)
 				self.parts.wpn_fps_ass_tecci_ns_special.supported = true
 				self.parts.wpn_fps_ass_tecci_ns_special.stats = deep_clone(muzzle_device.muzz_rec_a)
 				self.parts.wpn_fps_ass_tecci_ns_special.custom_stats = deep_clone(muzzle_device.muzz_rec_a)
-				
+
 				--Overrides
 				self.wpn_fps_ass_tecci.override = {
 					wpn_fps_upg_ammo_half_that = {
@@ -8083,8 +8083,8 @@ end)
 							--total_ammo_mod = 50,
 							--concealment = -2
 						},
-						--custom_stats = {movement_speed = 0.75}	
-					}	
+						--custom_stats = {movement_speed = 0.75}
+					}
 				}
 
 				self.wpn_fps_ass_tecci.override.wpn_fps_upg_m4_s_standard = {
@@ -8156,8 +8156,8 @@ end)
 				--UOOOH
 				table.insert(self.wpn_fps_ass_tecci.uses_parts, "wpn_fps_ass_tecci_cnuy_ibuki")
 				--table.insert(self.wpn_fps_ass_tecci.uses_parts, "wpn_fps_upg_ammo_half_that")
-				
-				self.wpn_fps_ass_tecci_npc.uses_parts = deep_clone(self.wpn_fps_ass_tecci.uses_parts)	
+
+				self.wpn_fps_ass_tecci_npc.uses_parts = deep_clone(self.wpn_fps_ass_tecci.uses_parts)
 			end)
 
 		--KAC CHAINSAW
@@ -8299,7 +8299,7 @@ end)
 				if not self.wpn_fps_lmg_m249.override then
 					self.wpn_fps_lmg_m249.override = {}
 				end
-				
+
 				self.wpn_fps_lmg_m249.override.wpn_fps_upg_m4_s_standard = {
 					stats = deep_clone(stocks.folder_to_adj_acc1_stats),
 					custom_stats = deep_clone(stocks.folder_to_adj_acc1_stats)
@@ -8333,46 +8333,46 @@ end)
 					custom_stats = deep_clone(stocks.folder_to_hvy_acc2_stats)
 				}
 
-				
+
 				self.wpn_fps_lmg_m249.override.wpn_fps_upg_o_specter = {
 					parent = "upper_reciever"
-				}	
+				}
 				self.wpn_fps_lmg_m249.override.wpn_fps_upg_o_aimpoint = {
 					parent = "upper_reciever"
 				}
 				self.wpn_fps_lmg_m249.override.wpn_fps_upg_o_docter = {
 					parent = "upper_reciever"
-				}	
+				}
 				self.wpn_fps_lmg_m249.override.wpn_fps_upg_o_eotech = {
 					parent = "upper_reciever"
-				}	
+				}
 				self.wpn_fps_lmg_m249.override.wpn_fps_upg_o_t1micro = {
 					parent = "upper_reciever"
-				}	
+				}
 				self.wpn_fps_lmg_m249.override.wpn_fps_upg_o_cmore = {
 					parent = "upper_reciever"
-				}	
+				}
 				self.wpn_fps_lmg_m249.override.wpn_fps_upg_o_aimpoint_2 = {
 					parent = "upper_reciever"
 				}
 				self.wpn_fps_lmg_m249.override.wpn_fps_upg_o_cs = {
 					parent = "upper_reciever"
-				}	
+				}
 				self.wpn_fps_lmg_m249.override.wpn_fps_upg_o_rx30 = {
 					parent = "upper_reciever"
 				}
 				self.wpn_fps_lmg_m249.override.wpn_fps_upg_o_rx01 = {
 					parent = "upper_reciever"
-				}	
+				}
 				self.wpn_fps_lmg_m249.override.wpn_fps_upg_o_reflex = {
 					parent = "upper_reciever"
 				}
 				self.wpn_fps_lmg_m249.override.wpn_fps_upg_o_eotech_xps = {
 					parent = "upper_reciever"
-				}	
+				}
 				self.wpn_fps_lmg_m249.override.wpn_fps_upg_o_sig = {
 					parent = "upper_reciever"
-				}	
+				}
 				self.wpn_fps_lmg_m249.override.wpn_fps_upg_o_uh = {
 					parent = "upper_reciever"
 				}
@@ -8397,10 +8397,10 @@ end)
 				self.wpn_fps_lmg_m249.override.wpn_fps_upg_o_atibal = {
 					parent = "upper_reciever"
 				}
-				
+
 				--M249 Part Additions
 				table.insert(self.wpn_fps_lmg_m249.uses_parts, "wpn_fps_upg_o_specter")
-				table.insert(self.wpn_fps_lmg_m249.uses_parts, "wpn_fps_upg_o_aimpoint")	
+				table.insert(self.wpn_fps_lmg_m249.uses_parts, "wpn_fps_upg_o_aimpoint")
 				table.insert(self.wpn_fps_lmg_m249.uses_parts, "wpn_fps_upg_o_docter")
 				table.insert(self.wpn_fps_lmg_m249.uses_parts, "wpn_fps_upg_o_eotech")
 				table.insert(self.wpn_fps_lmg_m249.uses_parts, "wpn_fps_upg_o_t1micro")
@@ -8457,12 +8457,12 @@ end)
 					"wpn_fps_upg_vg_ass_smg_verticalgrip_vanilla",
 					"wpn_fps_addon_ris"
 				}
-				
+
 				--Default Stock
 				self.parts.wpn_fps_lmg_rpk_s_wood.adds = {
 					"wpn_upg_ak_g_standard"
-				}	
-					
+				}
+
 				--Plastic Stock
 				self.parts.wpn_fps_lmg_rpk_s_standard.pcs = {
 					10,
@@ -8486,7 +8486,7 @@ end)
 						value = 1
 					}
 				}
-				
+
 				--RPK Part Additions
 				table.insert(self.wpn_fps_lmg_rpk.uses_parts, "wpn_fps_upg_o_specter")
 				table.insert(self.wpn_fps_lmg_rpk.uses_parts, "wpn_fps_upg_o_aimpoint")
@@ -8523,8 +8523,8 @@ end)
 				--table.insert(self.wpn_fps_lmg_rpk.uses_parts, "wpn_fps_upg_ak_fg_krebs") -- Don't fit right, missing their respective unique attachment points
 				--table.insert(self.wpn_fps_lmg_rpk.uses_parts, "wpn_fps_upg_ak_fg_trax")
 
-				table.insert(self.wpn_fps_lmg_rpk.uses_parts, "wpn_fps_upg_ak_m_quick")		
-				table.insert(self.wpn_fps_lmg_rpk.uses_parts, "wpn_fps_upg_ak_m_quad")	
+				table.insert(self.wpn_fps_lmg_rpk.uses_parts, "wpn_fps_upg_ak_m_quick")
+				table.insert(self.wpn_fps_lmg_rpk.uses_parts, "wpn_fps_upg_ak_m_quad")
 
 				table.insert(self.wpn_fps_lmg_rpk.uses_parts, "wpn_fps_upg_vg_ass_smg_stubby")
 				table.insert(self.wpn_fps_lmg_rpk.uses_parts, "wpn_fps_smg_schakal_vg_surefire")
@@ -8533,9 +8533,9 @@ end)
 
 				table.insert(self.wpn_fps_lmg_rpk.uses_parts, "wpn_fps_upg_o_xpsg33_magnifier")
 				table.insert(self.wpn_fps_lmg_rpk.uses_parts, "wpn_fps_upg_o_sig")
-						
 
-				self.wpn_fps_lmg_rpk.adds = { 
+
+				self.wpn_fps_lmg_rpk.adds = {
 					wpn_fps_upg_o_specter = { "wpn_fps_ak_extra_ris" },
 					wpn_fps_upg_o_aimpoint = { "wpn_fps_ak_extra_ris" },
 					wpn_fps_upg_o_aimpoint_2 = { "wpn_fps_ak_extra_ris" },
@@ -8728,8 +8728,8 @@ end)
 					end
 				end
 
-				self.wpn_fps_lmg_rpk_npc.uses_parts = deep_clone(self.wpn_fps_lmg_rpk.uses_parts)		
-				self.wpn_fps_lmg_rpk_npc.override = deep_clone(self.wpn_fps_lmg_rpk.override)		
+				self.wpn_fps_lmg_rpk_npc.uses_parts = deep_clone(self.wpn_fps_lmg_rpk.uses_parts)
+				self.wpn_fps_lmg_rpk_npc.override = deep_clone(self.wpn_fps_lmg_rpk.override)
 			end)
 
 		--HK51B
@@ -8759,7 +8759,7 @@ end)
 					recoil = -2,
 					concealment = 1
 				}
-				
+
 				--Zittern Stock (what a fucking stupid name YOU'RE JUST EXTENDING THE FUCKING STOCK FOR FUCKS SAKE)
 				self.parts.wpn_fps_lmg_hk51b_s_extended.pcs = {
 					10,
@@ -8772,7 +8772,7 @@ end)
 				self.parts.wpn_fps_lmg_hk51b_s_extended.stats = deep_clone(stocks.unfold_nocheeks_stats)
 				self.parts.wpn_fps_lmg_hk51b_s_extended.stats.value = 0
 				self.parts.wpn_fps_lmg_hk51b_s_extended.custom_stats = deep_clone(stocks.unfold_nocheeks_stats)
-				
+
 				--Verdunkeln Brake
 				--Tank Comp clone
 				self.parts.wpn_fps_lmg_hk51b_ns_jcomp.pcs = {
@@ -8898,7 +8898,7 @@ end)
 
 				self.wpn_fps_lmg_hk51b.override = self.wpn_fps_lmg_hk51b.override or {}
 
-				
+
 				self.wpn_fps_lmg_hk51b.override.wpn_fps_upg_m4_s_standard = {
 					stats = deep_clone(stocks.folded_to_adj_rec2),
 					custom_stats = deep_clone(stocks.folded_to_adj_rec2)
@@ -8968,14 +8968,14 @@ end)
 				table.insert(self.wpn_fps_lmg_hk51b.uses_parts, "wpn_fps_upg_m4_s_mk46")
 				table.insert(self.wpn_fps_lmg_hk51b.uses_parts, "wpn_fps_snp_victor_s_mod0")
 				table.insert(self.wpn_fps_lmg_hk51b.uses_parts, "wpn_fps_upg_m4_s_ubr")
-				table.insert(self.wpn_fps_lmg_hk51b.uses_parts, "wpn_fps_snp_tti_s_vltor")	
+				table.insert(self.wpn_fps_lmg_hk51b.uses_parts, "wpn_fps_snp_tti_s_vltor")
 				table.insert(self.wpn_fps_lmg_hk51b.uses_parts, "wpn_fps_sho_sko12_stock")
 				table.insert(self.wpn_fps_lmg_hk51b.uses_parts, "wpn_fps_upg_i_og_rof")
 				table.insert(self.wpn_fps_lmg_hk51b.uses_parts, "wpn_fps_lmg_hk51b_m_belt_60")
 				table.insert(self.wpn_fps_lmg_hk51b.uses_parts, "wpn_fps_lmg_hk51b_m_belt_80")
-						
-				self.wpn_fps_lmg_hk51b_npc.override = deep_clone(self.wpn_fps_lmg_hk51b.override)		
-				self.wpn_fps_lmg_hk51b_npc.uses_parts = deep_clone(self.wpn_fps_lmg_hk51b.uses_parts)		
+
+				self.wpn_fps_lmg_hk51b_npc.override = deep_clone(self.wpn_fps_lmg_hk51b.override)
+				self.wpn_fps_lmg_hk51b_npc.uses_parts = deep_clone(self.wpn_fps_lmg_hk51b.uses_parts)
 			end)
 
 	--[[     HEAVY MGs     ]]
@@ -9030,7 +9030,7 @@ end)
 				}
 
 				self.parts.wpn_fps_lmg_hcar_body_conversionkit.supported = true
-				self.parts.wpn_fps_lmg_hcar_body_conversionkit.stats = { 
+				self.parts.wpn_fps_lmg_hcar_body_conversionkit.stats = {
 					value = 10,
 					recoil = -2,
 					spread = -5,
@@ -9142,8 +9142,8 @@ end)
 							self.wpn_fps_lmg_hcar.uses_parts[i] = "resmod_dummy"
 						end
 					end
-				end	
-				
+				end
+
 				self.parts.wpn_fps_lmg_hcar_ck_switch.supported = true
 				self.parts.wpn_fps_lmg_hcar_ck_switch.no_cull = true
 
@@ -9177,7 +9177,7 @@ end)
 				self.parts.wpn_fps_lmg_hk21_fg_short.supported = true
 				self.parts.wpn_fps_lmg_hk21_fg_short.stats = deep_clone(barrels.short_b3_stats)
 				self.parts.wpn_fps_lmg_hk21_fg_short.custom_stats = deep_clone(barrels.short_b3_stats)
-				
+
 				--Ergo Grip
 				self.parts.wpn_fps_lmg_hk21_g_ergo.pcs = {
 					10,
@@ -9201,7 +9201,7 @@ end)
 				}
 
 				--Adds Rails
-				self.wpn_fps_lmg_hk21.adds = { 
+				self.wpn_fps_lmg_hk21.adds = {
 					wpn_fps_upg_o_specter = { "wpn_fps_ass_g3_body_rail" },
 					wpn_fps_upg_o_aimpoint = { "wpn_fps_ass_g3_body_rail" },
 					wpn_fps_upg_o_aimpoint_2 = { "wpn_fps_ass_g3_body_rail" },
@@ -9219,15 +9219,15 @@ end)
 					wpn_fps_upg_o_leupold = { "wpn_fps_ass_g3_body_rail" },
 					wpn_fps_upg_o_bmg = { "wpn_fps_ass_g3_body_rail" },
 					wpn_fps_upg_o_uh = { "wpn_fps_ass_g3_body_rail" },
-					wpn_fps_upg_o_fc1 = { "wpn_fps_ass_g3_body_rail" },		
-					wpn_fps_upg_o_tf90 = { "wpn_fps_ass_g3_body_rail" },		
-					wpn_fps_upg_o_spot = { "wpn_fps_ass_g3_body_rail" },		
-					wpn_fps_upg_o_poe = { "wpn_fps_ass_g3_body_rail" },		
-					wpn_fps_upg_o_health = { "wpn_fps_ass_g3_body_rail" },		
-					wpn_fps_upg_o_hamr = { "wpn_fps_ass_g3_body_rail" },		
-					wpn_fps_upg_o_atibal = { "wpn_fps_ass_g3_body_rail" },		
+					wpn_fps_upg_o_fc1 = { "wpn_fps_ass_g3_body_rail" },
+					wpn_fps_upg_o_tf90 = { "wpn_fps_ass_g3_body_rail" },
+					wpn_fps_upg_o_spot = { "wpn_fps_ass_g3_body_rail" },
+					wpn_fps_upg_o_poe = { "wpn_fps_ass_g3_body_rail" },
+					wpn_fps_upg_o_health = { "wpn_fps_ass_g3_body_rail" },
+					wpn_fps_upg_o_hamr = { "wpn_fps_ass_g3_body_rail" },
+					wpn_fps_upg_o_atibal = { "wpn_fps_ass_g3_body_rail" },
 				}
-					
+
 				--HK21 Part Additions
 				table.insert(self.wpn_fps_lmg_hk21.uses_parts, "wpn_fps_ass_g3_s_sniper")
 				table.insert(self.wpn_fps_lmg_hk21.uses_parts, "wpn_fps_ass_g3_s_wood")
@@ -9243,7 +9243,7 @@ end)
 				table.insert(self.wpn_fps_lmg_hk21.uses_parts, "wpn_fps_upg_o_rx01")
 				table.insert(self.wpn_fps_lmg_hk21.uses_parts, "wpn_fps_upg_o_reflex")
 				table.insert(self.wpn_fps_lmg_hk21.uses_parts, "wpn_fps_upg_o_eotech_xps")
-				table.insert(self.wpn_fps_lmg_hk21.uses_parts, "wpn_fps_upg_o_uh")		
+				table.insert(self.wpn_fps_lmg_hk21.uses_parts, "wpn_fps_upg_o_uh")
 				table.insert(self.wpn_fps_lmg_hk21.uses_parts, "wpn_fps_upg_o_fc1")
 				table.insert(self.wpn_fps_lmg_hk21.uses_parts, "wpn_fps_upg_o_tf90")
 				table.insert(self.wpn_fps_lmg_hk21.uses_parts, "wpn_fps_upg_o_spot")
@@ -9261,22 +9261,22 @@ end)
 				table.insert(self.wpn_fps_lmg_hk21.uses_parts, "wpn_fps_upg_o_sig")
 
 				self.wpn_fps_lmg_hk21.override = self.wpn_fps_lmg_hk21.override or {}
-				self.wpn_fps_lmg_hk21.override.wpn_fps_ass_g3_s_sniper = { 
+				self.wpn_fps_lmg_hk21.override.wpn_fps_ass_g3_s_sniper = {
 					adds = {"wpn_fps_hk21_s_fix"},
 					a_obj = "a_ns",
 					parent = "shitass_s",
 				}
-				self.wpn_fps_lmg_hk21.override.wpn_fps_ass_g3_s_wood = { 
+				self.wpn_fps_lmg_hk21.override.wpn_fps_ass_g3_s_wood = {
 					adds = {"wpn_fps_hk21_s_fix"},
 					a_obj = "a_ns",
 					parent = "shitass_s"
 				}
-				self.wpn_fps_lmg_hk21.override.wpn_fps_smg_mp5_s_adjust = { 
+				self.wpn_fps_lmg_hk21.override.wpn_fps_smg_mp5_s_adjust = {
 					adds = {"wpn_fps_hk21_s_fix"},
 					a_obj = "a_ns",
 					parent = "shitass_s"
 				}
-				self.wpn_fps_lmg_hk21.override.wpn_fps_smg_mp5_s_adjusted = { 
+				self.wpn_fps_lmg_hk21.override.wpn_fps_smg_mp5_s_adjusted = {
 					adds = {"wpn_fps_hk21_s_fix"},
 					a_obj = "a_ns",
 					parent = "shitass_s"
@@ -9297,13 +9297,13 @@ end)
 				}
 
 
-				self.wpn_fps_lmg_hk21_npc.override = deep_clone(self.wpn_fps_lmg_hk21.override)	
-				self.wpn_fps_lmg_hk21_npc.uses_parts = deep_clone(self.wpn_fps_lmg_hk21.uses_parts)	
+				self.wpn_fps_lmg_hk21_npc.override = deep_clone(self.wpn_fps_lmg_hk21.override)
+				self.wpn_fps_lmg_hk21_npc.uses_parts = deep_clone(self.wpn_fps_lmg_hk21.uses_parts)
 			end)
 
 		--MG42
 			Hooks:PostHook(WeaponFactoryTweakData, "_init_mg42", "resmod_mg42", function(self)
-				
+
 				--Light Barrel
 				self.parts.wpn_fps_lmg_mg42_b_mg34.pcs = {}
 				self.parts.wpn_fps_lmg_mg42_b_mg34.supported = true
@@ -9311,12 +9311,12 @@ end)
 					value = 1,
 					recoil = 2
 				}
-				self.parts.wpn_fps_lmg_mg42_b_mg34.custom_stats = { 
+				self.parts.wpn_fps_lmg_mg42_b_mg34.custom_stats = {
 					rof_mult = 0.708333
 				}
 				--self.parts.wpn_fps_lmg_mg42_b_mg34.has_description = true
 				--self.parts.wpn_fps_lmg_mg42_b_mg34.desc_id = "bm_wp_mg42_b_mg34_desc_sc"
-				
+
 				--Heatsinked Suppressed Barrel
 				self.parts.wpn_fps_lmg_mg42_b_vg38.pcs = {}
 				self.parts.wpn_fps_lmg_mg42_b_vg38.supported = true
@@ -9326,13 +9326,13 @@ end)
 					value = 10,
 					recoil = 4,
 					extra_ammo = -10
-				}		
+				}
 				self.parts.wpn_fps_lmg_mg42_b_vg38.custom_stats = {
 					muzzleflash = "effects/payday2/particles/weapons/9mm_auto_silence_fps",
 					starwars = {
-						regen_ammo_time = 3, 
-						regen_rate = 9, 
-						overheat_pen = 4, 
+						regen_ammo_time = 3,
+						regen_rate = 9,
+						overheat_pen = 4,
 						regen_rate_overheat = 4.5
 					},
 					rof_mult = 0.52083,
@@ -9356,11 +9356,11 @@ end)
 				self.parts.wpn_fps_lmg_mg42_b_vg38.perks = nil--{"silencer"}
 
 				--Bringing back my old MG42 mag/belt fix method for more accurate looking DLT-19
-				self.parts.wpn_fps_lmg_mg42_dummy_mag = deep_clone(self.parts.wpn_fps_lmg_mg42_reciever)	
+				self.parts.wpn_fps_lmg_mg42_dummy_mag = deep_clone(self.parts.wpn_fps_lmg_mg42_reciever)
 				self.parts.wpn_fps_lmg_mg42_dummy_mag.type = "ammo"
 				self.parts.wpn_fps_lmg_mg42_dummy_mag.adds = nil
 				self.parts.wpn_fps_lmg_mg42_dummy_mag.bullet_objects = {
-					prefix = "g_bullet_", 
+					prefix = "g_bullet_",
 					amount = 6
 				}
 				self.parts.wpn_fps_lmg_mg42_dummy_mag.visibility = {
@@ -9408,10 +9408,10 @@ end)
 				table.insert(self.wpn_fps_lmg_mg42.uses_parts, "wpn_fps_upg_o_aimpoint_2")
 				table.insert(self.wpn_fps_lmg_mg42.uses_parts, "wpn_fps_upg_o_cs")
 				table.insert(self.wpn_fps_lmg_mg42.uses_parts, "wpn_fps_upg_o_rx30")
-				table.insert(self.wpn_fps_lmg_mg42.uses_parts, "wpn_fps_upg_o_rx01")	
-				table.insert(self.wpn_fps_lmg_mg42.uses_parts, "wpn_fps_upg_o_reflex")	
+				table.insert(self.wpn_fps_lmg_mg42.uses_parts, "wpn_fps_upg_o_rx01")
+				table.insert(self.wpn_fps_lmg_mg42.uses_parts, "wpn_fps_upg_o_reflex")
 				table.insert(self.wpn_fps_lmg_mg42.uses_parts, "wpn_fps_upg_o_eotech_xps")
-				table.insert(self.wpn_fps_lmg_mg42.uses_parts, "wpn_fps_upg_o_uh")	
+				table.insert(self.wpn_fps_lmg_mg42.uses_parts, "wpn_fps_upg_o_uh")
 				table.insert(self.wpn_fps_lmg_mg42.uses_parts, "wpn_fps_upg_o_fc1")
 				table.insert(self.wpn_fps_lmg_mg42.uses_parts, "wpn_fps_upg_o_tf90")
 				table.insert(self.wpn_fps_lmg_mg42.uses_parts, "wpn_fps_upg_o_spot")
@@ -9429,9 +9429,9 @@ end)
 				self.wpn_fps_lmg_mg42.override = self.wpn_fps_lmg_mg42.override or {}
 
 				for i, part_id in pairs(self.wpn_fps_lmg_mg42.uses_parts) do
-					if part_id ~= "wpn_fps_ass_sub2000_o_back" and self.parts[part_id] and self.parts[part_id].type and self.parts[part_id].type == "sight" then	
+					if part_id ~= "wpn_fps_ass_sub2000_o_back" and self.parts[part_id] and self.parts[part_id].type and self.parts[part_id].type == "sight" then
 						self.wpn_fps_lmg_mg42.adds[part_id] = { "wpn_fps_snp_mosin_rail" }
-						self.wpn_fps_lmg_mg42.override[part_id] = { 
+						self.wpn_fps_lmg_mg42.override[part_id] = {
 							parent = "magazine_extra",
 							custom_stats = { big_scope = true }
 						}
@@ -9442,10 +9442,10 @@ end)
 					a_obj = "a_ns",
 					parent = "barrel"
 				}
-						
-				self.wpn_fps_lmg_mg42_npc.adds = deep_clone(self.wpn_fps_lmg_mg42.adds)			
-				self.wpn_fps_lmg_mg42_npc.override = deep_clone(self.wpn_fps_lmg_mg42.override)			
-				self.wpn_fps_lmg_mg42_npc.uses_parts = deep_clone(self.wpn_fps_lmg_mg42.uses_parts)			
+
+				self.wpn_fps_lmg_mg42_npc.adds = deep_clone(self.wpn_fps_lmg_mg42.adds)
+				self.wpn_fps_lmg_mg42_npc.override = deep_clone(self.wpn_fps_lmg_mg42.override)
+				self.wpn_fps_lmg_mg42_npc.uses_parts = deep_clone(self.wpn_fps_lmg_mg42.uses_parts)
 			end)
 
 		--KSP 58
@@ -9461,7 +9461,7 @@ end)
 				self.parts.wpn_fps_lmg_par_b_short.supported = true
 				self.parts.wpn_fps_lmg_par_b_short.stats = deep_clone(barrels.short_b2_stats)
 				self.parts.wpn_fps_lmg_par_b_short.custom_stats = deep_clone(barrels.short_b2_stats)
-				
+
 				--Plastic Stock
 				self.parts.wpn_fps_lmg_par_s_plastic.pcs = {
 					10,
@@ -9478,27 +9478,27 @@ end)
 
 				--Belt fix
 				self.parts.wpn_fps_lmg_par_m_standard.bullet_objects = {
-					prefix = "g_bullet_", 
+					prefix = "g_bullet_",
 					amount = 5
 				}
-				
+
 				self.wpn_fps_lmg_par.stock_adapter = "wpn_fps_smg_cobray_s_m4adapter"
 				self.wpn_fps_lmg_par_npc.stock_adapter = "wpn_fps_smg_cobray_s_m4adapter"
 
-				--M240 Part Additions	
+				--M240 Part Additions
 				table.insert(self.wpn_fps_lmg_par.uses_parts, "wpn_fps_upg_par_legend")
 
-				table.insert(self.wpn_fps_lmg_par.uses_parts, "wpn_fps_upg_o_specter")	
+				table.insert(self.wpn_fps_lmg_par.uses_parts, "wpn_fps_upg_o_specter")
 				table.insert(self.wpn_fps_lmg_par.uses_parts, "wpn_fps_upg_o_aimpoint")
 				table.insert(self.wpn_fps_lmg_par.uses_parts, "wpn_fps_upg_o_docter")
-				table.insert(self.wpn_fps_lmg_par.uses_parts, "wpn_fps_upg_o_eotech")	
-				table.insert(self.wpn_fps_lmg_par.uses_parts, "wpn_fps_upg_o_t1micro")		
+				table.insert(self.wpn_fps_lmg_par.uses_parts, "wpn_fps_upg_o_eotech")
+				table.insert(self.wpn_fps_lmg_par.uses_parts, "wpn_fps_upg_o_t1micro")
 				table.insert(self.wpn_fps_lmg_par.uses_parts, "wpn_fps_upg_o_cmore")
 				table.insert(self.wpn_fps_lmg_par.uses_parts, "wpn_fps_upg_o_aimpoint_2")
 				table.insert(self.wpn_fps_lmg_par.uses_parts, "wpn_fps_upg_o_cs")
 				table.insert(self.wpn_fps_lmg_par.uses_parts, "wpn_fps_upg_o_rx30")
 				table.insert(self.wpn_fps_lmg_par.uses_parts, "wpn_fps_upg_o_rx01")
-				table.insert(self.wpn_fps_lmg_par.uses_parts, "wpn_fps_upg_o_reflex")	
+				table.insert(self.wpn_fps_lmg_par.uses_parts, "wpn_fps_upg_o_reflex")
 				table.insert(self.wpn_fps_lmg_par.uses_parts, "wpn_fps_upg_o_eotech_xps")
 				table.insert(self.wpn_fps_lmg_par.uses_parts, "wpn_fps_upg_o_uh")
 				table.insert(self.wpn_fps_lmg_par.uses_parts, "wpn_fps_upg_o_fc1")
@@ -9512,21 +9512,21 @@ end)
 				table.insert(self.wpn_fps_lmg_par.uses_parts, "wpn_fps_upg_o_xpsg33_magnifier")
 				table.insert(self.wpn_fps_lmg_par.uses_parts, "wpn_fps_upg_o_sig")
 
-				self.wpn_fps_lmg_par_npc.uses_parts = deep_clone(self.wpn_fps_lmg_par.uses_parts)		
+				self.wpn_fps_lmg_par_npc.uses_parts = deep_clone(self.wpn_fps_lmg_par.uses_parts)
 
 				--sorry for the pasghetti! Fix my fucking coding mess!!!!
 				--Hey, can't be any worse than mine :^)
 				self.wpn_fps_lmg_par.override = self.wpn_fps_lmg_par.override or {}
 
 				for i, part_id in pairs(self.wpn_fps_lmg_par.uses_parts) do
-					if self.parts[part_id] and self.parts[part_id].type and self.parts[part_id].type == "sight" then	
-						self.wpn_fps_lmg_par.override[part_id] = { parent = "upper_reciever" }	
+					if self.parts[part_id] and self.parts[part_id].type and self.parts[part_id].type == "sight" then
+						self.wpn_fps_lmg_par.override[part_id] = { parent = "upper_reciever" }
 					end
 				end
-				self.wpn_fps_lmg_par.override.wpn_fps_upg_o_hamr_reddot = { parent = "upper_reciever" }	
-				self.wpn_fps_lmg_par.override.wpn_fps_upg_o_atibal_reddot = { parent = "upper_reciever" }	
+				self.wpn_fps_lmg_par.override.wpn_fps_upg_o_hamr_reddot = { parent = "upper_reciever" }
+				self.wpn_fps_lmg_par.override.wpn_fps_upg_o_atibal_reddot = { parent = "upper_reciever" }
 
-				self.wpn_fps_lmg_par_npc.override = deep_clone(self.wpn_fps_lmg_par.override)		
+				self.wpn_fps_lmg_par_npc.override = deep_clone(self.wpn_fps_lmg_par.override)
 			end)
 
 		--M60
@@ -9545,7 +9545,7 @@ end)
 				self.parts.wpn_fps_lmg_m60_b_short.forbids = {
 					"wpn_fps_upg_bp_lmg_lionbipod"
 				}
-				
+
 				--Tactical Foregrip
 				self.parts.wpn_fps_lmg_m60_fg_tactical.pcs = {
 					10,
@@ -9559,7 +9559,7 @@ end)
 					concealment = -1,
 					recoil = 2
 				}
-				
+
 				--Tropical Foregrip
 				self.parts.wpn_fps_lmg_m60_fg_tropical.pcs = {
 					10,
@@ -9589,7 +9589,7 @@ end)
 				}
 
 
-				self.parts.wpn_fps_lmg_m60_sight_standard = deep_clone(self.parts.wpn_fps_lmg_m60_body_standard)	
+				self.parts.wpn_fps_lmg_m60_sight_standard = deep_clone(self.parts.wpn_fps_lmg_m60_body_standard)
 				self.parts.wpn_fps_lmg_m60_sight_standard.adds = nil
 				self.parts.wpn_fps_lmg_m60_sight_standard.visibility = {
 					{
@@ -9600,7 +9600,7 @@ end)
 						}
 					}
 				}
-				
+
 				--self.parts.wpn_fps_lmg_m60_body_standard.adds = { "wpn_fps_lmg_m60_sight_standard" }
 				self.parts.wpn_fps_lmg_m60_body_standard.visibility = {
 					{
@@ -9618,8 +9618,8 @@ end)
 				table.insert(self.wpn_fps_lmg_m60.uses_parts, "wpn_fps_upg_o_t1micro")
 				table.insert(self.wpn_fps_lmg_m60.uses_parts, "wpn_fps_upg_o_cmore")
 				table.insert(self.wpn_fps_lmg_m60.uses_parts, "wpn_fps_upg_o_aimpoint_2")
-				table.insert(self.wpn_fps_lmg_m60.uses_parts, "wpn_fps_upg_o_cs")	
-				table.insert(self.wpn_fps_lmg_m60.uses_parts, "wpn_fps_upg_o_rx30")	
+				table.insert(self.wpn_fps_lmg_m60.uses_parts, "wpn_fps_upg_o_cs")
+				table.insert(self.wpn_fps_lmg_m60.uses_parts, "wpn_fps_upg_o_rx30")
 				table.insert(self.wpn_fps_lmg_m60.uses_parts, "wpn_fps_upg_o_rx01")
 				table.insert(self.wpn_fps_lmg_m60.uses_parts, "wpn_fps_upg_o_reflex")
 				table.insert(self.wpn_fps_lmg_m60.uses_parts, "wpn_fps_upg_o_eotech_xps")
@@ -9640,22 +9640,22 @@ end)
 						adds = {"wpn_fps_lmg_m60_sight_standard"}
 					}
 				}
-				
+
 				for i, part_id in pairs(self.wpn_fps_lmg_m60.uses_parts) do
-					if self.parts[part_id] and self.parts[part_id].type and self.parts[part_id].type == "sight" then	
-						self.wpn_fps_lmg_m60.override[part_id] = { 
-							parent = "upper_reciever",				
+					if self.parts[part_id] and self.parts[part_id].type and self.parts[part_id].type == "sight" then
+						self.wpn_fps_lmg_m60.override[part_id] = {
+							parent = "upper_reciever",
 							forbids = { "wpn_fps_lmg_m60_sight_standard" }
 						}
 						self.wpn_fps_lmg_m60.adds[part_id] = {"wpn_fps_ass_groza_o_adapter"}
 					end
 				end
-				self.wpn_fps_lmg_m60.override.wpn_fps_ass_groza_o_adapter = { parent = "upper_reciever" }	
-				self.wpn_fps_lmg_m60.override.wpn_fps_upg_o_hamr_reddot = { parent = "upper_reciever" }	
-				self.wpn_fps_lmg_m60.override.wpn_fps_upg_o_atibal_reddot = { parent = "upper_reciever" }	
-					
-				self.wpn_fps_lmg_m60_npc.override = deep_clone(self.wpn_fps_lmg_m60.override)			
-				self.wpn_fps_lmg_m60_npc.uses_parts = deep_clone(self.wpn_fps_lmg_m60.uses_parts)			
+				self.wpn_fps_lmg_m60.override.wpn_fps_ass_groza_o_adapter = { parent = "upper_reciever" }
+				self.wpn_fps_lmg_m60.override.wpn_fps_upg_o_hamr_reddot = { parent = "upper_reciever" }
+				self.wpn_fps_lmg_m60.override.wpn_fps_upg_o_atibal_reddot = { parent = "upper_reciever" }
+
+				self.wpn_fps_lmg_m60_npc.override = deep_clone(self.wpn_fps_lmg_m60.override)
+				self.wpn_fps_lmg_m60_npc.uses_parts = deep_clone(self.wpn_fps_lmg_m60.uses_parts)
 			end)
 
 	--[[     MINIGUNS     ]]
@@ -9678,7 +9678,7 @@ end)
 					concealment = 2
 				}
 				self.parts.wpn_fps_lmg_shuno_b_short.custom_stats = deep_clone(barrels.short_b1_stats)
-				
+
 				--XS Heat Sink Barrel
 				self.parts.wpn_fps_lmg_shuno_b_heat_short.pcs = {
 					10,
@@ -9693,7 +9693,7 @@ end)
 					value = 3
 				}
 				self.parts.wpn_fps_lmg_shuno_b_heat_short.custom_stats = deep_clone(barrels.short_b1_stats)
-				
+
 				--Heat Sink Barrel
 				self.parts.wpn_fps_lmg_shuno_b_heat_long.pcs = {
 					10,
@@ -9707,7 +9707,7 @@ end)
 					recoil = 2,
 					concealment = -1
 				}
-				
+
 				self.wpn_fps_lmg_shuno.override = {
 					wpn_fps_upg_ammo_half_that = {
 						supported = true,
@@ -9717,19 +9717,19 @@ end)
 							--extra_ammo = 60,
 							--concealment = -2
 						},
-						--custom_stats = {movement_speed = 0.9},	
+						--custom_stats = {movement_speed = 0.9},
 					}
-				}	
+				}
 
 				--table.insert(self.wpn_fps_lmg_shuno.uses_parts, "wpn_fps_upg_ammo_half_that")
-				--table.insert(self.wpn_fps_lmg_shuno_npc.uses_parts, "wpn_fps_upg_ammo_half_that")		
-					
-				self.wpn_fps_lmg_shuno_npc.uses_parts = deep_clone(self.wpn_fps_lmg_shuno.uses_parts)	
+				--table.insert(self.wpn_fps_lmg_shuno_npc.uses_parts, "wpn_fps_upg_ammo_half_that")
+
+				self.wpn_fps_lmg_shuno_npc.uses_parts = deep_clone(self.wpn_fps_lmg_shuno.uses_parts)
 			end)
 
 		--M134
 			Hooks:PostHook(WeaponFactoryTweakData, "_init_m134", "resmod_m134", function(self)
-				
+
 				--Light Body
 				self.parts.wpn_fps_lmg_m134_body_upper_light.pcs = {
 					10,
@@ -9744,7 +9744,7 @@ end)
 					recoil = -2
 				}
 				self.parts.wpn_fps_lmg_m134_body_upper_light.custom_stats = {}
-				
+
 				--The Stump Barrel
 				self.parts.wpn_fps_lmg_m134_barrel_short.pcs = {
 					10,
@@ -9768,7 +9768,7 @@ end)
 				self.parts.wpn_fps_lmg_m134_barrel_extreme.stats = deep_clone(barrels.long_b3_stats)
 				self.parts.wpn_fps_lmg_m134_barrel_extreme.stats.jab_range = 50
 				self.parts.wpn_fps_lmg_m134_barrel_extreme.custom_stats = deep_clone(barrels.long_b3_stats)
-				
+
 				--Override
 				self.wpn_fps_lmg_m134.override = {
 					wpn_fps_upg_ammo_half_that = {
@@ -9779,14 +9779,14 @@ end)
 							--extra_ammo = 60,
 							--concealment = -2
 						},
-						--custom_stats = {movement_speed = 0.9},	
+						--custom_stats = {movement_speed = 0.9},
 					}
-				}				
-				
+				}
+
 				--table.insert(self.wpn_fps_lmg_m134.uses_parts, "wpn_fps_upg_ammo_half_that")
-				--table.insert(self.wpn_fps_lmg_m134_npc.uses_parts, "wpn_fps_upg_ammo_half_that")			
-						
-				self.wpn_fps_lmg_m134_npc.uses_parts = deep_clone(self.wpn_fps_lmg_m134.uses_parts)			
+				--table.insert(self.wpn_fps_lmg_m134_npc.uses_parts, "wpn_fps_upg_ammo_half_that")
+
+				self.wpn_fps_lmg_m134_npc.uses_parts = deep_clone(self.wpn_fps_lmg_m134.uses_parts)
 			end)
 
 
@@ -9851,7 +9851,7 @@ end)
 								self.wpn_fps_ass_amcar.default_blueprint[i] = "wpn_fps_m4_uupg_m_std_vanilla"
 							end
 						end
-					end	
+					end
 
 					--AMCAR Part Table
 					for i, part_id in pairs(self.wpn_fps_ass_amcar.uses_parts) do
@@ -9871,13 +9871,13 @@ end)
 								self.wpn_fps_ass_amcar.uses_parts[i] = "wpn_fps_upg_m4_m_straight"
 							end
 						end
-					end	
+					end
 
-					
+
 					table.insert(self.wpn_fps_ass_amcar.uses_parts, "wpn_fps_m4_uupg_s_fold")
 					table.insert(self.wpn_fps_ass_amcar.uses_parts, "wpn_fps_ass_m16_s_fixed")
 					table.insert(self.wpn_fps_ass_amcar.uses_parts, "wpn_fps_upg_m4_s_pts")
-					table.insert(self.wpn_fps_ass_amcar.uses_parts, "wpn_fps_smg_olympic_s_short")	
+					table.insert(self.wpn_fps_ass_amcar.uses_parts, "wpn_fps_smg_olympic_s_short")
 					table.insert(self.wpn_fps_ass_amcar.uses_parts, "wpn_fps_upg_ass_m4_lower_reciever_core")
 					table.insert(self.wpn_fps_ass_amcar.uses_parts, "wpn_fps_upg_m4_m_drum")
 					table.insert(self.wpn_fps_ass_amcar.uses_parts, "wpn_fps_m4_upper_reciever_edge")
@@ -9890,10 +9890,10 @@ end)
 					table.insert(self.wpn_fps_ass_amcar.uses_parts, "wpn_fps_upg_s_saintvictor_hera")
 					table.insert(self.wpn_fps_ass_amcar.uses_parts, "wpn_fps_upg_o_northtac")
 					table.insert(self.wpn_fps_ass_amcar.uses_parts, "wpn_fps_upg_o_northtac_reddot")
-					
-					self.wpn_fps_ass_amcar_npc.default_blueprint = deep_clone(self.wpn_fps_ass_amcar.default_blueprint)	
-					self.wpn_fps_ass_amcar_npc.uses_parts = deep_clone(self.wpn_fps_ass_amcar.uses_parts)	
-					self.wpn_fps_ass_amcar_npc.adds = deep_clone(self.wpn_fps_ass_amcar.adds)	
+
+					self.wpn_fps_ass_amcar_npc.default_blueprint = deep_clone(self.wpn_fps_ass_amcar.default_blueprint)
+					self.wpn_fps_ass_amcar_npc.uses_parts = deep_clone(self.wpn_fps_ass_amcar.uses_parts)
+					self.wpn_fps_ass_amcar_npc.adds = deep_clone(self.wpn_fps_ass_amcar.adds)
 				end)
 
 			--G36
@@ -9921,7 +9921,7 @@ end)
 						ads_speed_mult = 0.975
 					}
 					table.insert(self.parts.wpn_fps_ass_g36_fg_c.forbids, "wpn_fps_pis_usp_fl_adapter")
-					
+
 					--Polizei Special Foregrip
 					self.parts.wpn_fps_ass_g36_fg_ksk.pcs = {
 						10,
@@ -9935,7 +9935,7 @@ end)
 						recoil = 2,
 						concealment = -1
 					}
-					
+
 					--(JP36) Solid Stock
 					self.parts.wpn_fps_ass_g36_s_kv.pcs = {
 						10,
@@ -9946,7 +9946,7 @@ end)
 					self.parts.wpn_fps_ass_g36_s_kv.supported = true
 					self.parts.wpn_fps_ass_g36_s_kv.stats = deep_clone(stocks.folder_to_adj_rec_stats)
 					self.parts.wpn_fps_ass_g36_s_kv.custom_stats = deep_clone(stocks.folder_to_adj_rec_stats)
-					
+
 					--(JP36) Sniper Stock
 					self.parts.wpn_fps_ass_g36_s_sl8.pcs = {
 						10,
@@ -9962,7 +9962,7 @@ end)
 					self.wpn_fps_ass_g36_npc.stock_adapter = "wpn_fps_upg_m4_s_adapter"
 
 					self.wpn_fps_ass_g36.adds = self.wpn_fps_ass_g36.adds or {}
-					self.wpn_fps_ass_g36.adds.wpn_fps_upg_m4_s_adapter = { 
+					self.wpn_fps_ass_g36.adds.wpn_fps_upg_m4_s_adapter = {
 						"wpn_fps_ass_g36_body_standard",
 						"wpn_fps_ass_g36_g_standard"
 					}
@@ -9970,7 +9970,7 @@ end)
 					self.wpn_fps_ass_g36.adds.wpn_fps_upg_vg_ass_smg_verticalgrip = { "wpn_fps_pis_usp_fl_adapter" }
 					self.wpn_fps_ass_g36.adds.wpn_fps_upg_vg_ass_smg_afg = { "wpn_fps_pis_usp_fl_adapter" }
 					self.wpn_fps_ass_g36.adds.wpn_fps_smg_schakal_vg_surefire = { "wpn_fps_pis_usp_fl_adapter" }
-					
+
 					self.wpn_fps_ass_g36.override = self.wpn_fps_ass_g36.override or {}
 					self.wpn_fps_ass_g36.override.wpn_fps_upg_m4_s_standard = {
 						stats = deep_clone(stocks.folder_to_adj_acc1_stats),
@@ -10026,7 +10026,7 @@ end)
 
 			--SG552
 				Hooks:PostHook(WeaponFactoryTweakData, "_init_s552", "resmod_s552", function(self)
-					
+
 					--Long Barrel
 					self.parts.wpn_fps_ass_s552_b_long.pcs = {
 						10,
@@ -10065,7 +10065,7 @@ end)
 						recoil = 2,
 						concealment = -1
 					}
-						
+
 					--Railed Foregrip
 					self.parts.wpn_fps_ass_s552_fg_railed.pcs = {
 						10,
@@ -10089,7 +10089,7 @@ end)
 					}
 					self.parts.wpn_fps_ass_s552_g_standard_green.supported = true
 					self.parts.wpn_fps_ass_s552_g_standard_green.stats = deep_clone(grips.recoil_1)
-					
+
 					--Enhanced Stock
 					self.parts.wpn_fps_ass_s552_s_standard_green.pcs = {
 						10,
@@ -10138,10 +10138,10 @@ end)
 						stats = deep_clone(stocks.folder_to_hvy_acc2_stats),
 						custom_stats = deep_clone(stocks.folder_to_hvy_acc2_stats)
 					}
-					
+
 					table.insert(self.wpn_fps_ass_s552.uses_parts, "wpn_fps_upg_o_northtac")
 					table.insert(self.wpn_fps_ass_s552.uses_parts, "wpn_fps_upg_o_northtac_reddot")
-					
+
 					self.wpn_fps_ass_s552_npc.uses_parts = deep_clone(self.wpn_fps_ass_s552.uses_parts)
 
 					self.wpn_fps_ass_s552_secondary = nil
@@ -10150,7 +10150,7 @@ end)
 
 			--VHS-2
 				Hooks:PostHook(WeaponFactoryTweakData, "_init_vhs", "resmod_vhs", function(self)
-					
+
 					--default mag
 					self.parts.wpn_fps_ass_vhs_m.stats = { value = 0 }
 
@@ -10165,7 +10165,7 @@ end)
 							}
 						}
 					}
-					
+
 					--CQB Barrel
 					self.parts.wpn_fps_ass_vhs_b_short.pcs = {
 						10,
@@ -10176,7 +10176,7 @@ end)
 					self.parts.wpn_fps_ass_vhs_b_short.supported = true
 					self.parts.wpn_fps_ass_vhs_b_short.stats = deep_clone(barrels.short_b1_stats)
 					self.parts.wpn_fps_ass_vhs_b_short.custom_stats = deep_clone(barrels.short_b1_stats)
-					
+
 					--Silenced Barrel
 					self.parts.wpn_fps_ass_vhs_b_silenced.pcs = {
 						10,
@@ -10193,7 +10193,7 @@ end)
 						alert_size = -1
 					}
 					self.parts.wpn_fps_ass_vhs_b_silenced.perks = {"silencer"}
-					
+
 					--Precision Barrel
 					self.parts.wpn_fps_ass_vhs_b_sniper.pcs = {
 						10,
@@ -10249,7 +10249,7 @@ end)
 						recoil = -2,
 						concealment = 1
 					}
-						
+
 					--(CAR) Long Barrel
 					self.parts.wpn_fps_m4_uupg_b_long.pcs = {
 						10,
@@ -10282,7 +10282,7 @@ end)
 					self.parts.wpn_fps_m4_uupg_b_medium.supported = true
 					self.parts.wpn_fps_m4_uupg_b_medium.stats = deep_clone(barrels.long_b2_stats)
 					self.parts.wpn_fps_m4_uupg_b_medium.custom_stats = deep_clone(barrels.long_b2_stats)
-					
+
 					--(CAR) Stealth Barrel
 					self.parts.wpn_fps_m4_uupg_b_sd.pcs = {
 						20,
@@ -10311,8 +10311,8 @@ end)
 					table.insert(self.parts.wpn_fps_m4_uupg_b_sd.forbids, "wpn_fps_snp_msr_ns_suppressor")
 					table.insert(self.parts.wpn_fps_m4_uupg_b_sd.forbids, "wpn_fps_snp_victor_ns_omega")
 					table.insert(self.parts.wpn_fps_m4_uupg_b_sd.forbids, "wpn_fps_upg_ns_ass_filter")
-					
-					
+
+
 					--Aftermarket Special Handguard
 					self.parts.wpn_fps_m4_uupg_fg_lr300.pcs = {
 						10,
@@ -10342,7 +10342,7 @@ end)
 						reload = -3,
 						concealment = -1
 					}
-					
+
 					--Folding Stock
 					self.parts.wpn_fps_m4_uupg_s_fold.pcs = {
 						10,
@@ -10353,7 +10353,7 @@ end)
 					self.parts.wpn_fps_m4_uupg_s_fold.supported = true
 					self.parts.wpn_fps_m4_uupg_s_fold.stats = deep_clone(stocks.adj_to_fold_stats)
 					self.parts.wpn_fps_m4_uupg_s_fold.custom_stats = deep_clone(stocks.adj_to_fold_stats)
-					
+
 					--(CAR) Ergo Grip
 					self.parts.wpn_fps_upg_m4_g_ergo.pcs = {
 						10,
@@ -10363,7 +10363,7 @@ end)
 					}
 					self.parts.wpn_fps_upg_m4_g_ergo.supported = true
 					self.parts.wpn_fps_upg_m4_g_ergo.stats = deep_clone(grips.acc_recoil)
-					self.parts.wpn_fps_upg_m4_g_ergo.custom_stats = {}	
+					self.parts.wpn_fps_upg_m4_g_ergo.custom_stats = {}
 
 					--(CAR) Pro Grip
 					self.parts.wpn_fps_upg_m4_g_sniper.pcs = {
@@ -10375,8 +10375,8 @@ end)
 					self.parts.wpn_fps_upg_m4_g_sniper.supported = true
 					self.parts.wpn_fps_upg_m4_g_sniper.stats = deep_clone(grips.dual_stat_1)
 					self.parts.wpn_fps_upg_m4_g_sniper.custom_stats = deep_clone(grips.dual_stat_1)
-					
-					--(CAR) Drum Magazine 
+
+					--(CAR) Drum Magazine
 					self.parts.wpn_fps_upg_m4_m_drum = {
 						pcs = {},
 						type = "magazine",
@@ -10398,7 +10398,7 @@ end)
 						}
 					}
 					self.parts.wpn_fps_upg_m4_m_drum.third_unit = "units/pd2_dlc_opera/weapons/wpn_fps_ass_tecci_pts/wpn_third_ass_tecci_m_drum"
-					
+
 					--(CAR) Tactical Mag.
 					self.parts.wpn_fps_upg_m4_m_pmag.pcs = {
 						10,
@@ -10413,10 +10413,10 @@ end)
 						extra_ammo = -5,
 						reload = 3
 					}
-					self.parts.wpn_fps_upg_m4_m_pmag.custom_stats = { 
+					self.parts.wpn_fps_upg_m4_m_pmag.custom_stats = {
 						ads_speed_mult = 0.975
 					}
-					
+
 					--Vintage Mag.
 					self.parts.wpn_fps_upg_m4_m_straight.pcs = {
 						10,
@@ -10432,10 +10432,10 @@ end)
 						reload = 5,
 						extra_ammo = -10
 					}
-					self.parts.wpn_fps_upg_m4_m_straight.custom_stats = { 
+					self.parts.wpn_fps_upg_m4_m_straight.custom_stats = {
 						ads_speed_mult = 0.95
 					}
-					
+
 					--Standard Stock
 					self.parts.wpn_fps_upg_m4_s_standard.pcs = {
 						10,
@@ -10457,7 +10457,7 @@ end)
 					self.parts.wpn_fps_upg_m4_s_pts.supported = true
 					self.parts.wpn_fps_upg_m4_s_pts.stats = deep_clone(stocks.adj_acc_stats)
 					self.parts.wpn_fps_upg_m4_s_pts.custom_stats = deep_clone(stocks.adj_acc_stats)
-						
+
 					--Longbore (Exclusive Set)
 					self.parts.wpn_fps_m4_upg_fg_mk12.pcs = {}
 					self.parts.wpn_fps_m4_upg_fg_mk12.unit = "units/payday2/weapons/wpn_upg_dummy/wpn_upg_dummy"
@@ -10472,12 +10472,12 @@ end)
 						value = 10,
 						spread = 4,
 						concealment = -4
-					}	
+					}
 					self.parts.wpn_fps_m4_upg_fg_mk12.custom_stats = {
 						falloff_start_mult = 1.3,
 						falloff_end_mult = 1.3,
 						ads_speed_mult = 1.1
-					}	
+					}
 					self.parts.wpn_fps_m4_upg_fg_mk12.perks = nil
 					self.parts.wpn_fps_m4_upg_fg_mk12.stance_mod = {
 						wpn_fps_ass_m4 = {
@@ -10490,7 +10490,7 @@ end)
 						wpn_fps_m4_uupg_fg_rail_ext = {
 							third_unit = "units/payday2/weapons/wpn_upg_dummy/wpn_upg_dummy",
 							unit = "units/payday2/weapons/wpn_upg_dummy/wpn_upg_dummy"
-						},		
+						},
 						--Overriding barrels for the unique FG model
 						wpn_fps_m4_uupg_b_medium_vanilla = {
 							third_unit = "units/payday2/weapons/wpn_third_ass_m4_pts/wpn_third_m4_uupg_b_long",
@@ -10499,14 +10499,14 @@ end)
 						wpn_fps_m4_uupg_b_short = {
 							third_unit = "units/payday2/weapons/wpn_third_ass_m4_pts/wpn_third_m4_uupg_b_long",
 							unit = "units/payday2/weapons/wpn_fps_ass_m4_pts/wpn_fps_m4_uupg_b_long"
-						},		
+						},
 						wpn_fps_m4_uupg_b_sd = {
 							adds = {
 								"wpn_fps_m4_upg_ns_mk12"
 							},
 							third_unit = "units/payday2/weapons/wpn_third_ass_m4_pts/wpn_third_m4_uupg_b_long",
 							unit = "units/payday2/weapons/wpn_fps_ass_m4_pts/wpn_fps_m4_uupg_b_long"
-						},	
+						},
 						wpn_fps_m4_uupg_b_long = {
 							third_unit = "units/payday2/weapons/wpn_third_ass_m4_pts/wpn_third_m4_uupg_b_long",
 							unit = "units/payday2/weapons/wpn_fps_ass_m4_pts/wpn_fps_m4_uupg_b_long"
@@ -10515,14 +10515,14 @@ end)
 						wpn_fps_upg_m4_b_victor = {
 							third_unit = "units/payday2/weapons/wpn_third_ass_m4_pts/wpn_third_m4_uupg_b_long",
 							unit = "units/payday2/weapons/wpn_fps_ass_m4_pts/wpn_fps_m4_uupg_b_long"
-						},			
+						},
 						--Now foregrips
 						wpn_fps_m4_uupg_fg_rail = {
 							third_unit = "units/pd2_dlc_ja22/weapons/wpn_fps_m4_upg_mk12_pts/wpn_third_m4_upg_fg_mk12",
 							unit = "units/pd2_dlc_ja22/weapons/wpn_fps_m4_upg_mk12_pts/wpn_fps_m4_upg_fg_mk12",
 							adds = {},
 							override = {}
-						},		
+						},
 						wpn_fps_m4_uupg_fg_lr300 = {
 							third_unit = "units/pd2_dlc_ja22/weapons/wpn_fps_m4_upg_mk12_pts/wpn_third_m4_upg_fg_mk12",
 							unit = "units/pd2_dlc_ja22/weapons/wpn_fps_m4_upg_mk12_pts/wpn_fps_m4_upg_fg_mk12"
@@ -10530,23 +10530,23 @@ end)
 						wpn_fps_upg_fg_jp = {
 							third_unit = "units/pd2_dlc_ja22/weapons/wpn_fps_m4_upg_mk12_pts/wpn_third_m4_upg_fg_mk12",
 							unit = "units/pd2_dlc_ja22/weapons/wpn_fps_m4_upg_mk12_pts/wpn_fps_m4_upg_fg_mk12"
-						},	
+						},
 						wpn_fps_upg_fg_smr = {
 							third_unit = "units/pd2_dlc_ja22/weapons/wpn_fps_m4_upg_mk12_pts/wpn_third_m4_upg_fg_mk12",
 							unit = "units/pd2_dlc_ja22/weapons/wpn_fps_m4_upg_mk12_pts/wpn_fps_m4_upg_fg_mk12"
-						},		
+						},
 						wpn_fps_upg_ass_m4_fg_moe = {
 							third_unit = "units/pd2_dlc_ja22/weapons/wpn_fps_m4_upg_mk12_pts/wpn_third_m4_upg_fg_mk12",
 							unit = "units/pd2_dlc_ja22/weapons/wpn_fps_m4_upg_mk12_pts/wpn_fps_m4_upg_fg_mk12"
-						},	
+						},
 						wpn_fps_upg_ass_m4_fg_lvoa = {
 							third_unit = "units/pd2_dlc_ja22/weapons/wpn_fps_m4_upg_mk12_pts/wpn_third_m4_upg_fg_mk12",
 							unit = "units/pd2_dlc_ja22/weapons/wpn_fps_m4_upg_mk12_pts/wpn_fps_m4_upg_fg_mk12"
-						},		
+						},
 						wpn_fps_uupg_fg_radian = {
 							third_unit = "units/pd2_dlc_ja22/weapons/wpn_fps_m4_upg_mk12_pts/wpn_third_m4_upg_fg_mk12",
 							unit = "units/pd2_dlc_ja22/weapons/wpn_fps_m4_upg_mk12_pts/wpn_fps_m4_upg_fg_mk12"
-						},		
+						},
 
 						wpn_fps_ass_m4_fg_vietnam_akcar = {
 							third_unit = "units/pd2_dlc_ja22/weapons/wpn_fps_m4_upg_mk12_pts/wpn_third_m4_upg_fg_mk12",
@@ -10555,11 +10555,11 @@ end)
 						wpn_fps_snp_tti_fg_m4 = {
 							third_unit = "units/pd2_dlc_ja22/weapons/wpn_fps_m4_upg_mk12_pts/wpn_third_m4_upg_fg_mk12",
 							unit = "units/pd2_dlc_ja22/weapons/wpn_fps_m4_upg_mk12_pts/wpn_fps_m4_upg_fg_mk12"
-						},		
+						},
 						wpn_fps_upg_m4_fg_hera = {
 							third_unit = "units/pd2_dlc_ja22/weapons/wpn_fps_m4_upg_mk12_pts/wpn_third_m4_upg_fg_mk12",
 							unit = "units/pd2_dlc_ja22/weapons/wpn_fps_m4_upg_mk12_pts/wpn_fps_m4_upg_fg_mk12"
-						},		
+						},
 						--Slight change to optics just cause of how huge the FG is
 						wpn_fps_upg_o_specter = {
 							a_obj = "a_o_2"
@@ -10688,14 +10688,14 @@ end)
 									rotation = Rotation(-0, -0, -10)
 								}
 							}
-						}		
+						}
 					}
 					--Longbore Suppressor
 					self.parts.wpn_fps_m4_upg_ns_mk12.pcs = nil
 					self.parts.wpn_fps_m4_upg_ns_mk12.supported = true
 					self.parts.wpn_fps_m4_upg_ns_mk12.stats = {
 						value = 0
-					}	
+					}
 
 					--M4A1 sights set up
 					self.parts.fake_a_os = {
@@ -10784,7 +10784,7 @@ end)
 					self.wpn_fps_ass_m4.adds.wpn_fps_uupg_fg_radian = { "wpn_fps_m4_uupg_fg_rail_ext_dummy" }
 					self.wpn_fps_ass_m4.adds.wpn_fps_upg_m4_fg_hera = { "wpn_fps_m4_uupg_fg_rail_ext_dummy" }
 					self.wpn_fps_ass_m4.adds.wpn_fps_uupg_m4_fg_victorcar = { "wpn_fps_m4_uupg_fg_rail_ext_dummy" }
-					
+
 					--CAR-4 Part Additions
 					table.insert(self.wpn_fps_ass_m4.uses_parts, "wpn_fps_smg_olympic_s_short")
 					table.insert(self.wpn_fps_ass_m4.uses_parts, "wpn_fps_ass_m16_s_fixed")
@@ -10796,13 +10796,13 @@ end)
 					table.insert(self.wpn_fps_ass_m4.uses_parts, "wpn_fps_upg_o_northtac_reddot")
 					table.insert(self.wpn_fps_ass_m4.uses_parts, "wpn_fps_ass_m4_azusa_cnuy")
 					table.insert(self.wpn_fps_ass_m4.uses_parts, "wpn_fps_ass_m4_cnuy_saori")
-					
+
 					--Faster/Slower ROF mods (Unused)
 					--[[
 					table.insert(self.wpn_fps_ass_m4.uses_parts, "wpn_fps_upg_i_slower_rof")
-					table.insert(self.wpn_fps_ass_m4_npc.uses_parts, "wpn_fps_upg_i_slower_rof")	
+					table.insert(self.wpn_fps_ass_m4_npc.uses_parts, "wpn_fps_upg_i_slower_rof")
 					table.insert(self.wpn_fps_ass_m4.uses_parts, "wpn_fps_upg_i_faster_rof")
-					table.insert(self.wpn_fps_ass_m4_npc.uses_parts, "wpn_fps_upg_i_faster_rof")	
+					table.insert(self.wpn_fps_ass_m4_npc.uses_parts, "wpn_fps_upg_i_faster_rof")
 					]]--
 
 					self.wpn_fps_ass_m4_npc.override = deep_clone(self.wpn_fps_ass_m4.override)
@@ -10829,7 +10829,7 @@ end)
 						concealment = -2,
 						recoil = 4
 					}
-					
+
 					--Belgian Heat Handguard
 					self.parts.wpn_fps_ass_ak5_fg_fnc.pcs = {
 						10,
@@ -10870,7 +10870,7 @@ end)
 						spread = 1,
 						recoil = -2
 					}
-					
+
 					--Caesar Stock
 					self.parts.wpn_fps_ass_ak5_s_ak5c.pcs = {
 						10,
@@ -10928,8 +10928,8 @@ end)
 					table.insert(self.wpn_fps_ass_ak5.uses_parts, "wpn_fps_upg_m4_s_standard")
 					table.insert(self.wpn_fps_ass_ak5.uses_parts, "wpn_fps_upg_m4_s_pts")
 					table.insert(self.wpn_fps_ass_ak5.uses_parts, "wpn_fps_upg_m4_s_crane")
-					table.insert(self.wpn_fps_ass_ak5.uses_parts, "wpn_fps_upg_m4_s_mk46")	
-					table.insert(self.wpn_fps_ass_ak5.uses_parts, "wpn_fps_snp_victor_s_mod0")	
+					table.insert(self.wpn_fps_ass_ak5.uses_parts, "wpn_fps_upg_m4_s_mk46")
+					table.insert(self.wpn_fps_ass_ak5.uses_parts, "wpn_fps_snp_victor_s_mod0")
 					table.insert(self.wpn_fps_ass_ak5.uses_parts, "wpn_fps_upg_m4_s_ubr")
 					table.insert(self.wpn_fps_ass_ak5.uses_parts, "wpn_fps_snp_tti_s_vltor")
 					table.insert(self.wpn_fps_ass_ak5.uses_parts, "wpn_fps_sho_sko12_stock")
@@ -11023,7 +11023,7 @@ end)
 					self.wpn_fps_ass_aug.override.wpn_fps_upg_o_mbus_front = {
 						a_obj = "a_of"
 					}
-					
+
 					--[[
 					self.wpn_fps_ass_aug.override.wpn_upg_o_marksmansight_rear_vanilla = {
 						a_obj = "a_or",
@@ -11038,7 +11038,7 @@ end)
 						a_obj = "a_of"
 					}
 					--]]
-					
+
 					--UAR Default Blueprint, disabling Vertical Grips
 					for i, part_id in pairs(self.wpn_fps_ass_aug.default_blueprint) do
 						attachment_list = {
@@ -11050,7 +11050,7 @@ end)
 							end
 						end
 					end
-					
+
 					for i, part_id in pairs(self.wpn_fps_ass_aug.uses_parts) do
 						attachment_list = {
 							"wpn_fps_upg_vg_ass_smg_verticalgrip",
@@ -11061,14 +11061,14 @@ end)
 								self.wpn_fps_ass_aug.uses_parts[i] = "wpn_fps_upg_vg_ass_smg_verticalgrip_vanilla"
 							end
 						end
-					end	
+					end
 
 					table.insert(self.wpn_fps_ass_aug.uses_parts, "wpn_fps_smg_schakal_vg_surefire")
 					table.insert(self.wpn_fps_ass_aug.uses_parts, "wpn_fps_upg_o_northtac")
 					table.insert(self.wpn_fps_ass_aug.uses_parts, "wpn_fps_upg_o_northtac_reddot")
 					table.insert(self.wpn_fps_ass_aug.uses_parts, "wpn_fps_upg_o_dd_irons_dmc")
 					table.insert(self.wpn_fps_ass_aug.uses_parts, "wpn_fps_upg_o_mbus_rear")
-					
+
 					self.wpn_fps_ass_aug_npc.uses_parts = deep_clone(self.wpn_fps_ass_aug.uses_parts)
 
 					self.wpn_fps_ass_aug_secondary = nil
@@ -11077,7 +11077,7 @@ end)
 
 			--FN2000
 				Hooks:PostHook(WeaponFactoryTweakData, "_init_corgi", "resmod_corgi", function(self)
-					
+
 					--Dunes Tactical Receiver
 					self.parts.wpn_fps_ass_corgi_body_lower_strap.pcs = {
 						10,
@@ -11091,7 +11091,7 @@ end)
 						concealment = -1,
 						recoil = 2
 					}
-					
+
 					--MSG Barrel
 					self.parts.wpn_fps_ass_corgi_b_short.pcs = {
 						10,
@@ -11105,7 +11105,7 @@ end)
 
 					table.insert(self.wpn_fps_ass_corgi.uses_parts, "wpn_fps_upg_o_northtac")
 					table.insert(self.wpn_fps_ass_corgi.uses_parts, "wpn_fps_upg_o_northtac_reddot")
-					
+
 					self.wpn_fps_ass_corgi_npc.uses_parts = deep_clone(self.wpn_fps_ass_corgi.uses_parts)
 				end)
 
@@ -11114,7 +11114,7 @@ end)
 
 					--AK74 Overrides Table
 					self.wpn_fps_ass_74.override = self.wpn_fps_ass_74.override or {}
-					
+
 					self.wpn_fps_ass_74.override.wpn_fps_upg_ass_ak_b_zastava = nil -- fuck
 
 					self.wpn_fps_ass_74.override.wpn_fps_upg_m4_s_standard = {
@@ -11205,7 +11205,7 @@ end)
 					--table.insert(self.wpn_fps_ass_74.uses_parts, "wpn_upg_ak_s_nostock")
 					--table.insert(self.wpn_fps_ass_74_npc.uses_parts, "wpn_upg_ak_s_nostock")
 
-					self.wpn_fps_ass_74_npc.uses_parts = deep_clone(self.wpn_fps_ass_74.uses_parts)	
+					self.wpn_fps_ass_74_npc.uses_parts = deep_clone(self.wpn_fps_ass_74.uses_parts)
 
 					self.wpn_fps_ass_74_secondary = nil
 					self.wpn_fps_ass_74_secondary_npc = nil
@@ -11221,7 +11221,7 @@ end)
 					}
 					--AK17 Custom parts
 					--table.insert(self.wpn_fps_ass_flint.uses_parts, "wpn_fps_upg_m4_s_standard")
-					--table.insert(self.wpn_fps_ass_flint_npc.uses_parts, "wpn_fps_upg_m4_s_standard")	
+					--table.insert(self.wpn_fps_ass_flint_npc.uses_parts, "wpn_fps_upg_m4_s_standard")
 					self.wpn_fps_ass_flint.override = self.wpn_fps_ass_flint.override or {}
 
 					self.wpn_fps_ass_flint.override.wpn_lmg_rpk_m_ban = {
@@ -11242,8 +11242,8 @@ end)
 					table.insert(self.wpn_fps_ass_flint.uses_parts, "wpn_fps_upg_o_northtac")
 					table.insert(self.wpn_fps_ass_flint.uses_parts, "wpn_fps_upg_o_northtac_reddot")
 					table.insert(self.wpn_fps_ass_flint.uses_parts, "wpn_fps_upg_i_abakan")
-						
-					self.wpn_fps_ass_flint_npc.uses_parts = deep_clone(self.wpn_fps_ass_flint.uses_parts)	
+
+					self.wpn_fps_ass_flint_npc.uses_parts = deep_clone(self.wpn_fps_ass_flint.uses_parts)
 				end)
 
 		--SECONDARIES
@@ -11268,7 +11268,7 @@ end)
 						recoil = 2,
 						concealment = -1
 					}
-					
+
 					--Shorter Than Short Stock
 					self.parts.wpn_fps_smg_olympic_s_short.pcs = {
 						10,
@@ -11422,7 +11422,7 @@ end)
 								self.wpn_fps_smg_olympic.default_blueprint[i] = "wpn_fps_m4_uupg_m_std_vanilla"
 							end
 						end
-					end	
+					end
 
 					--Para Part Table
 					for i, part_id in pairs(self.wpn_fps_smg_olympic.uses_parts) do
@@ -11443,10 +11443,10 @@ end)
 							end
 						end
 					end
-					
+
 					table.insert(self.wpn_fps_smg_olympic.uses_parts, "wpn_fps_m4_uupg_s_fold")
-					table.insert(self.wpn_fps_smg_olympic.uses_parts, "wpn_fps_ass_m16_s_fixed")			
-					table.insert(self.wpn_fps_smg_olympic.uses_parts, "wpn_fps_upg_s_saintvictor_hera")	
+					table.insert(self.wpn_fps_smg_olympic.uses_parts, "wpn_fps_ass_m16_s_fixed")
+					table.insert(self.wpn_fps_smg_olympic.uses_parts, "wpn_fps_upg_s_saintvictor_hera")
 					table.insert(self.wpn_fps_smg_olympic.uses_parts, "wpn_fps_upg_o_northtac")
 					table.insert(self.wpn_fps_smg_olympic.uses_parts, "wpn_fps_upg_o_northtac_reddot")
 					table.insert(self.wpn_fps_smg_olympic.uses_parts, "wpn_fps_upg_i_og_rof")
@@ -11460,7 +11460,7 @@ end)
 							end
 						end
 					end
-						
+
 					self.wpn_fps_smg_olympic_npc.override = deep_clone(self.wpn_fps_smg_olympic.override)
 					self.wpn_fps_smg_olympic_npc.uses_parts = deep_clone(self.wpn_fps_smg_olympic.uses_parts)
 					self.wpn_fps_smg_olympic_npc.adds = deep_clone(self.wpn_fps_smg_olympic.adds)
@@ -11511,7 +11511,7 @@ end)
 						}
 					}
 					self.wpn_fps_smg_x_olympic.override.wpn_fps_ass_m4_m_slick = nil
-					self.wpn_fps_smg_x_olympic.override.wpn_fps_upg_m4_m_quad = { 
+					self.wpn_fps_smg_x_olympic.override.wpn_fps_upg_m4_m_quad = {
 						stats = {
 							value = 3,
 							concealment = -4,
@@ -11581,7 +11581,7 @@ end)
 								self.wpn_fps_smg_x_olympic.default_blueprint[i] = "wpn_fps_m4_uupg_m_std_vanilla"
 							end
 						end
-					end	
+					end
 
 					--Para Part Table
 					for i, part_id in pairs(self.wpn_fps_smg_x_olympic.uses_parts) do
@@ -11615,7 +11615,7 @@ end)
 					self.wpn_fps_smg_x_olympic_npc.uses_parts = deep_clone(self.wpn_fps_smg_x_olympic.uses_parts)
 				end)
 
-			--FAMAS 
+			--FAMAS
 				Hooks:PostHook(WeaponFactoryTweakData, "_init_famas", "resmod_famas", function(self)
 
 					self.parts.wpn_fps_ass_famas_m_standard_dummy = deep_clone(self.parts.wpn_fps_ass_famas_m_standard)
@@ -11634,19 +11634,19 @@ end)
 					self.parts.wpn_fps_ass_famas_b_long.supported = true
 					self.parts.wpn_fps_ass_famas_b_long.stats = deep_clone(barrels.long_b1_stats)
 					self.parts.wpn_fps_ass_famas_b_long.custom_stats = deep_clone(barrels.long_b1_stats)
-					
+
 					--Short Barrel
 					self.parts.wpn_fps_ass_famas_b_short.pcs = {}
 					self.parts.wpn_fps_ass_famas_b_short.supported = true
 					self.parts.wpn_fps_ass_famas_b_short.stats = deep_clone(barrels.short_b1_stats)
 					self.parts.wpn_fps_ass_famas_b_short.custom_stats = deep_clone(barrels.short_b1_stats)
-					
+
 					--Sniper Barrel
 					self.parts.wpn_fps_ass_famas_b_sniper.pcs = {}
 					self.parts.wpn_fps_ass_famas_b_sniper.supported = true
 					self.parts.wpn_fps_ass_famas_b_sniper.stats = deep_clone(barrels.long_b3_stats)
 					self.parts.wpn_fps_ass_famas_b_sniper.custom_stats = deep_clone(barrels.long_b3_stats)
-					
+
 					--Suppressed Barrel
 					self.parts.wpn_fps_ass_famas_b_suppressed.pcs = {}
 					self.parts.wpn_fps_ass_famas_b_suppressed.supported = true
@@ -11658,7 +11658,7 @@ end)
 						alert_size = -1
 					}
 					self.parts.wpn_fps_ass_famas_b_suppressed.perks = {"silencer"}
-					
+
 					--G2 Grip
 					self.parts.wpn_fps_ass_famas_g_retro.pcs = {}
 					self.parts.wpn_fps_ass_famas_g_retro.supported = true
@@ -11680,9 +11680,9 @@ end)
 
 					self.wpn_fps_ass_famas.override = self.wpn_fps_ass_famas.override or {}
 
-					self.wpn_fps_ass_famas_npc.adds = deep_clone(self.wpn_fps_ass_famas.adds)	
-					self.wpn_fps_ass_famas_npc.override = deep_clone(self.wpn_fps_ass_famas.override)	
-					self.wpn_fps_ass_famas_npc.uses_parts = deep_clone(self.wpn_fps_ass_famas.uses_parts)	
+					self.wpn_fps_ass_famas_npc.adds = deep_clone(self.wpn_fps_ass_famas.adds)
+					self.wpn_fps_ass_famas_npc.override = deep_clone(self.wpn_fps_ass_famas.override)
+					self.wpn_fps_ass_famas_npc.uses_parts = deep_clone(self.wpn_fps_ass_famas.uses_parts)
 				end)
 
 			--MTAR
@@ -11713,7 +11713,7 @@ end)
 					self.parts.wpn_fps_smg_hajk_b_short.supported = true
 					self.parts.wpn_fps_smg_hajk_b_short.stats = deep_clone(barrels.short_b3_stats)
 					self.parts.wpn_fps_smg_hajk_b_short.custom_stats = deep_clone(barrels.short_b3_stats)
-					
+
 					--Medium Barrel
 					self.parts.wpn_fps_smg_hajk_b_medium.pcs = {
 						10,
@@ -11886,7 +11886,7 @@ end)
 					table.insert(self.wpn_fps_ass_m16.uses_parts, "wpn_fps_m4_uupg_s_fold")
 					table.insert(self.wpn_fps_ass_m16.uses_parts, "wpn_fps_upg_m4_s_standard")
 					table.insert(self.wpn_fps_ass_m16.uses_parts, "wpn_fps_upg_m4_s_pts")
-					table.insert(self.wpn_fps_ass_m16.uses_parts, "wpn_fps_smg_olympic_s_short")		
+					table.insert(self.wpn_fps_ass_m16.uses_parts, "wpn_fps_smg_olympic_s_short")
 					table.insert(self.wpn_fps_ass_m16.uses_parts, "wpn_fps_upg_i_m16a2")
 					table.insert(self.wpn_fps_ass_m16.uses_parts, "wpn_fps_upg_s_saintvictor_hera")
 					table.insert(self.wpn_fps_ass_m16.uses_parts, "wpn_fps_upg_o_northtac")
@@ -11894,7 +11894,7 @@ end)
 
 					--Overriding these
 					self.wpn_fps_ass_m16.override = {}
-						
+
 					--M16 Default Blueprint, making it use the 30 rounder by default
 					for i, part_id in pairs(self.wpn_fps_ass_m16.default_blueprint) do
 						attachment_list = {
@@ -11905,8 +11905,8 @@ end)
 								self.wpn_fps_ass_m16.default_blueprint[i] = "wpn_fps_m4_uupg_m_std_vanilla"
 							end
 						end
-					end	
-					
+					end
+
 					--M16 Part Table
 					for i, part_id in pairs(self.wpn_fps_ass_m16.uses_parts) do
 						attachment_list = {
@@ -11997,7 +11997,7 @@ end)
 							zoom = 5,
 							recoil = 4
 						}
-					}	
+					}
 
 					self.wpn_fps_ass_m16.adds = {}
 
@@ -12018,7 +12018,7 @@ end)
 
 			--L85A2
 				Hooks:PostHook(WeaponFactoryTweakData, "_init_l85a2", "resmod_l85a2", function(self)
-					
+
 					--Expert Mag
 					self.parts.wpn_fps_ass_l85a2_m_emag.pcs = {
 						10,
@@ -12032,7 +12032,7 @@ end)
 						concealment = 1,
 						recoil = -2
 					}
-					
+
 					--Versatile Foregrip
 					self.parts.wpn_fps_ass_l85a2_fg_short.pcs = {
 						10,
@@ -12047,7 +12047,7 @@ end)
 						spread = 1,
 						concealment = -1
 					}
-					
+
 					--Prodigious Barrel
 					self.parts.wpn_fps_ass_l85a2_b_long.pcs = {
 						10,
@@ -12058,7 +12058,7 @@ end)
 					self.parts.wpn_fps_ass_l85a2_b_long.supported = true
 					self.parts.wpn_fps_ass_l85a2_b_long.stats = deep_clone(barrels.long_b2_stats)
 					self.parts.wpn_fps_ass_l85a2_b_long.custom_stats = deep_clone(barrels.long_b2_stats)
-					
+
 					--Diminutive Barrel
 					self.parts.wpn_fps_ass_l85a2_b_short.pcs = {
 						10,
@@ -12069,7 +12069,7 @@ end)
 					self.parts.wpn_fps_ass_l85a2_b_short.supported = true
 					self.parts.wpn_fps_ass_l85a2_b_short.stats = deep_clone(barrels.short_b2_stats)
 					self.parts.wpn_fps_ass_l85a2_b_short.custom_stats = deep_clone(barrels.short_b2_stats)
-					
+
 					--Delightful Grip
 					self.parts.wpn_fps_ass_l85a2_g_worn.pcs = {
 						10,
@@ -12083,7 +12083,7 @@ end)
 
 					table.insert(self.wpn_fps_ass_l85a2.uses_parts, "wpn_fps_upg_o_northtac")
 					table.insert(self.wpn_fps_ass_l85a2.uses_parts, "wpn_fps_upg_o_northtac_reddot")
-					
+
 					self.wpn_fps_ass_l85a2_npc.uses_parts = deep_clone(self.wpn_fps_ass_l85a2.uses_parts)
 				end)
 
@@ -12155,16 +12155,16 @@ end)
 					table.insert(self.wpn_fps_ass_akm.uses_parts, "wpn_upg_ak_m_drum")
 					table.insert(self.wpn_fps_ass_akm.uses_parts, "wpn_lmg_rpk_m_ban")
 					table.insert(self.wpn_fps_ass_akm.uses_parts, "wpn_fps_snp_victor_s_mod0")
-					
+
 					--Plastic Stock
 					table.insert(self.wpn_fps_ass_akm.uses_parts, "wpn_fps_lmg_rpk_s_standard")
 					table.insert(self.wpn_fps_ass_akm.uses_parts, "wpn_fps_lmg_rpk_fg_standard")
 
 					table.insert(self.wpn_fps_ass_akm.uses_parts, "wpn_fps_upg_o_xpsg33_magnifier")
 					table.insert(self.wpn_fps_ass_akm.uses_parts, "wpn_fps_upg_o_sig")
-					
+
 					table.insert(self.wpn_fps_ass_akm.uses_parts, "wpn_fps_upg_o_northtac")
-					
+
 					--No Stock
 					--table.insert(self.wpn_fps_ass_akm.uses_parts, "wpn_upg_ak_s_nostock")
 
@@ -12275,7 +12275,7 @@ end)
 					table.insert(self.wpn_fps_ass_akm_gold.uses_parts, "wpn_fps_upg_o_sig")
 					table.insert(self.wpn_fps_ass_akm_gold.uses_parts, "wpn_fps_upg_o_northtac")
 					table.insert(self.wpn_fps_ass_akm_gold.uses_parts, "wpn_fps_upg_o_northtac_reddot")
-					
+
 					self.wpn_fps_ass_akm_gold_npc.uses_parts = deep_clone(self.wpn_fps_ass_akm_gold.uses_parts)
 				end)
 
@@ -12297,7 +12297,7 @@ end)
 						alert_size = -1
 					}
 					self.parts.wpn_fps_ass_groza_b_supressor.perks = {"silencer"}
-					
+
 					--Quick Pull
 					if SystemFS:exists("assets/mod_overrides/AK Correct Magpul Assist Mags") then
 						self.parts.wpn_fps_ass_groza_m_speed.unit = "units/mods/weapons/wpn_fps_ass_akm_m_magpul/wpn_fps_ass_akm_m_magpul"
@@ -12342,9 +12342,9 @@ end)
 					table.insert(self.wpn_fps_ass_groza.uses_parts, "wpn_lmg_rpk_m_ban")
 					table.insert(self.wpn_fps_ass_groza.uses_parts, "wpn_fps_upg_o_northtac")
 					table.insert(self.wpn_fps_ass_groza.uses_parts, "wpn_fps_upg_o_northtac_reddot")
-					
-					self.wpn_fps_ass_groza_npc.uses_parts = deep_clone(self.wpn_fps_ass_groza.uses_parts)	
-					self.wpn_fps_ass_groza_npc.adds = deep_clone(self.wpn_fps_ass_groza.adds)	
+
+					self.wpn_fps_ass_groza_npc.uses_parts = deep_clone(self.wpn_fps_ass_groza.uses_parts)
+					self.wpn_fps_ass_groza_npc.adds = deep_clone(self.wpn_fps_ass_groza.adds)
 				end)
 
 			--TKB-059
@@ -12441,7 +12441,7 @@ end)
 								self.wpn_fps_ass_tkb.uses_parts[i] = "resmod_dummy"
 							end
 						end
-					end	
+					end
 
 					self.wpn_fps_ass_tkb.override.wpn_fps_ass_tkb_o_tt01_mount = {
 						custom_stats = { big_scope = true }
@@ -12454,10 +12454,10 @@ end)
 
 			--AKMSU
 				Hooks:PostHook(WeaponFactoryTweakData, "_init_akmsu", "resmod_akmsu", function(self)
-					
+
 					self.parts.wpn_fps_smg_akmsu_fg_standard.override.wpn_fps_upg_o_specter = {
 						a_obj = "a_of",
-						stance_mod = { 
+						stance_mod = {
 							wpn_fps_smg_akmsu = {
 								translation = Vector3(-0.006, -1, -3.335)
 							}
@@ -12528,7 +12528,7 @@ end)
 					end
 
 					self.parts.wpn_fps_smg_akmsu_fg_standard.override.wpn_fps_upg_o_poe.stance_mod = deep_clone(self.parts.wpn_fps_smg_akmsu_fg_standard.override.wpn_fps_upg_o_specter.stance_mod)
-					
+
 					self.parts.wpn_fps_smg_akmsu_fg_standard.override.wpn_fps_upg_o_acog.stance_mod = deep_clone(self.parts.wpn_fps_smg_akmsu_fg_standard.override.wpn_fps_upg_o_specter.stance_mod)
 					for i, weap in pairs(self.parts.wpn_fps_smg_akmsu_fg_standard.override.wpn_fps_upg_o_acog.stance_mod) do
 						if weap and weap.translation then
@@ -12547,13 +12547,13 @@ end)
 					self.parts.wpn_fps_smg_akmsu_fg_rail.pcs = {
 						10,
 						20,
-						30, 
+						30,
 						40
 					}
 					self.parts.wpn_fps_smg_akmsu_fg_rail.supported = true
 					self.parts.wpn_fps_smg_akmsu_fg_rail.stats = {
-						value = 5, 
-						spread = 2, 
+						value = 5,
+						spread = 2,
 						concealment = -2
 					}
 					self.parts.wpn_fps_smg_akmsu_fg_rail.forbids = self.parts.wpn_fps_smg_akmsu_fg_rail.forbids or {}
@@ -12759,7 +12759,7 @@ end)
 						}
 					}
 					self.wpn_fps_smg_x_akmsu.override.wpn_fps_smg_schakal_vg_surefire = {
-						stats = { 
+						stats = {
 							recoil = 4,
 							concealment = -2
 						}
@@ -12816,7 +12816,7 @@ end)
 				}
 				self.parts.wpn_fps_ass_asval_b_proto.perks = nil
 				self.parts.wpn_fps_ass_asval_b_proto.adds = { "wpn_fps_ass_asval_sound_switch" }
-				
+
 				--Standard Barrel
 				self.parts.wpn_fps_ass_asval_b_standard.supported = true
 				self.parts.wpn_fps_ass_asval_b_standard.stats = {
@@ -12849,7 +12849,7 @@ end)
 					"wpn_fps_upg_ak_g_rk3",
 					"wpn_fps_upg_ak_g_hgrip",
 					"wpn_fps_upg_ak_g_pgrip",
-					"wpn_fps_upg_ak_g_wgrip"			
+					"wpn_fps_upg_ak_g_wgrip"
 				}
 
 
@@ -12866,7 +12866,7 @@ end)
 				}
 				self.parts.wpn_fps_ass_asval_body_standard.adds = {"wpn_fps_ass_asval_m_standard_dummy"}
 
-				self.wpn_fps_ass_asval.stock_adapter = "wpn_upg_ak_s_adapter"	
+				self.wpn_fps_ass_asval.stock_adapter = "wpn_upg_ak_s_adapter"
 				self.wpn_fps_ass_asval_npc.stock_adapter = "wpn_upg_ak_s_adapter"
 
 				self.wpn_fps_ass_asval.adds.wpn_fps_upg_o_northtac = deep_clone(self.wpn_fps_ass_asval.adds.wpn_fps_upg_o_specter)
@@ -12884,7 +12884,7 @@ end)
 					wpn_fps_upg_ak_g_pgrip = {
 						unit = "units/pd2_dlc_character_sokol/weapons/wpn_fps_ass_asval_pts/wpn_fps_ass_asval_g_pgrip",
 						third_unit = "units/pd2_dlc_character_sokol/weapons/wpn_third_ass_asval_pts/wpn_third_ass_asval_g_pgrip"
-					},					
+					},
 					wpn_upg_ak_s_folding = {
 						adds = {
 							"wpn_fps_ass_asval_g_standard"
@@ -12947,7 +12947,7 @@ end)
 					custom_stats = deep_clone(stocks.remove_folder_stats),
 					adds = { "wpn_fps_ass_asval_g_standard" }
 				}
-					
+
 				table.insert(self.wpn_fps_ass_asval.uses_parts, "wpn_fps_m4_uupg_fg_rail_ext")
 				table.insert(self.wpn_fps_ass_asval.uses_parts, "wpn_fps_upg_ns_ass_smg_large")
 				table.insert(self.wpn_fps_ass_asval.uses_parts, "wpn_fps_upg_ns_ass_smg_medium")
@@ -12963,7 +12963,7 @@ end)
 				table.insert(self.wpn_fps_ass_asval.uses_parts, "wpn_fps_upg_m4_s_pts")
 				table.insert(self.wpn_fps_ass_asval.uses_parts, "wpn_fps_upg_m4_s_crane")
 				table.insert(self.wpn_fps_ass_asval.uses_parts, "wpn_fps_upg_m4_s_mk46")
-				table.insert(self.wpn_fps_ass_asval.uses_parts, "wpn_fps_snp_victor_s_mod0")	
+				table.insert(self.wpn_fps_ass_asval.uses_parts, "wpn_fps_snp_victor_s_mod0")
 				table.insert(self.wpn_fps_ass_asval.uses_parts, "wpn_fps_upg_m4_s_ubr")
 				table.insert(self.wpn_fps_ass_asval.uses_parts, "wpn_fps_snp_tti_s_vltor")
 				table.insert(self.wpn_fps_ass_asval.uses_parts, "wpn_upg_ak_s_folding")
@@ -12985,7 +12985,7 @@ end)
 				self.wpn_fps_ass_asval_npc.adds = deep_clone(self.wpn_fps_ass_asval.adds)
 			end)
 
-		--HK417 W/M203	
+		--HK417 W/M203
 			Hooks:PostHook(WeaponFactoryTweakData, "_init_contraband", "resmod_contraband", function(self)
 
 				self.parts.wpn_fps_ass_contraband_o_standard.stance_mod = {
@@ -12993,7 +12993,7 @@ end)
 						translation = Vector3(0, -7, 0)
 					}
 				}
-				
+
 				--Stock Adapter
 				self.wpn_fps_ass_contraband.stock_adapter = "wpn_fps_upg_m4_s_adapter"
 				self.wpn_fps_ass_contraband_npc.stock_adapter = "wpn_fps_upg_m4_s_adapter"
@@ -13060,25 +13060,25 @@ end)
 					stats = deep_clone(stocks.fixed_to_thumbhole_stats),
 					custom_stats = deep_clone(stocks.fixed_to_thumbhole_stats)
 				}
-				
+
 				--So it has more than like 3 parts
 				table.insert(self.wpn_fps_ass_contraband.uses_parts, "wpn_fps_upg_m4_g_ergo")
 				table.insert(self.wpn_fps_ass_contraband.uses_parts, "wpn_fps_upg_m4_g_sniper")
-				table.insert(self.wpn_fps_ass_contraband.uses_parts, "wpn_fps_upg_m4_g_hgrip")	
+				table.insert(self.wpn_fps_ass_contraband.uses_parts, "wpn_fps_upg_m4_g_hgrip")
 				table.insert(self.wpn_fps_ass_contraband.uses_parts, "wpn_fps_upg_m4_g_mgrip")
-				table.insert(self.wpn_fps_ass_contraband.uses_parts, "wpn_fps_m4_uupg_s_fold")	
-				table.insert(self.wpn_fps_ass_contraband.uses_parts, "wpn_fps_upg_m4_s_standard")	
+				table.insert(self.wpn_fps_ass_contraband.uses_parts, "wpn_fps_m4_uupg_s_fold")
+				table.insert(self.wpn_fps_ass_contraband.uses_parts, "wpn_fps_upg_m4_s_standard")
 				table.insert(self.wpn_fps_ass_contraband.uses_parts, "wpn_fps_upg_m4_s_pts")
-				table.insert(self.wpn_fps_ass_contraband.uses_parts, "wpn_fps_upg_m4_s_ubr")	
+				table.insert(self.wpn_fps_ass_contraband.uses_parts, "wpn_fps_upg_m4_s_ubr")
 				table.insert(self.wpn_fps_ass_contraband.uses_parts, "wpn_fps_upg_m4_s_crane")
-				table.insert(self.wpn_fps_ass_contraband.uses_parts, "wpn_fps_upg_m4_s_mk46")	
-				table.insert(self.wpn_fps_ass_contraband.uses_parts, "wpn_fps_snp_victor_s_mod0")	
+				table.insert(self.wpn_fps_ass_contraband.uses_parts, "wpn_fps_upg_m4_s_mk46")
+				table.insert(self.wpn_fps_ass_contraband.uses_parts, "wpn_fps_snp_victor_s_mod0")
 				table.insert(self.wpn_fps_ass_contraband.uses_parts, "wpn_fps_snp_tti_s_vltor")
 				table.insert(self.wpn_fps_ass_contraband.uses_parts, "wpn_fps_smg_olympic_s_short")
 				table.insert(self.wpn_fps_ass_contraband.uses_parts, "wpn_fps_upg_o_northtac")
 				table.insert(self.wpn_fps_ass_contraband.uses_parts, "wpn_fps_upg_o_northtac_reddot")
-				
-				self.wpn_fps_ass_contraband_npc.uses_parts = deep_clone(self.wpn_fps_ass_contraband.uses_parts)		
+
+				self.wpn_fps_ass_contraband_npc.uses_parts = deep_clone(self.wpn_fps_ass_contraband.uses_parts)
 			end)
 
 		--MK17
@@ -13134,7 +13134,7 @@ end)
 				self.parts.wpn_fps_ass_scar_s_sniper.supported = true
 				self.parts.wpn_fps_ass_scar_s_sniper.stats = deep_clone(stocks.adj_to_fixed_acc_stats)
 				self.parts.wpn_fps_ass_scar_s_sniper.custom_stats = deep_clone(stocks.adj_to_fixed_acc_stats)
-				
+
 				--Disabling Vertical Grip Mods
 				for i, part_id in pairs(self.wpn_fps_ass_scar.default_blueprint) do
 					attachment_list = {
@@ -13173,7 +13173,7 @@ end)
 						end
 					end
 				end
-				
+
 				--SCAR Part mods
 				table.insert(self.wpn_fps_ass_scar.uses_parts, "wpn_fps_upg_m4_g_hgrip")
 
@@ -13184,7 +13184,7 @@ end)
 				table.insert(self.wpn_fps_ass_scar.uses_parts, "wpn_fps_upg_m4_s_crane")
 				table.insert(self.wpn_fps_ass_scar.uses_parts, "wpn_fps_upg_m4_s_mk46")
 				table.insert(self.wpn_fps_ass_scar.uses_parts, "wpn_fps_upg_m4_s_ubr")
-				table.insert(self.wpn_fps_ass_scar.uses_parts, "wpn_fps_snp_tti_s_vltor")	
+				table.insert(self.wpn_fps_ass_scar.uses_parts, "wpn_fps_snp_tti_s_vltor")
 				table.insert(self.wpn_fps_ass_scar.uses_parts, "wpn_fps_sho_sko12_stock")
 
 				table.insert(self.wpn_fps_ass_scar.uses_parts, "wpn_fps_upg_o_northtac")
@@ -13204,7 +13204,7 @@ end)
 					stats = {},
 					custom_stats = {}
 				}
-				
+
 				self.wpn_fps_ass_scar_npc.adds = deep_clone(self.wpn_fps_ass_scar.adds)
 				self.wpn_fps_ass_scar_npc.override = deep_clone(self.wpn_fps_ass_scar.override)
 				self.wpn_fps_ass_scar_npc.uses_parts = deep_clone(self.wpn_fps_ass_scar.uses_parts)
@@ -13212,7 +13212,7 @@ end)
 
 		--GALIL
 			Hooks:PostHook(WeaponFactoryTweakData, "_init_galil", "resmod_galil", function(self)
-				
+
 				--Fabulous Foregrip
 				self.parts.wpn_fps_ass_galil_fg_fab.pcs = {}
 				self.parts.wpn_fps_ass_galil_fg_fab.supported = true
@@ -13221,7 +13221,7 @@ end)
 					recoil = 2,
 					concealment = -1
 				}
-				self.parts.wpn_fps_ass_galil_fg_fab.override.wpn_fps_upg_o_specter.stance_mod = { 
+				self.parts.wpn_fps_ass_galil_fg_fab.override.wpn_fps_upg_o_specter.stance_mod = {
 					wpn_fps_ass_galil = {
 						translation = Vector3(-0.004, 4.1, -3.495)
 					}
@@ -13256,7 +13256,7 @@ end)
 				self.parts.wpn_fps_ass_galil_fg_fab.override.wpn_fps_upg_o_aimpoint.stance_mod = deep_clone(self.parts.wpn_fps_ass_galil_fg_fab.override.wpn_fps_upg_o_specter.stance_mod)
 				self.parts.wpn_fps_ass_galil_fg_fab.override.wpn_fps_upg_o_aimpoint_2.stance_mod = deep_clone(self.parts.wpn_fps_ass_galil_fg_fab.override.wpn_fps_upg_o_aimpoint.stance_mod)
 				self.parts.wpn_fps_ass_galil_fg_fab.override.wpn_fps_upg_o_cs.stance_mod = deep_clone(self.parts.wpn_fps_ass_galil_fg_fab.override.wpn_fps_upg_o_aimpoint.stance_mod)
-				
+
 				self.parts.wpn_fps_ass_galil_fg_fab.override.wpn_fps_upg_o_xpsg33_magnifier = deep_clone(self.parts.wpn_fps_ass_galil_fg_fab.override.wpn_fps_upg_o_specter)
 				self.parts.wpn_fps_ass_galil_fg_fab.override.wpn_fps_upg_o_xpsg33_magnifier.a_obj = nil
 				self.parts.wpn_fps_ass_galil_fg_fab.override.wpn_fps_upg_o_sig = deep_clone(self.parts.wpn_fps_ass_galil_fg_fab.override.wpn_fps_upg_o_xpsg33_magnifier)
@@ -13292,7 +13292,7 @@ end)
 
 				self.parts.wpn_fps_ass_galil_fg_fab.override.wpn_fps_upg_o_spot.stance_mod = deep_clone(self.parts.wpn_fps_ass_galil_fg_fab.override.wpn_fps_upg_o_specter.stance_mod)
 				self.parts.wpn_fps_ass_galil_fg_fab.override.wpn_fps_upg_o_poe.stance_mod = deep_clone(self.parts.wpn_fps_ass_galil_fg_fab.override.wpn_fps_upg_o_specter.stance_mod)
-				
+
 				self.parts.wpn_fps_ass_galil_fg_fab.override.wpn_fps_upg_o_acog.stance_mod = deep_clone(self.parts.wpn_fps_ass_galil_fg_fab.override.wpn_fps_upg_o_specter.stance_mod)
 				for i, weap in pairs(self.parts.wpn_fps_ass_galil_fg_fab.override.wpn_fps_upg_o_acog.stance_mod) do
 					if weap and weap.translation then
@@ -13306,8 +13306,8 @@ end)
 					end
 				end
 
-				
-					
+
+
 				--CQB Foregrip
 				self.parts.wpn_fps_ass_galil_fg_mar.pcs = {}
 				self.parts.wpn_fps_ass_galil_fg_mar.supported = true
@@ -13327,13 +13327,13 @@ end)
 						a_obj = "a_ns_s"
 					}
 				}
-				
+
 				--Light Foregrip
 				self.parts.wpn_fps_ass_galil_fg_sar.pcs = {}
 				self.parts.wpn_fps_ass_galil_fg_sar.supported = true
 				self.parts.wpn_fps_ass_galil_fg_sar.stats = deep_clone(barrels.short_b1_stats)
 				self.parts.wpn_fps_ass_galil_fg_sar.custom_stats = deep_clone(barrels.short_b1_stats)
-				
+
 				--Sniper Foregrip
 				self.parts.wpn_fps_ass_galil_fg_sniper.pcs = {}
 				self.parts.wpn_fps_ass_galil_fg_sniper.supported = true
@@ -13343,12 +13343,12 @@ end)
 				self.parts.wpn_fps_ass_galil_fg_sniper.custom_stats = deep_clone(barrels.long_b2_stats)
 				self.parts.wpn_fps_ass_galil_fg_sniper.custom_stats.alt_desc = "bm_galil_ap25_sc_desc"
 				self.parts.wpn_fps_ass_galil_fg_sniper.adds = { "wpn_fps_upg_a_ap25" }
-				
+
 				--Sniper Grip
 				self.parts.wpn_fps_ass_galil_g_sniper.pcs = {}
 				self.parts.wpn_fps_ass_galil_g_sniper.supported = true
 				self.parts.wpn_fps_ass_galil_g_sniper.stats = deep_clone(grips.acc_1)
-				
+
 				--Skeletal Stock
 				self.parts.wpn_fps_ass_galil_s_skeletal.pcs = {}
 				self.parts.wpn_fps_ass_galil_s_skeletal.supported = true
@@ -13409,7 +13409,7 @@ end)
 					falloff_end_mult = 0.9,
 					ads_speed_mult = 0.95
 				}
-				
+
 				--Retro Foregrip
 				self.parts.wpn_fps_ass_fal_fg_03.pcs = {}
 				self.parts.wpn_fps_ass_fal_fg_03.supported = true
@@ -13418,7 +13418,7 @@ end)
 					recoil = -2,
 					spread = 1
 				}
-				
+
 				--Marksman Foregrip
 				self.parts.wpn_fps_ass_fal_fg_04.pcs = {}
 				self.parts.wpn_fps_ass_fal_fg_04.supported = true
@@ -13436,7 +13436,7 @@ end)
 					falloff_end_mult = 1.075,
 					ads_speed_mult = 1.025
 				}
-				
+
 				--Wooden Foregrip
 				self.parts.wpn_fps_ass_fal_fg_wood.pcs = {}
 				self.parts.wpn_fps_ass_fal_fg_wood.supported = true
@@ -13445,13 +13445,13 @@ end)
 					recoil = 2,
 					spread = -1
 				}
-				
+
 				--Tactical Grip
 				self.parts.wpn_fps_ass_fal_g_01.pcs = {}
 				self.parts.wpn_fps_ass_fal_g_01.supported = true
 				self.parts.wpn_fps_ass_fal_g_01.stats = deep_clone(grips.quickdraw_1)
 				self.parts.wpn_fps_ass_fal_g_01.custom_stats = deep_clone(grips.quickdraw_1)
-				
+
 				--Vintage Mag (Formerly Extended Magazine)
 				self.parts.wpn_fps_ass_fal_m_01.pcs = {}
 				self.parts.wpn_fps_ass_fal_m_01.name_id = "bm_wp_upg_vintage_fal_sc"
@@ -13465,13 +13465,13 @@ end)
 					concealment = -2,
 					reload = -4
 				}
-				
+
 				--CQB Stock
 				self.parts.wpn_fps_ass_fal_s_01.pcs = {}
 				self.parts.wpn_fps_ass_fal_s_01.supported = true
 				self.parts.wpn_fps_ass_fal_s_01.stats = deep_clone(stocks.fixed_to_folder_stats)
 				self.parts.wpn_fps_ass_fal_s_01.custom_stats = deep_clone(stocks.fixed_to_folder_stats)
-				
+
 				--Marksman Stock
 				self.parts.wpn_fps_ass_fal_s_03.pcs = {}
 				self.parts.wpn_fps_ass_fal_s_03.supported = true
@@ -13480,7 +13480,7 @@ end)
 					spread = 1,
 					recoil = -2
 				}
-				
+
 				--Wooden Stock
 				self.parts.wpn_fps_ass_fal_s_wood.pcs = {}
 				self.parts.wpn_fps_ass_fal_s_wood.supported = true
@@ -13597,7 +13597,7 @@ end)
 					}
 				}
 				self.parts.wpn_fps_ass_shak12_body_vks.perks = nil
-				
+
 				--Carry Handle Sight
 				self.parts.wpn_fps_ass_shak12_o_carry_dummy.pcs = {
 					10,
@@ -13684,7 +13684,7 @@ end)
 
 				self.parts.wpn_fps_ass_shak12_o_carry_dummy.override.wpn_fps_upg_o_spot = deep_clone(self.parts.wpn_fps_ass_shak12_o_carry_dummy.override.wpn_fps_upg_o_specter)
 				self.parts.wpn_fps_ass_shak12_o_carry_dummy.override.wpn_fps_upg_o_poe = deep_clone(self.parts.wpn_fps_ass_shak12_o_carry_dummy.override.wpn_fps_upg_o_specter)
-				
+
 				self.parts.wpn_fps_ass_shak12_o_carry_dummy.override.wpn_fps_upg_o_acog = deep_clone(self.parts.wpn_fps_ass_shak12_o_carry_dummy.override.wpn_fps_upg_o_specter)
 				for i, weap in pairs(self.parts.wpn_fps_ass_shak12_o_carry_dummy.override.wpn_fps_upg_o_acog) do
 					if weap and weap.translation then
@@ -13717,8 +13717,8 @@ end)
 						weap.rotation = (weap.rotation or Rotation(0,0,0)) * Rotation(-0.07, 0, 0)
 					end
 				end
-				
-				
+
+
 				--Long Silencer
 				self.parts.wpn_fps_ass_shak12_ns_suppressor.pcs = {
 					10,
@@ -13761,8 +13761,8 @@ end)
 				table.insert(self.wpn_fps_ass_shak12.uses_parts, "wpn_fps_upg_o_northtac_reddot")
 				table.insert(self.wpn_fps_ass_shak12.uses_parts, "wpn_fps_upg_o_arbiter_irons_dmc")
 
-				self.wpn_fps_ass_shak12_npc.forbids = deep_clone(self.wpn_fps_ass_shak12.forbids)	
-				self.wpn_fps_ass_shak12_npc.uses_parts = deep_clone(self.wpn_fps_ass_shak12.uses_parts)	
+				self.wpn_fps_ass_shak12_npc.forbids = deep_clone(self.wpn_fps_ass_shak12.forbids)
+				self.wpn_fps_ass_shak12_npc.uses_parts = deep_clone(self.wpn_fps_ass_shak12.uses_parts)
 			end)
 
 		--M14
@@ -13790,25 +13790,25 @@ end)
 				self.parts.wpn_fps_ass_m14_body_ebr.pcs = {
 					10,
 					20,
-					30, 
+					30,
 					40
 				}
 				self.parts.wpn_fps_ass_m14_body_ebr.supported = true
 				self.parts.wpn_fps_ass_m14_body_ebr.stats = deep_clone(stocks.fixed_to_hvy_rec_stats)
 				self.parts.wpn_fps_ass_m14_body_ebr.custom_stats = deep_clone(stocks.fixed_to_hvy_rec_stats)
-					
+
 				--Jaeger Body
 				self.parts.wpn_fps_ass_m14_body_jae.pcs = {
 					10,
 					20,
-					30, 
+					30,
 					40
 				}
 				self.parts.wpn_fps_ass_m14_body_jae.supported = true
 				self.parts.wpn_fps_ass_m14_body_jae.stats = deep_clone(stocks.fixed_to_thumbhole_stats)
 				self.parts.wpn_fps_ass_m14_body_jae.custom_stats = deep_clone(stocks.fixed_to_thumbhole_stats)
-					
-				--M308 Additional Parts	
+
+				--M308 Additional Parts
 				table.insert(self.wpn_fps_ass_m14.uses_parts, "wpn_fps_upg_m14_legend")
 				--Vertical Grips
 				table.insert(self.wpn_fps_ass_m14.uses_parts, "wpn_fps_upg_vg_ass_smg_verticalgrip")
@@ -13820,13 +13820,13 @@ end)
 				table.insert(self.wpn_fps_ass_m14.uses_parts, "wpn_fps_upg_o_northtac_reddot")
 				table.insert(self.wpn_fps_ass_m14.uses_parts, "wpn_fps_upg_o_schmidt")
 				table.insert(self.wpn_fps_ass_m14.uses_parts, "wpn_fps_upg_o_schmidt_magnified")
-				
+
 				--ROF Mods (Unused)
 				--[[
 				table.insert(self.wpn_fps_ass_m14.uses_parts, "wpn_fps_upg_i_slower_rof")
-				table.insert(self.wpn_fps_ass_m14_npc.uses_parts, "wpn_fps_upg_i_slower_rof")	
+				table.insert(self.wpn_fps_ass_m14_npc.uses_parts, "wpn_fps_upg_i_slower_rof")
 				table.insert(self.wpn_fps_ass_m14.uses_parts, "wpn_fps_upg_i_faster_rof")
-				table.insert(self.wpn_fps_ass_m14_npc.uses_parts, "wpn_fps_upg_i_faster_rof")		
+				table.insert(self.wpn_fps_ass_m14_npc.uses_parts, "wpn_fps_upg_i_faster_rof")
 				]]--
 
 				self.wpn_fps_ass_m14.override = self.wpn_fps_ass_m14.override or {}
@@ -13840,14 +13840,14 @@ end)
 				self.wpn_fps_ass_m14.override.wpn_fps_upg_o_schmidt = {
 					depends_on = "extra"
 				}
-				
+
 				self.wpn_fps_ass_m14_npc.override = deep_clone(self.wpn_fps_ass_m14.override)
 				self.wpn_fps_ass_m14_npc.uses_parts = deep_clone(self.wpn_fps_ass_m14.uses_parts)
 			end)
 
 		--JIISURI
 			Hooks:PostHook(WeaponFactoryTweakData, "_init_g3", "resmod_g3", function(self)
-				
+
 				--DMR Kit
 				self.parts.wpn_fps_ass_g3_b_sniper.pcs = {}
 				self.parts.wpn_fps_ass_g3_b_sniper.supported = true
@@ -13858,19 +13858,19 @@ end)
 				self.parts.wpn_fps_ass_g3_b_sniper.custom_stats.alt_desc = "bm_g3_ap25_sc_desc"
 				self.parts.wpn_fps_ass_g3_b_sniper.override = {}
 				self.parts.wpn_fps_ass_g3_b_sniper.adds = { "wpn_fps_upg_a_ap25" }
-				
+
 				--Just in case
 				self.parts.wpn_fps_ammo_type.supported = true
 				self.parts.wpn_fps_ammo_type.cull = true
 				self.parts.wpn_fps_ammo_type.stats = {value = 1}
 				self.parts.wpn_fps_ammo_type.custom_stats = {}
-				
+
 				--Assault Kit
 				self.parts.wpn_fps_ass_g3_b_short.pcs = {}
 				self.parts.wpn_fps_ass_g3_b_short.supported = true
 				self.parts.wpn_fps_ass_g3_b_short.stats = deep_clone(barrels.short_b2_stats)
 				self.parts.wpn_fps_ass_g3_b_short.custom_stats = deep_clone(barrels.short_b2_stats)
-				
+
 				--Precision Foregrip
 				self.parts.wpn_fps_ass_g3_fg_psg.pcs = {}
 				self.parts.wpn_fps_ass_g3_fg_psg.supported = true
@@ -13894,7 +13894,7 @@ end)
 					recoil = -2,
 					concealment = 1
 				}
-				
+
 				--Wooden Foregrip
 				self.parts.wpn_fps_ass_g3_fg_retro.pcs = {}
 				self.parts.wpn_fps_ass_g3_fg_retro.supported = true
@@ -13908,7 +13908,7 @@ end)
 					falloff_end_mult = 0.925,
 					ads_speed_mult = 0.975
 				}
-				
+
 				--Plastic Foregrip
 				self.parts.wpn_fps_ass_g3_fg_retro_plastic.pcs = {}
 				self.parts.wpn_fps_ass_g3_fg_retro_plastic.supported = true
@@ -13923,18 +13923,18 @@ end)
 					falloff_end_mult = 0.925,
 					ads_speed_mult = 0.975
 				}
-				
+
 				--Retro Grip
 				self.parts.wpn_fps_ass_g3_g_retro.pcs = {}
 				self.parts.wpn_fps_ass_g3_g_retro.supported = true
 				self.parts.wpn_fps_ass_g3_g_retro.stats = deep_clone(grips.quickdraw_1)
 				self.parts.wpn_fps_ass_g3_g_retro.custom_stats = deep_clone(grips.quickdraw_1)
-				
+
 				--Precision Grip
 				self.parts.wpn_fps_ass_g3_g_sniper.pcs = {}
 				self.parts.wpn_fps_ass_g3_g_sniper.supported = true
 				self.parts.wpn_fps_ass_g3_g_sniper.stats = deep_clone(grips.recoil_2)
-				
+
 				--Precision Stock
 				self.parts.wpn_fps_ass_g3_s_sniper.pcs = {}
 				self.parts.wpn_fps_ass_g3_s_sniper.has_description = true
@@ -13945,7 +13945,7 @@ end)
 					spread = 1,
 					recoil = -2
 				}
-				
+
 				--Wooden Stock
 				self.parts.wpn_fps_ass_g3_s_wood.pcs = {}
 				self.parts.wpn_fps_ass_g3_s_wood.has_description = true
@@ -13956,7 +13956,7 @@ end)
 					recoil = 2,
 					spread = -1
 				}
-				
+
 				--PSG Magazine
 				self.parts.wpn_fps_ass_g3_m_psg = {
 					pcs = {},
@@ -14010,7 +14010,7 @@ end)
 				self.parts.wpn_fps_ass_ching_b_short.supported = true
 				self.parts.wpn_fps_ass_ching_b_short.stats = deep_clone(barrels.short_b3_stats)
 				self.parts.wpn_fps_ass_ching_b_short.custom_stats = deep_clone(barrels.short_b3_stats)
-				
+
 				--Custom Foregrip
 				self.parts.wpn_fps_ass_ching_fg_railed.pcs = {
 					10,
@@ -14020,8 +14020,8 @@ end)
 				}
 				self.parts.wpn_fps_ass_ching_fg_railed.supported = true
 				self.parts.wpn_fps_ass_ching_fg_railed.stats = {
-					value = 2, 
-					recoil = 2, 
+					value = 2,
+					recoil = 2,
 					concealment = -1
 				}
 
@@ -14058,7 +14058,7 @@ end)
 					self.parts.wpn_fps_snp_qbu88_b_short.supported = true
 					self.parts.wpn_fps_snp_qbu88_b_short.stats = deep_clone(barrels.short_b2_stats)
 					self.parts.wpn_fps_snp_qbu88_b_short.custom_stats = deep_clone(barrels.short_b2_stats)
-					
+
 					--Long Barrel
 					self.parts.wpn_fps_snp_qbu88_b_long.pcs = {
 						10,
@@ -14069,7 +14069,7 @@ end)
 					self.parts.wpn_fps_snp_qbu88_b_long.supported = true
 					self.parts.wpn_fps_snp_qbu88_b_long.stats = deep_clone(barrels.long_b2_stats)
 					self.parts.wpn_fps_snp_qbu88_b_long.custom_stats = deep_clone(barrels.long_b2_stats)
-						
+
 					--Extended Mag
 					self.parts.wpn_fps_snp_qbu88_m_extended.pcs = {
 						10,
@@ -14087,7 +14087,7 @@ end)
 					self.parts.wpn_fps_snp_qbu88_m_extended.custom_stats = {
 						ads_speed_mult = 1.025
 					}
-					
+
 					--Iron Sight
 					self.parts.wpn_fps_snp_qbu88_o_standard.pcs = {
 						10,
@@ -14098,7 +14098,7 @@ end)
 					self.parts.wpn_fps_snp_qbu88_o_standard.supported = true
 					self.parts.wpn_fps_snp_qbu88_o_standard.stats = {
 						value = 0
-					}		
+					}
 				end)
 
 			--TTI AR-10
@@ -14131,7 +14131,7 @@ end)
 						alert_size = -1
 					}
 					self.parts.wpn_fps_snp_tti_ns_hex.perks = {"silencer"}
-					
+
 					--Contractor Grip
 					self.parts.wpn_fps_snp_tti_g_grippy.pcs = {
 						10,
@@ -14144,9 +14144,9 @@ end)
 
 					--stop putting rails on rails dangit
 					self.parts.wpn_fps_snp_tti_fg_standard.forbids = {"wpn_fps_addon_ris"}
-					
+
 					--Contractor Override
-					self.wpn_fps_snp_tti.override = {}	
+					self.wpn_fps_snp_tti.override = {}
 
 					self.wpn_fps_snp_tti.override.wpn_fps_upg_m4_s_standard = {
 						stats = deep_clone(stocks.fixed_to_adj_dual_stats),
@@ -14206,14 +14206,14 @@ end)
 
 					--table.insert(self.wpn_fps_snp_tti.uses_parts, "wpn_fps_smg_olympic_s_short")
 					--table.insert(self.wpn_fps_snp_tti_npc.uses_parts, "wpn_fps_smg_olympic_s_short")
-					
+
 					self.wpn_fps_snp_tti_npc.override = deep_clone(self.wpn_fps_snp_tti.override)
 					self.wpn_fps_snp_tti_npc.uses_parts = deep_clone(self.wpn_fps_snp_tti.uses_parts)
 				end)
 
 			--WINCHESTER MODEL 1873
 				Hooks:PostHook(WeaponFactoryTweakData, "_init_winchester1874", "resmod_winchester1874", function(self)
-					
+
 					--Long Range Barrel
 					self.parts.wpn_fps_snp_winchester_b_long.pcs = {
 						10,
@@ -14226,7 +14226,7 @@ end)
 					self.parts.wpn_fps_snp_winchester_b_long.stats.concealment = -4
 					self.parts.wpn_fps_snp_winchester_b_long.stats.extra_ammo = 5
 					self.parts.wpn_fps_snp_winchester_b_long.custom_stats = deep_clone(barrels.long_b3_stats)
-					
+
 					--Outlaw's Silenced Barrel
 					self.parts.wpn_fps_snp_winchester_b_suppressed.pcs = {
 						10,
@@ -14246,7 +14246,7 @@ end)
 					self.parts.wpn_fps_snp_winchester_b_suppressed.sound_switch = {
 						suppressed = "suppressed_a"
 					}
-					
+
 					--A5 Scope
 					self.parts.wpn_fps_upg_winchester_o_classic.pcs = {
 						10,
@@ -14262,7 +14262,7 @@ end)
 						zoom = 40
 					}
 					self.parts.wpn_fps_upg_winchester_o_classic.reticle_obj = nil
-					
+
 					--Add Table for optic adapters
 					self.wpn_fps_snp_winchester.adds = {}
 
@@ -14298,8 +14298,8 @@ end)
 						self.wpn_fps_snp_winchester.adds[part_id] = { "wpn_fps_smg_thompson_o_adapter"}
 					end
 
-					self.wpn_fps_snp_winchester_npc.adds = deep_clone(self.wpn_fps_snp_winchester.adds)		
-					self.wpn_fps_snp_winchester_npc.uses_parts = deep_clone(self.wpn_fps_snp_winchester.uses_parts)		
+					self.wpn_fps_snp_winchester_npc.adds = deep_clone(self.wpn_fps_snp_winchester.adds)
+					self.wpn_fps_snp_winchester_npc.uses_parts = deep_clone(self.wpn_fps_snp_winchester.uses_parts)
 				end)
 
 			--R700
@@ -14321,7 +14321,7 @@ end)
 						10,
 						20,
 						30,
-						40	
+						40
 					}
 					self.parts.wpn_fps_snp_r700_b_medium.supported = true
 					self.parts.wpn_fps_snp_r700_b_medium.stats = {
@@ -14342,7 +14342,7 @@ end)
 						10,
 						20,
 						30,
-						40		
+						40
 					}
 					self.parts.wpn_fps_snp_r700_s_tactical.supported = true
 					self.parts.wpn_fps_snp_r700_s_tactical.stats = {
@@ -14355,7 +14355,7 @@ end)
 						third_unit = "units/pd2_dlc_joy/weapons/wpn_fps_smg_shepheard_pts/wpn_third_smg_shepheard_o_standard",
 						unit = "units/pd2_dlc_joy/weapons/wpn_fps_smg_shepheard_pts/wpn_fps_smg_shepheard_o_standard"
 					}
-					
+
 					--Military Stock
 					self.parts.wpn_fps_snp_r700_s_military.pcs = {
 						10,
@@ -14402,9 +14402,9 @@ end)
 
 					table.insert(self.wpn_fps_snp_r700.uses_parts, "wpn_fps_upg_o_ecp_irons_dmc")
 					table.insert(self.wpn_fps_snp_r700.uses_parts, "wpn_fps_upg_o_arbiter_irons_dmc")
-					
-					self.wpn_fps_snp_r700_npc.override = deep_clone(self.wpn_fps_snp_r700.override)	
-					self.wpn_fps_snp_r700_npc.uses_parts = deep_clone(self.wpn_fps_snp_r700.uses_parts)		
+
+					self.wpn_fps_snp_r700_npc.override = deep_clone(self.wpn_fps_snp_r700.override)
+					self.wpn_fps_snp_r700_npc.uses_parts = deep_clone(self.wpn_fps_snp_r700.uses_parts)
 				end)
 
 			--MSR
@@ -14415,7 +14415,7 @@ end)
 					self.parts.wpn_fps_snp_msr_b_long.supported = true
 					self.parts.wpn_fps_snp_msr_b_long.stats = deep_clone(barrels.long_b2_stats)
 					self.parts.wpn_fps_snp_msr_b_long.custom_stats = deep_clone(barrels.long_b2_stats)
-					
+
 					--Sniper Suppressor
 					self.parts.wpn_fps_snp_msr_ns_suppressor.pcs = {}
 					self.parts.wpn_fps_snp_msr_ns_suppressor.supported = true
@@ -14427,7 +14427,7 @@ end)
 						alert_size = -1
 					}
 					self.parts.wpn_fps_snp_msr_ns_suppressor.perks = {"silencer"}
-					
+
 					--Tactical Aluminium Body
 					self.parts.wpn_fps_snp_msr_body_msr.pcs = {}
 					self.parts.wpn_fps_snp_msr_body_msr.supported = true
@@ -14439,7 +14439,7 @@ end)
 							third_unit = "units/pd2_dlc_born/weapons/wpn_third_smg_hajk_pts/wpn_third_smg_hajk_o_standard"
 						}
 					}
-					
+
 					--Default Wood Body
 					self.parts.wpn_fps_snp_msr_body_wood.override = {}
 
@@ -14447,7 +14447,7 @@ end)
 
 					table.insert(self.wpn_fps_snp_msr.uses_parts, "wpn_fps_upg_o_arbiter_irons_dmc")
 					table.insert(self.wpn_fps_snp_msr.uses_parts, "wpn_fps_snp_victor_o_standard")
-							
+
 					self.wpn_fps_snp_msr_npc.override = deep_clone(self.wpn_fps_snp_msr.override)
 					self.wpn_fps_snp_msr_npc.uses_parts = deep_clone(self.wpn_fps_snp_msr.uses_parts)
 				end)
@@ -14682,7 +14682,7 @@ end)
 					self.parts.wpn_fps_snp_victor_ns_omega_special.pcs = nil
 					self.parts.wpn_fps_snp_victor_ns_omega_special.third_unit = "units/pd2_dlc_savi/weapons/wpn_third_snp_victor_pts/wpn_third_snp_victor_ns_hera_supp"
 					self.parts.wpn_fps_snp_victor_ns_omega_special.unit = "units/pd2_dlc_savi/weapons/wpn_fps_snp_victor_pts/wpn_fps_snp_victor_ns_hera_supp"
-							
+
 					--Ursa Minor Grip
 					self.parts.wpn_fps_snp_victor_g_mod3.pcs = {
 						10,
@@ -14822,7 +14822,7 @@ end)
 							recoil = -2
 						}
 					}
-					
+
 					self.wpn_fps_snp_victor.override.wpn_fps_vg_vmp_vert = {
 						stats = {
 							concealment = 2,
@@ -14872,7 +14872,7 @@ end)
 					self.parts.wpn_fps_snp_scout_bolt_speed.custom_stats = deep_clone(barrels.short_b3_stats)
 					self.parts.wpn_fps_snp_scout_bolt_speed.custom_stats.ads_speed_mult = 1
 					self.parts.wpn_fps_snp_scout_bolt_speed.custom_stats.rof_mult = 1.18181
-					
+
 					--Longshot Suppressor
 					self.parts.wpn_fps_snp_scout_ns_suppressor.pcs = {
 						10,
@@ -14931,7 +14931,7 @@ end)
 						spread = -1,
 						concealment = -1,
 						reload = 3
-					}		
+					}
 
 					--Steakout Stock
 					self.parts.wpn_fps_snp_scout_s_pads_none.pcs = {
@@ -14986,7 +14986,7 @@ end)
 						alert_size = -1
 					}
 					self.parts.wpn_fps_snp_siltstone_b_silenced.perks = {"silencer"}
-					
+
 					--Grievky Compensator
 					self.parts.wpn_fps_snp_siltstone_ns_variation_b.pcs = {
 						10,
@@ -14996,11 +14996,11 @@ end)
 					}
 					self.parts.wpn_fps_snp_siltstone_ns_variation_b.supported = true
 					self.parts.wpn_fps_snp_siltstone_ns_variation_b.stats = {
-						value = 5,			
+						value = 5,
 						spread = 1,
 						concealment = -3
 					}
-					
+
 					--Lightweight Foregrip
 					self.parts.wpn_fps_snp_siltstone_fg_polymer.pcs = {
 						10,
@@ -15014,7 +15014,7 @@ end)
 						recoil = -2,
 						concealment = 1
 					}
-					
+
 					--Iron Sight
 					self.parts.wpn_fps_snp_siltstone_iron_sight.pcs = {
 						10,
@@ -15026,7 +15026,7 @@ end)
 					self.parts.wpn_fps_snp_siltstone_iron_sight.stats = {
 						value = 0
 					}
-					
+
 					--Lightweight Stock
 					self.parts.wpn_fps_snp_siltstone_s_polymer.pcs = {
 						10,
@@ -15055,7 +15055,7 @@ end)
 					self.parts.wpn_fps_snp_wa2000_b_long.supported = true
 					self.parts.wpn_fps_snp_wa2000_b_long.stats = deep_clone(barrels.long_b2_stats)
 					self.parts.wpn_fps_snp_wa2000_b_long.custom_stats = deep_clone(barrels.long_b2_stats)
-					
+
 					--Suppressed Barrel
 					self.parts.wpn_fps_snp_wa2000_b_suppressed.pcs = {
 						10,
@@ -15072,7 +15072,7 @@ end)
 						alert_size = -1
 					}
 					self.parts.wpn_fps_snp_wa2000_b_suppressed.perks = {"silencer"}
-					
+
 					--Light Grip
 					self.parts.wpn_fps_snp_wa2000_g_light.pcs = {
 						10,
@@ -15094,7 +15094,7 @@ end)
 					self.parts.wpn_fps_snp_wa2000_g_stealth.supported = true
 					self.parts.wpn_fps_snp_wa2000_g_stealth.stats = deep_clone(grips.quickdraw_acc)
 					self.parts.wpn_fps_snp_wa2000_g_stealth.custom_stats = deep_clone(grips.quickdraw_acc)
-					
+
 					--Walnut Grip
 					self.parts.wpn_fps_snp_wa2000_g_walnut.pcs = {
 						10,
@@ -15114,11 +15114,11 @@ end)
 						}
 					}
 					self.wpn_fps_snp_wa2000.override = {}
-					
+
 					table.insert(self.wpn_fps_snp_wa2000.uses_parts, "wpn_fps_upg_o_arbiter_irons_dmc")
 
-					self.wpn_fps_snp_wa2000_npc.override = deep_clone(self.wpn_fps_snp_wa2000.override)	
-					self.wpn_fps_snp_wa2000_npc.uses_parts = deep_clone(self.wpn_fps_snp_wa2000.uses_parts)	
+					self.wpn_fps_snp_wa2000_npc.override = deep_clone(self.wpn_fps_snp_wa2000.override)
+					self.wpn_fps_snp_wa2000_npc.uses_parts = deep_clone(self.wpn_fps_snp_wa2000.uses_parts)
 				end)
 
 			--MARLIN SBL
@@ -15140,14 +15140,14 @@ end)
 					self.parts.wpn_fps_snp_sbl_b_long.custom_stats = {
 						falloff_start_mult = 1.075,
 						falloff_end_mult = 1.075
-					}		
-					
+					}
+
 					--Sniper Suppressor
 					self.parts.wpn_fps_snp_sbl_b_short.pcs = {
 						10,
 						20,
 						30,
-						40	
+						40
 					}
 					self.parts.wpn_fps_snp_sbl_b_short.supported = true
 					self.parts.wpn_fps_snp_sbl_b_short.has_description = true
@@ -15160,7 +15160,7 @@ end)
 						alert_size = -1
 					}
 					self.parts.wpn_fps_snp_sbl_b_short.perks = {"silencer"}
-					
+
 					--Club Stock
 					self.parts.wpn_fps_snp_sbl_s_saddle.pcs = {
 						10,
@@ -15175,12 +15175,12 @@ end)
 						concealment = -1,
 						reload = 3
 					}
-					
+
 					--Iron Sights (Still basically the same as ours)
 					self.parts.wpn_fps_snp_sbl_o_standard.supported = true
 					self.parts.wpn_fps_snp_sbl_o_standard.stats = {
 						value = 1
-					}	
+					}
 
 					self.wpn_fps_snp_sbl.override = self.wpn_fps_snp_sbl.override or {}
 
@@ -15189,32 +15189,32 @@ end)
 							self.wpn_fps_snp_sbl.override[part_id] = self.wpn_fps_snp_sbl.override[part_id] or {}
 							self.wpn_fps_snp_sbl.override[part_id].a_obj = "a_fl_2"
 						end
-					end	
+					end
 
 					self.wpn_fps_snp_sbl.override.wpn_fps_addon_ris = self.wpn_fps_snp_sbl.override.wpn_fps_addon_ris or {}
 					self.wpn_fps_snp_sbl.override.wpn_fps_addon_ris.a_obj = "a_fl_2"
 
-					self.wpn_fps_snp_sbl_npc.override = deep_clone(self.wpn_fps_snp_sbl.override)		
-					self.wpn_fps_snp_sbl_npc.uses_parts = deep_clone(self.wpn_fps_snp_sbl.uses_parts)		
+					self.wpn_fps_snp_sbl_npc.override = deep_clone(self.wpn_fps_snp_sbl.override)
+					self.wpn_fps_snp_sbl_npc.uses_parts = deep_clone(self.wpn_fps_snp_sbl.uses_parts)
 				end)
 
 			--MOSIN
 				Hooks:PostHook(WeaponFactoryTweakData, "_init_mosin", "resmod_mosin", function(self)
-					
+
 					--Long Barrel
 					self.parts.wpn_fps_snp_mosin_b_standard.pcs = {}
 					self.parts.wpn_fps_snp_mosin_b_standard.supported = true
 					self.parts.wpn_fps_snp_mosin_b_standard.stats = deep_clone(barrels.long_b3_stats)
 					self.parts.wpn_fps_snp_mosin_b_standard.stats.bayonet_range = 50
 					self.parts.wpn_fps_snp_mosin_b_standard.custom_stats = deep_clone(barrels.long_b3_stats)
-					
+
 					--Short Barrel
 					self.parts.wpn_fps_snp_mosin_b_short.pcs = {}
 					self.parts.wpn_fps_snp_mosin_b_short.supported = true
 					self.parts.wpn_fps_snp_mosin_b_short.stats = deep_clone(barrels.short_b1_stats)
 					self.parts.wpn_fps_snp_mosin_b_short.stats.bayonet_range = -20
 					self.parts.wpn_fps_snp_mosin_b_short.custom_stats = deep_clone(barrels.short_b1_stats)
-					
+
 					--Silenced Barrel
 					self.parts.wpn_fps_snp_mosin_b_sniper.pcs = {}
 					self.parts.wpn_fps_snp_mosin_b_sniper.supported = true
@@ -15227,7 +15227,7 @@ end)
 						alert_size = -1
 					}
 					self.parts.wpn_fps_snp_mosin_b_sniper.perks = {"silencer"}
-					
+
 					--Discreet Stock
 					self.parts.wpn_fps_snp_mosin_body_black.pcs = {}
 					self.parts.wpn_fps_snp_mosin_body_black.supported = true
@@ -15236,7 +15236,7 @@ end)
 						concealment = 1,
 						recoil = -2
 					}
-					
+
 					--Nagant Bayonet
 					self.parts.wpn_fps_snp_mosin_ns_bayonet.pcs = {}
 					self.parts.wpn_fps_snp_mosin_ns_bayonet.supported = true
@@ -15253,14 +15253,14 @@ end)
 						melee_speed_mult = 0.8,
 						ads_speed_mult = 1.125
 					}
-						
+
 					--Iron Sight
 					self.parts.wpn_fps_snp_mosin_iron_sight.pcs = {}
 					self.parts.wpn_fps_snp_mosin_iron_sight.supported = true
 					self.parts.wpn_fps_snp_mosin_iron_sight.stats = {
 						value = 0
 					}
-					
+
 					--Tranq Rounds
 					self.parts.wpn_fps_snp_mosin_a_tranq = {
 						pcs = {},
@@ -15294,16 +15294,16 @@ end)
 					self.wpn_fps_snp_mosin.override.wpn_fps_addon_ris = {
 						unit = "units/pd2_dlc_pines/weapons/wpn_fps_smg_m1928_pts/wpn_fps_smg_thompson_fl_adapter"
 					}
-					
+
 					table.insert(self.wpn_fps_snp_mosin.uses_parts, "wpn_fps_snp_mosin_a_tranq")
-					table.insert(self.wpn_fps_snp_mosin_npc.uses_parts, "wpn_fps_snp_mosin_a_tranq")		
-					
-					self.wpn_fps_snp_mosin_npc.uses_parts = deep_clone(self.wpn_fps_snp_mosin.uses_parts)	
+					table.insert(self.wpn_fps_snp_mosin_npc.uses_parts, "wpn_fps_snp_mosin_a_tranq")
+
+					self.wpn_fps_snp_mosin_npc.uses_parts = deep_clone(self.wpn_fps_snp_mosin.uses_parts)
 				end)
 
 			--WINCHESTER MODEL 70
 				Hooks:PostHook(WeaponFactoryTweakData, "_init_model70", "resmod_model70", function(self)
-					
+
 					--Beak Suppressor
 					self.parts.wpn_fps_snp_model70_ns_suppressor.pcs = {
 						10,
@@ -15317,7 +15317,7 @@ end)
 						suppression = 12,
 						alert_size = -1
 					}
-					
+
 					--Iron Sight
 					self.parts.wpn_fps_snp_model70_iron_sight.pcs = {}
 					self.parts.wpn_fps_snp_model70_iron_sight.supported = true
@@ -15378,7 +15378,7 @@ end)
 
 			--DT SRS
 				Hooks:PostHook(WeaponFactoryTweakData, "_init_desertfox", "resmod_desertfox", function(self)
-					
+
 					--Default Barrel
 					self.parts.wpn_fps_snp_desertfox_b_short.override = {
 						wpn_fps_upg_o_arbiter_irons_dmc = {
@@ -15386,7 +15386,7 @@ end)
 							unit = "units/pd2_dlc_joy/weapons/wpn_fps_smg_shepheard_pts/wpn_fps_smg_shepheard_o_short"
 						}
 					}
-					
+
 					--Long Barrel
 					self.parts.wpn_fps_snp_desertfox_b_long.pcs = {}
 					self.parts.wpn_fps_snp_desertfox_b_long.supported = true
@@ -15398,7 +15398,7 @@ end)
 							unit = "units/pd2_dlc_joy/weapons/wpn_fps_smg_shepheard_pts/wpn_fps_smg_shepheard_o_standard"
 						}
 					}
-					
+
 					--Suppressed Barrel
 					self.parts.wpn_fps_snp_desertfox_b_silencer.pcs = {}
 					self.parts.wpn_fps_snp_desertfox_b_silencer.supported = true
@@ -15413,9 +15413,9 @@ end)
 							unit = "units/pd2_dlc_joy/weapons/wpn_fps_smg_shepheard_pts/wpn_fps_smg_shepheard_o_short"
 						}
 					}
-					
+
 					table.insert(self.wpn_fps_snp_desertfox.uses_parts, "wpn_fps_upg_o_arbiter_irons_dmc")
-					
+
 					self.wpn_fps_snp_desertfox_npc.uses_parts = deep_clone(self.wpn_fps_snp_desertfox.uses_parts)
 				end)
 
@@ -15435,7 +15435,7 @@ end)
 						spread = -2,
 						concealment = 2
 					}
-					
+
 					--Compensated Suppressor
 					self.parts.wpn_fps_snp_r93_b_suppressed.pcs = {}
 					self.parts.wpn_fps_snp_r93_b_suppressed.supported = true
@@ -15447,7 +15447,7 @@ end)
 						alert_size = -1
 					}
 					self.parts.wpn_fps_snp_r93_b_suppressed.perks = {"silencer"}
-					
+
 					--Wooden Body
 					self.parts.wpn_fps_snp_r93_body_wood.pcs = {}
 					self.parts.wpn_fps_snp_r93_body_wood.supported = true
@@ -15456,13 +15456,13 @@ end)
 						concealment = -2,
 						recoil = 4
 					}
-					
+
 					--Override Table
 					self.wpn_fps_snp_r93.override = {}
 
 					table.insert(self.wpn_fps_snp_r93.uses_parts, "wpn_fps_upg_o_arbiter_irons_dmc")
-							
-					self.wpn_fps_snp_r93_npc.uses_parts = deep_clone(self.wpn_fps_snp_r93.uses_parts)	
+
+					self.wpn_fps_snp_r93_npc.uses_parts = deep_clone(self.wpn_fps_snp_r93.uses_parts)
 				end)
 
 			--FLINTLOCK
@@ -15480,7 +15480,7 @@ end)
 							wpn_fps_spec_bessy = {
 								translation = Vector3(0, 2.5, -0.5)
 							}
-						}		
+						}
 					}
 					self.parts.wpn_fps_spec_bessy_reciever = {
 						texture_bundle_folder = "pda10",
@@ -15602,15 +15602,15 @@ end)
 						}
 					}
 
-					table.insert(self.wpn_fps_spec_bessy.uses_parts, "wpn_fps_upg_o_arbiter_irons_dmc")	
-					table.insert(self.wpn_fps_spec_bessy.uses_parts, "wpn_fps_upg_o_specter")	
-					table.insert(self.wpn_fps_spec_bessy.uses_parts, "wpn_fps_upg_o_aimpoint")	
+					table.insert(self.wpn_fps_spec_bessy.uses_parts, "wpn_fps_upg_o_arbiter_irons_dmc")
+					table.insert(self.wpn_fps_spec_bessy.uses_parts, "wpn_fps_upg_o_specter")
+					table.insert(self.wpn_fps_spec_bessy.uses_parts, "wpn_fps_upg_o_aimpoint")
 					table.insert(self.wpn_fps_spec_bessy.uses_parts, "wpn_fps_upg_o_docter")
 					table.insert(self.wpn_fps_spec_bessy.uses_parts, "wpn_fps_upg_o_eotech")
 					table.insert(self.wpn_fps_spec_bessy.uses_parts, "wpn_fps_upg_o_t1micro")
 					table.insert(self.wpn_fps_spec_bessy.uses_parts, "wpn_fps_upg_o_rx30")
-					table.insert(self.wpn_fps_spec_bessy.uses_parts, "wpn_fps_upg_o_rx01")	
-					table.insert(self.wpn_fps_spec_bessy.uses_parts, "wpn_fps_upg_o_reflex")	
+					table.insert(self.wpn_fps_spec_bessy.uses_parts, "wpn_fps_upg_o_rx01")
+					table.insert(self.wpn_fps_spec_bessy.uses_parts, "wpn_fps_upg_o_reflex")
 					table.insert(self.wpn_fps_spec_bessy.uses_parts, "wpn_fps_upg_o_eotech_xps")
 					table.insert(self.wpn_fps_spec_bessy.uses_parts, "wpn_fps_upg_o_cmore")
 					table.insert(self.wpn_fps_spec_bessy.uses_parts, "wpn_fps_upg_o_aimpoint_2")
@@ -15627,7 +15627,7 @@ end)
 					table.insert(self.wpn_fps_spec_bessy.uses_parts, "wpn_fps_upg_o_atibal")
 					table.insert(self.wpn_fps_spec_bessy.uses_parts, "wpn_fps_upg_o_xpsg33_magnifier")
 					table.insert(self.wpn_fps_spec_bessy.uses_parts, "wpn_fps_upg_o_sig")
-					
+
 					table.insert(self.wpn_fps_spec_bessy.uses_parts, "wpn_fps_upg_fl_ass_smg_sho_peqbox")
 					table.insert(self.wpn_fps_spec_bessy.uses_parts, "wpn_fps_upg_fl_ass_smg_sho_surefire")
 					table.insert(self.wpn_fps_spec_bessy.uses_parts, "wpn_fps_upg_fl_ass_utg")
@@ -15639,12 +15639,12 @@ end)
 						if self.parts[used_part_id] and self.parts[used_part_id].type then
 							if self.parts[used_part_id].type == "sight" then
 								self.wpn_fps_spec_bessy.adds[used_part_id] = {"wpn_fps_bessy_o", "wpn_fps_smg_thompson_o_adapter"}
-								self.wpn_fps_spec_bessy.override[used_part_id] = { 
+								self.wpn_fps_spec_bessy.override[used_part_id] = {
 									parent = "shitass_o"
 								}
 							elseif self.parts[used_part_id].type == "gadget" then
 								self.wpn_fps_spec_bessy.adds[used_part_id] = {"wpn_fps_bessy_o", "wpn_fps_smg_thompson_fl_adapter"}
-								self.wpn_fps_spec_bessy.override[used_part_id] = { 
+								self.wpn_fps_spec_bessy.override[used_part_id] = {
 									parent = "shitass_o"
 								}
 							end
@@ -15654,13 +15654,13 @@ end)
 					self.wpn_fps_spec_bessy.override.wpn_fps_upg_o_hamr_reddot = {
 						parent = "shitass_o",
 					}
-					self.wpn_fps_spec_bessy.override.wpn_fps_upg_o_atibal_reddot = { 
+					self.wpn_fps_spec_bessy.override.wpn_fps_upg_o_atibal_reddot = {
 						parent = "shitass_o",
 					}
-					self.wpn_fps_spec_bessy.override.wpn_fps_smg_thompson_o_adapter = { 
+					self.wpn_fps_spec_bessy.override.wpn_fps_smg_thompson_o_adapter = {
 						parent = "shitass_o",
 					}
-					self.wpn_fps_spec_bessy.override.wpn_fps_smg_thompson_fl_adapter = { 
+					self.wpn_fps_spec_bessy.override.wpn_fps_smg_thompson_fl_adapter = {
 						parent = "shitass_o",
 					}
 
@@ -15668,7 +15668,7 @@ end)
 						"wpn_fps_bessy_o",
 						"wpn_fps_smg_thompson_o_adapter",
 					}
-					self.wpn_fps_spec_bessy.override.wpn_fps_upg_o_arbiter_irons_dmc = { 
+					self.wpn_fps_spec_bessy.override.wpn_fps_upg_o_arbiter_irons_dmc = {
 						parent = "shitass_o"
 					}
 
@@ -15737,7 +15737,7 @@ end)
 						"wpn_fps_m4_uupg_s_zulu",
 						"wpn_fps_snp_victor_s_mod0",
 						"wpn_fps_sho_sko12_stock"
-					}		
+					}
 					self.parts.wpn_fps_snp_contender_conversion.override = {
 						wpn_fps_snp_contender_grip_standard = {
 							third_unit = "units/pd2_dlc_pxp3/weapons/wpn_fps_snp_contender_pts/wpn_third_snp_contender_grip_conversion",
@@ -15790,13 +15790,13 @@ end)
 				self.parts.wpn_fps_snp_m95_barrel_long.supported = true
 				self.parts.wpn_fps_snp_m95_barrel_long.stats = deep_clone(barrels.long_b3_stats)
 				self.parts.wpn_fps_snp_m95_barrel_long.custom_stats = deep_clone(barrels.long_b3_stats)
-				
+
 				--CQB Barrel
 				self.parts.wpn_fps_snp_m95_barrel_short.pcs = {}
 				self.parts.wpn_fps_snp_m95_barrel_short.supported = true
 				self.parts.wpn_fps_snp_m95_barrel_short.stats = deep_clone(barrels.short_b3_stats)
 				self.parts.wpn_fps_snp_m95_barrel_short.custom_stats = deep_clone(barrels.short_b3_stats)
-				
+
 				--Suppressed Barrel
 				self.parts.wpn_fps_snp_m95_barrel_suppressed.pcs = {}
 				self.parts.wpn_fps_snp_m95_barrel_suppressed.has_description = true
@@ -15808,12 +15808,12 @@ end)
 					alert_size = -1
 				}
 				self.parts.wpn_fps_snp_m95_barrel_suppressed.perks = {"silencer"}
-					
+
 				self.wpn_fps_snp_m95.override.wpn_fps_upg_m4_g_mgrip = nil --fuck off
-				
+
 				table.insert(self.wpn_fps_snp_m95.uses_parts, "wpn_fps_upg_o_arbiter_irons_dmc")
 
-				self.wpn_fps_snp_m95_npc.uses_parts = deep_clone(self.wpn_fps_snp_m95.uses_parts)		
+				self.wpn_fps_snp_m95_npc.uses_parts = deep_clone(self.wpn_fps_snp_m95.uses_parts)
 			end)
 
 
@@ -15883,16 +15883,16 @@ end)
 						dot_data_name = "ammo_flamethrower_mk2_welldone"
 					}
 				}
-				
+
 				--Part Additions
 				table.insert(self.wpn_fps_fla_mk2.uses_parts, "wpn_fps_upg_dragon_lord_legend")
-				table.insert(self.wpn_fps_fla_mk2.uses_parts, "wpn_fps_upg_fl_ass_smg_sho_peqbox")	
-				table.insert(self.wpn_fps_fla_mk2.uses_parts, "wpn_fps_upg_fl_ass_smg_sho_surefire")		
+				table.insert(self.wpn_fps_fla_mk2.uses_parts, "wpn_fps_upg_fl_ass_smg_sho_peqbox")
+				table.insert(self.wpn_fps_fla_mk2.uses_parts, "wpn_fps_upg_fl_ass_smg_sho_surefire")
 				table.insert(self.wpn_fps_fla_mk2.uses_parts, "wpn_fps_upg_fl_ass_peq15")
 				table.insert(self.wpn_fps_fla_mk2.uses_parts, "wpn_fps_upg_fl_ass_laser")
-				table.insert(self.wpn_fps_fla_mk2.uses_parts, "wpn_fps_upg_fl_ass_utg")	
-				
-				self.wpn_fps_fla_mk2_npc.uses_parts = deep_clone(self.wpn_fps_fla_mk2.uses_parts)		
+				table.insert(self.wpn_fps_fla_mk2.uses_parts, "wpn_fps_upg_fl_ass_utg")
+
+				self.wpn_fps_fla_mk2_npc.uses_parts = deep_clone(self.wpn_fps_fla_mk2.uses_parts)
 			end)
 
 		--MA-17 FLAMETHROWER
@@ -15915,7 +15915,7 @@ end)
 					falloff_start_mult = 1,
 					falloff_end_mult = 1
 				}
-				
+
 				--High Temperature Mixture
 				self.parts.wpn_fps_fla_system_m_high.desc_id = "bm_wp_fla_mk2_mag_well_desc_sc"
 				self.parts.wpn_fps_fla_system_m_high.has_description = true
@@ -15931,7 +15931,7 @@ end)
 				}
 				self.parts.wpn_fps_fla_system_m_high.custom_stats = {
 					use_well_done_dot = true
-				}			
+				}
 
 				--Low Temperature Mixture
 				self.parts.wpn_fps_fla_system_m_low.desc_id = "bm_wp_fla_mk2_mag_rare_desc_sc"
@@ -15948,20 +15948,20 @@ end)
 				}
 				self.parts.wpn_fps_fla_system_m_low.custom_stats = {
 					use_rare_dot = true
-				}		
-				
+				}
+
 				table.insert(self.wpn_fps_fla_system.uses_parts, "wpn_fps_upg_fl_ass_smg_sho_peqbox")
-				table.insert(self.wpn_fps_fla_system_npc.uses_parts, "wpn_fps_upg_fl_ass_smg_sho_peqbox")		
+				table.insert(self.wpn_fps_fla_system_npc.uses_parts, "wpn_fps_upg_fl_ass_smg_sho_peqbox")
 				table.insert(self.wpn_fps_fla_system.uses_parts, "wpn_fps_upg_fl_ass_smg_sho_surefire")
-				table.insert(self.wpn_fps_fla_system_npc.uses_parts, "wpn_fps_upg_fl_ass_smg_sho_surefire")	
+				table.insert(self.wpn_fps_fla_system_npc.uses_parts, "wpn_fps_upg_fl_ass_smg_sho_surefire")
 				table.insert(self.wpn_fps_fla_system.uses_parts, "wpn_fps_upg_fl_ass_peq15")
-				table.insert(self.wpn_fps_fla_system_npc.uses_parts, "wpn_fps_upg_fl_ass_peq15")	
+				table.insert(self.wpn_fps_fla_system_npc.uses_parts, "wpn_fps_upg_fl_ass_peq15")
 				table.insert(self.wpn_fps_fla_system.uses_parts, "wpn_fps_upg_fl_ass_laser")
-				table.insert(self.wpn_fps_fla_system_npc.uses_parts, "wpn_fps_upg_fl_ass_laser")	
+				table.insert(self.wpn_fps_fla_system_npc.uses_parts, "wpn_fps_upg_fl_ass_laser")
 				table.insert(self.wpn_fps_fla_system.uses_parts, "wpn_fps_upg_fl_ass_utg")
-				table.insert(self.wpn_fps_fla_system_npc.uses_parts, "wpn_fps_upg_fl_ass_utg")	
-					
-				self.wpn_fps_fla_system_npc.uses_parts = deep_clone(self.wpn_fps_fla_system.uses_parts)	
+				table.insert(self.wpn_fps_fla_system_npc.uses_parts, "wpn_fps_upg_fl_ass_utg")
+
+				self.wpn_fps_fla_system_npc.uses_parts = deep_clone(self.wpn_fps_fla_system.uses_parts)
 			end)
 		--CASH BLASTER
 			function WeaponFactoryTweakData:_init_money()
@@ -16057,7 +16057,7 @@ end)
 					self.parts.wpn_upg_saiga_fg_lowerrail.pcs = {
 						10,
 						20,
-						30, 
+						30,
 						40
 					}
 					self.parts.wpn_upg_saiga_fg_lowerrail.stats = {
@@ -16076,7 +16076,7 @@ end)
 						concealment = -2
 					}
 					self.parts.wpn_upg_saiga_fg_lowerrail.custom_stats = nil
-					
+
 					--(Izhma) Drum Mag
 					self.parts.wpn_upg_saiga_m_20rnd = {
 						pcs = {},
@@ -16089,9 +16089,9 @@ end)
 						unit = "units/payday2/weapons/wpn_fps_shot_saiga_pts/wpn_upg_saiga_m_20rnd",
 						supported = true,
 						stats = {
-							value = 1, 
+							value = 1,
 							extra_ammo = 15,
-							reload = -7, 
+							reload = -7,
 							concealment = -5
 						},
 						custom_stats = {
@@ -16099,7 +16099,7 @@ end)
 						}
 					}
 					self.parts.wpn_upg_saiga_m_20rnd.third_unit = "units/payday2/weapons/wpn_third_shot_saiga_pts/wpn_third_saiga_m_20rnd"
-					
+
 					--Izhma Override Table
 					self.wpn_fps_shot_saiga.override = {
 						wpn_upg_o_marksmansight_rear_vanilla = {
@@ -16254,12 +16254,12 @@ end)
 							end
 						end
 					end
-					
+
 					--Override tables
 					self.wpn_fps_sho_aa12.override = {
 						wpn_fps_upg_a_slug = deep_clone(shot_ammo.a_slug_semi_override),
 						wpn_fps_upg_a_custom = deep_clone(shot_ammo.a_custom_semi_override),
-						wpn_fps_upg_a_custom_free = deep_clone(shot_ammo.a_custom_semi_override),			
+						wpn_fps_upg_a_custom_free = deep_clone(shot_ammo.a_custom_semi_override),
 						wpn_fps_upg_a_explosive = deep_clone(shot_ammo.a_explosive_semi_override),
 						wpn_fps_upg_a_rip = deep_clone(shot_ammo.a_rip_semi_override),
 						wpn_fps_upg_a_piercing = deep_clone(shot_ammo.a_piercing_semi_override),
@@ -16289,7 +16289,7 @@ end)
 						spread = 1,
 						recoil = -2
 					}
-					self.parts.wpn_fps_sho_sko12_body_grip.custom_stats = {}	
+					self.parts.wpn_fps_sho_sko12_body_grip.custom_stats = {}
 
 					self.parts.wpn_fps_sho_sko12_stock.supported = true
 					self.parts.wpn_fps_sho_sko12_stock.stats = deep_clone(stocks.adj_acc_stats)
@@ -16310,7 +16310,7 @@ end)
 					self.parts.wpn_fps_sho_sko12_conversion.unit = "units/payday2/weapons/wpn_upg_dummy/wpn_upg_dummy"
 					self.parts.wpn_fps_sho_sko12_conversion.stats = { value = 0 }
 
-					self.parts.wpn_fps_sho_sko12_m_drum.forbids = { 
+					self.parts.wpn_fps_sho_sko12_m_drum.forbids = {
 						"wpn_fps_upg_i_autofire",
 						"wpn_fps_upg_i_singlefire"
 					}
@@ -16322,13 +16322,13 @@ end)
 					self.wpn_fps_sho_sko12.override.wpn_fps_upg_a_explosive = deep_clone(shot_ammo.a_explosive_semi_override)
 					self.wpn_fps_sho_sko12.override.wpn_fps_upg_a_rip = deep_clone(shot_ammo.a_rip_semi_override)
 					self.wpn_fps_sho_sko12.override.wpn_fps_upg_a_piercing = deep_clone(shot_ammo.a_piercing_semi_override)
-					self.wpn_fps_sho_sko12.override.wpn_fps_upg_a_dragons_breath = deep_clone(shot_ammo.a_dragons_breath_semi_override)		
+					self.wpn_fps_sho_sko12.override.wpn_fps_upg_a_dragons_breath = deep_clone(shot_ammo.a_dragons_breath_semi_override)
 					self.wpn_fps_sho_sko12.override.wpn_fps_smg_mac10_s_no = {
 						unit = "units/pd2_dlc_pxp2/weapons/wpn_fps_sho_sko12_pts/wpn_fps_sho_sko12_s_adapter_short",
 						third_unit = "units/pd2_dlc_pxp2/weapons/wpn_fps_sho_sko12_pts/wpn_third_sho_sko12_s_adapter_short",
 						stats = deep_clone(stocks.remove_adj_stats),
 						custom_stats = deep_clone(stocks.remove_adj_stats)
-					}		
+					}
 
 					for i, part_id in pairs(self.wpn_fps_sho_sko12.uses_parts) do
 						attachment_list = {
@@ -16340,7 +16340,7 @@ end)
 								self.wpn_fps_sho_sko12.uses_parts[i] = "resmod_dummy"
 							end
 						end
-					end	
+					end
 
 					self.wpn_fps_sho_sko12.override.wpn_fps_upg_o_mbus_rear = {
 						a_obj = "a_or"
@@ -16348,7 +16348,7 @@ end)
 					self.wpn_fps_sho_sko12.override.wpn_fps_upg_o_mbus_front = {
 						a_obj = "a_of"
 					}
-					
+
 					table.insert(self.wpn_fps_sho_sko12.uses_parts, "wpn_fps_smg_mac10_s_no")
 					table.insert(self.wpn_fps_sho_sko12.uses_parts, "wpn_fps_upg_o_dd_irons_dmc")
 					table.insert(self.wpn_fps_sho_sko12.uses_parts, "wpn_fps_upg_o_mbus_rear")
@@ -16366,7 +16366,7 @@ end)
 					self.wpn_fps_sho_x_sko12.override.wpn_fps_upg_a_explosive = deep_clone(shot_ammo.a_explosive_semi_override)
 					self.wpn_fps_sho_x_sko12.override.wpn_fps_upg_a_rip = deep_clone(shot_ammo.a_rip_semi_override)
 					self.wpn_fps_sho_x_sko12.override.wpn_fps_upg_a_piercing = deep_clone(shot_ammo.a_piercing_semi_override)
-					self.wpn_fps_sho_x_sko12.override.wpn_fps_upg_a_dragons_breath = deep_clone(shot_ammo.a_dragons_breath_semi_override)		
+					self.wpn_fps_sho_x_sko12.override.wpn_fps_upg_a_dragons_breath = deep_clone(shot_ammo.a_dragons_breath_semi_override)
 
 					for i, part_id in pairs(self.wpn_fps_sho_x_sko12.uses_parts) do
 						attachment_list = {
@@ -16378,7 +16378,7 @@ end)
 								self.wpn_fps_sho_x_sko12.uses_parts[i] = "resmod_dummy"
 							end
 						end
-					end	
+					end
 
 					self.wpn_fps_sho_x_sko12_npc.uses_parts = deep_clone(self.wpn_fps_sho_x_sko12.uses_parts)
 				end)
@@ -16416,14 +16416,14 @@ end)
 						falloff_end_mult = 0.9,
 						ads_speed_mult = 0.95
 					}
-					
+
 					--Collapsed Stock
 					self.parts.wpn_fps_sho_ben_s_collapsed.pcs = {}
 					self.parts.wpn_fps_sho_ben_s_collapsed.supported = true
 					self.parts.wpn_fps_sho_ben_s_collapsed.stats = deep_clone(stocks.adj_to_folded_stats)
 					self.parts.wpn_fps_sho_ben_s_collapsed.stats.value = 0
 					self.parts.wpn_fps_sho_ben_s_collapsed.custom_stats = deep_clone(stocks.adj_to_folded_stats)
-					
+
 					--Tactical Stock
 					self.parts.wpn_fps_sho_ben_s_solid.pcs = {}
 					self.parts.wpn_fps_sho_ben_s_solid.supported = true
@@ -16434,11 +16434,11 @@ end)
 					self.wpn_fps_sho_ben.override = {
 						wpn_fps_upg_a_slug = deep_clone(shot_ammo.a_slug_semi_override),
 						wpn_fps_upg_a_custom = deep_clone(shot_ammo.a_custom_semi_override),
-						wpn_fps_upg_a_custom_free = deep_clone(shot_ammo.a_custom_semi_override),			
+						wpn_fps_upg_a_custom_free = deep_clone(shot_ammo.a_custom_semi_override),
 						wpn_fps_upg_a_explosive = deep_clone(shot_ammo.a_explosive_semi_override),
 						wpn_fps_upg_a_rip = deep_clone(shot_ammo.a_rip_semi_override),
 						wpn_fps_upg_a_piercing = deep_clone(shot_ammo.a_piercing_semi_override),
-						wpn_fps_upg_a_dragons_breath = deep_clone(shot_ammo.a_dragons_breath_semi_override)		
+						wpn_fps_upg_a_dragons_breath = deep_clone(shot_ammo.a_dragons_breath_semi_override)
 					}
 
 					table.insert(self.wpn_fps_sho_ben.uses_parts, "wpn_fps_sho_ben_cnuy_hoshino")
@@ -16462,7 +16462,7 @@ end)
 						concealment = -1,
 						extra_ammo = 2
 					}
-					
+
 					--Folded Stock
 					self.parts.wpn_fps_sho_s_spas12_folded.pcs = {
 						10,
@@ -16489,7 +16489,7 @@ end)
 					self.parts.wpn_fps_sho_s_spas12_nostock.supported = true
 					self.parts.wpn_fps_sho_s_spas12_nostock.stats = deep_clone(stocks.remove_nocheeks_stats)
 					self.parts.wpn_fps_sho_s_spas12_nostock.custom_stats = deep_clone(stocks.remove_nocheeks_stats)
-					
+
 					--Solid Stock
 					self.parts.wpn_fps_sho_s_spas12_solid.pcs = {
 						10,
@@ -16500,13 +16500,13 @@ end)
 					self.parts.wpn_fps_sho_s_spas12_solid.supported = true
 					self.parts.wpn_fps_sho_s_spas12_solid.stats = deep_clone(stocks.nocheeks_to_fixed_rec3_stats)
 					self.parts.wpn_fps_sho_s_spas12_solid.custom_stats = deep_clone(stocks.nocheeks_to_fixed_rec3_stats)
-					
+
 					--Overrides
 					self.wpn_fps_sho_spas12.override = self.wpn_fps_sho_spas12.override or {}
 
 					self.wpn_fps_sho_spas12.override.wpn_fps_upg_a_slug = deep_clone(shot_ammo.a_slug_semi_override)
 					self.wpn_fps_sho_spas12.override.wpn_fps_upg_a_custom = deep_clone(shot_ammo.a_custom_semi_override)
-					self.wpn_fps_sho_spas12.override.wpn_fps_upg_a_custom_free = deep_clone(shot_ammo.a_custom_semi_override)		
+					self.wpn_fps_sho_spas12.override.wpn_fps_upg_a_custom_free = deep_clone(shot_ammo.a_custom_semi_override)
 					self.wpn_fps_sho_spas12.override.wpn_fps_upg_a_explosive = deep_clone(shot_ammo.a_explosive_semi_override)
 					self.wpn_fps_sho_spas12.override.wpn_fps_upg_a_rip = deep_clone(shot_ammo.a_rip_semi_override)
 					self.wpn_fps_sho_spas12.override.wpn_fps_upg_a_piercing = deep_clone(shot_ammo.a_piercing_semi_override)
@@ -16521,7 +16521,7 @@ end)
 						10,
 						20,
 						30,
-						40	
+						40
 					}
 					self.parts.wpn_fps_sho_ultima_ns_comp.supported = true
 					self.parts.wpn_fps_sho_ultima_ns_comp.stats = {
@@ -16534,7 +16534,7 @@ end)
 						falloff_start_mult = 0.8,
 						falloff_end_mult = 0.8
 					}
-					
+
 					--Flak Frame Null Stock
 					self.parts.wpn_fps_sho_ultima_s_light.pcs = {
 						10,
@@ -16545,7 +16545,7 @@ end)
 					self.parts.wpn_fps_sho_ultima_s_light.supported = true
 					self.parts.wpn_fps_sho_ultima_s_light.stats = deep_clone(stocks.add_nocheeks_stats)
 					self.parts.wpn_fps_sho_ultima_s_light.custom_stats = deep_clone(stocks.add_nocheeks_stats)
-					
+
 					--Shellswitch M8 (Quick Pull)
 					self.parts.wpn_fps_sho_ultima_body_rack.pcs = {
 						10,
@@ -16563,8 +16563,8 @@ end)
 					self.parts.wpn_fps_sho_ultima_body_rack.custom_stats = {
 						falloff_start_mult = 1,
 						falloff_end_mult = 1
-					}	
-					
+					}
+
 					--Triple Tech Threat (Ultima Exclusive Kit)
 					self.parts.wpn_fps_sho_ultima_body_kit.supported = true
 					self.parts.wpn_fps_sho_ultima_body_kit.has_description = true
@@ -16591,7 +16591,7 @@ end)
 						wpn_fps_sho_ultima_body_rack = {
 							third_unit = "units/payday2/weapons/wpn_upg_dummy/wpn_upg_dummy",
 							unit = "units/payday2/weapons/wpn_upg_dummy/wpn_upg_dummy"
-						},		
+						},
 						wpn_fps_sho_ultima_fg_standard = {
 							third_unit = "units/pd2_dlc_lawp/weapons/wpn_fps_shot_ultima_pts/wpn_third_sho_ultima_fg_kit",
 							unit = "units/pd2_dlc_lawp/weapons/wpn_fps_shot_ultima_pts/wpn_fps_sho_ultima_fg_kit"
@@ -16605,24 +16605,24 @@ end)
 							unit = "units/pd2_dlc_lawp/weapons/wpn_fps_shot_ultima_pts/wpn_fps_sho_ultima_b_kit"
 						}
 					}
-					
+
 					--Override Table
 					self.wpn_fps_sho_ultima.override = {
 						wpn_fps_upg_a_slug = deep_clone(shot_ammo.a_slug_semi_override),
 						wpn_fps_upg_a_custom = deep_clone(shot_ammo.a_custom_semi_override),
-						wpn_fps_upg_a_custom_free = deep_clone(shot_ammo.a_custom_semi_override),			
+						wpn_fps_upg_a_custom_free = deep_clone(shot_ammo.a_custom_semi_override),
 						wpn_fps_upg_a_explosive = deep_clone(shot_ammo.a_explosive_semi_override),
 						wpn_fps_upg_a_rip = deep_clone(shot_ammo.a_rip_semi_override),
 						wpn_fps_upg_a_piercing = deep_clone(shot_ammo.a_piercing_semi_override),
-						wpn_fps_upg_a_dragons_breath = deep_clone(shot_ammo.a_dragons_breath_semi_override)			
-					}		
+						wpn_fps_upg_a_dragons_breath = deep_clone(shot_ammo.a_dragons_breath_semi_override)
+					}
 				end)
 
 		--SECONDARIES
 
 			--BULLPUP SAIGA
 				Hooks:PostHook(WeaponFactoryTweakData, "_init_basset", "resmod_basset", function(self)
-					
+
 					--Little Brother Foregrip
 					self.parts.wpn_fps_sho_basset_fg_short.pcs = {
 						10,
@@ -16646,33 +16646,33 @@ end)
 						ads_speed_mult = 1.05
 					}
 					self.parts.wpn_fps_sho_basset_m_extended.stats = {
-						value = 1, 
-						extra_ammo = 5, 
-						reload = -4, 
+						value = 1,
+						extra_ammo = 5,
+						reload = -4,
 						concealment = -2
 					}
 
 					self.wpn_fps_sho_basset.override = {
 						wpn_fps_upg_a_slug = deep_clone(shot_ammo.a_slug_semi_override),
 						wpn_fps_upg_a_custom = deep_clone(shot_ammo.a_custom_semi_override),
-						wpn_fps_upg_a_custom_free = deep_clone(shot_ammo.a_custom_semi_override),					
+						wpn_fps_upg_a_custom_free = deep_clone(shot_ammo.a_custom_semi_override),
 						wpn_fps_upg_a_explosive = deep_clone(shot_ammo.a_explosive_semi_override),
 						wpn_fps_upg_a_rip = deep_clone(shot_ammo.a_rip_semi_override),
 						wpn_fps_upg_a_piercing = deep_clone(shot_ammo.a_piercing_semi_override),
 						wpn_fps_upg_a_dragons_breath = deep_clone(shot_ammo.a_dragons_breath_semi_override)
 					}
-					
+
 					table.insert(self.wpn_fps_sho_basset.uses_parts, "wpn_upg_saiga_m_20rnd")
-					table.insert(self.wpn_fps_sho_basset_npc.uses_parts, "wpn_upg_saiga_m_20rnd")	
+					table.insert(self.wpn_fps_sho_basset_npc.uses_parts, "wpn_upg_saiga_m_20rnd")
 
 					self.wpn_fps_sho_basset_npc.uses_parts = deep_clone(self.wpn_fps_sho_basset.uses_parts)
 				end)
 				Hooks:PostHook(WeaponFactoryTweakData, "_init_x_basset", "resmod_x_basset", function(self)
-					
+
 					self.wpn_fps_sho_x_basset.override = {
 						wpn_fps_upg_a_slug = deep_clone(shot_ammo.a_slug_semi_override),
 						wpn_fps_upg_a_custom = deep_clone(shot_ammo.a_custom_semi_override),
-						wpn_fps_upg_a_custom_free = deep_clone(shot_ammo.a_custom_semi_override),					
+						wpn_fps_upg_a_custom_free = deep_clone(shot_ammo.a_custom_semi_override),
 						wpn_fps_upg_a_explosive = deep_clone(shot_ammo.a_slug_semi_override),
 						wpn_fps_upg_a_rip = deep_clone(shot_ammo.a_rip_semi_override),
 						wpn_fps_upg_a_piercing = deep_clone(shot_ammo.a_piercing_semi_override),
@@ -16681,8 +16681,8 @@ end)
 
 					self.wpn_fps_sho_x_basset.override.wpn_fps_sho_basset_m_extended = {
 						stats = {
-							extra_ammo = 10, 
-							reload = -4, 
+							extra_ammo = 10,
+							reload = -4,
 							concealment = -2
 						}
 					}
@@ -16698,7 +16698,7 @@ end)
 					self.parts.wpn_fps_sho_striker_b_long.supported = true
 					self.parts.wpn_fps_sho_striker_b_long.stats = deep_clone(barrels.long_b2_stats)
 					self.parts.wpn_fps_sho_striker_b_long.custom_stats = deep_clone(barrels.long_b2_stats)
-					
+
 					--Suppressed Barrel
 					self.parts.wpn_fps_sho_striker_b_suppressed.pcs = {}
 					self.parts.wpn_fps_sho_striker_b_suppressed.supported = true
@@ -16723,18 +16723,18 @@ end)
 						"wpn_fps_upg_a_explosive",
 						"wpn_fps_upg_ns_duck"
 					}
-					
+
 					--Override Table
 					self.wpn_fps_sho_striker.override = {
 						wpn_upg_o_marksmansight_rear_vanilla = {a_obj = "a_o_r"},
 						wpn_upg_o_marksmansight_front = {a_obj = "a_o_f"},
 						wpn_fps_upg_a_slug = deep_clone(shot_ammo.a_slug_semi_override),
-						wpn_fps_upg_a_custom = deep_clone(shot_ammo.a_custom_semi_override),	
-						wpn_fps_upg_a_custom_free = deep_clone(shot_ammo.a_custom_semi_override),				
+						wpn_fps_upg_a_custom = deep_clone(shot_ammo.a_custom_semi_override),
+						wpn_fps_upg_a_custom_free = deep_clone(shot_ammo.a_custom_semi_override),
 						wpn_fps_upg_a_explosive = deep_clone(shot_ammo.a_explosive_semi_override),
 						wpn_fps_upg_a_rip = deep_clone(shot_ammo.a_rip_semi_override),
 						wpn_fps_upg_a_piercing = deep_clone(shot_ammo.a_piercing_semi_override),
-						wpn_fps_upg_a_dragons_breath = deep_clone(shot_ammo.a_dragons_breath_revo_override)	
+						wpn_fps_upg_a_dragons_breath = deep_clone(shot_ammo.a_dragons_breath_revo_override)
 					}
 
 					self.wpn_fps_sho_striker.override.wpn_fps_upg_o_dd_irons_dmc = {
@@ -16769,7 +16769,7 @@ end)
 					self.parts.wpn_fps_sho_rota_b_short.supported = true
 					self.parts.wpn_fps_sho_rota_b_short.stats = deep_clone(barrels.short_b1_stats)
 					self.parts.wpn_fps_sho_rota_b_short.custom_stats = deep_clone(barrels.short_b1_stats)
-					
+
 					--Silenced Barrel
 					self.parts.wpn_fps_sho_rota_b_silencer.pcs = {
 						10,
@@ -16790,15 +16790,15 @@ end)
 						falloff_end_mult = 1
 					}
 					self.parts.wpn_fps_sho_rota_b_silencer.perks = {"silencer"}
-					
+
 					self.wpn_fps_sho_rota.override = {
 						wpn_fps_upg_a_slug = deep_clone(shot_ammo.a_slug_semi_override),
-						wpn_fps_upg_a_custom = deep_clone(shot_ammo.a_custom_semi_override),	
-						wpn_fps_upg_a_custom_free = deep_clone(shot_ammo.a_custom_semi_override),				
+						wpn_fps_upg_a_custom = deep_clone(shot_ammo.a_custom_semi_override),
+						wpn_fps_upg_a_custom_free = deep_clone(shot_ammo.a_custom_semi_override),
 						wpn_fps_upg_a_explosive = deep_clone(shot_ammo.a_explosive_semi_override),
 						wpn_fps_upg_a_rip = deep_clone(shot_ammo.a_rip_semi_override),
 						wpn_fps_upg_a_piercing = deep_clone(shot_ammo.a_piercing_semi_override),
-						wpn_fps_upg_a_dragons_breath = deep_clone(shot_ammo.a_dragons_breath_revo_override)		
+						wpn_fps_upg_a_dragons_breath = deep_clone(shot_ammo.a_dragons_breath_revo_override)
 					}
 					self.wpn_fps_sho_rota.override.wpn_fps_upg_vg_ass_smg_verticalgrip = {
 						stats = {
@@ -16843,8 +16843,8 @@ end)
 					table.insert(self.wpn_fps_sho_rota.uses_parts, "wpn_fps_vg_vmp_cheems")
 					table.insert(self.wpn_fps_sho_rota.uses_parts, "wpn_fps_vg_vmp_pod")
 
-					self.wpn_fps_sho_rota_npc.override = deep_clone(self.wpn_fps_sho_rota.override)		
-					self.wpn_fps_sho_rota_npc.uses_parts = deep_clone(self.wpn_fps_sho_rota.uses_parts)		
+					self.wpn_fps_sho_rota_npc.override = deep_clone(self.wpn_fps_sho_rota.override)
+					self.wpn_fps_sho_rota_npc.uses_parts = deep_clone(self.wpn_fps_sho_rota.uses_parts)
 				end)
 
 	--[[     LIGHT SHOTGUNS     ]]
@@ -16998,7 +16998,7 @@ end)
 					self.parts.wpn_fps_sho_m590_b_suppressor.perks = {
 						"silencer"
 					}
-					
+
 					--Long Barrel
 					self.parts.wpn_fps_sho_m590_b_long.pcs = {
 						10,
@@ -17018,7 +17018,7 @@ end)
 						falloff_end_mult = 1.075,
 						ads_speed_mult = 1.05,
 					}
-					
+
 					--CE Rail Stabilizer
 					self.parts.wpn_fps_sho_m590_body_rail.pcs = {
 						10,
@@ -17031,8 +17031,8 @@ end)
 						recoil = 2,
 						value = 2,
 						concealment = -1
-					}	
-					self.parts.wpn_fps_sho_m590_body_rail.override.wpn_fps_upg_o_specter.stance_mod = { 
+					}
+					self.parts.wpn_fps_sho_m590_body_rail.override.wpn_fps_upg_o_specter.stance_mod = {
 						wpn_fps_sho_m590 = {
 							translation = Vector3(-0.156, 9.6, -4.42)
 						}
@@ -17103,7 +17103,7 @@ end)
 
 					self.parts.wpn_fps_sho_m590_body_rail.override.wpn_fps_upg_o_spot.stance_mod = deep_clone(self.parts.wpn_fps_sho_m590_body_rail.override.wpn_fps_upg_o_specter.stance_mod)
 					self.parts.wpn_fps_sho_m590_body_rail.override.wpn_fps_upg_o_poe.stance_mod = deep_clone(self.parts.wpn_fps_sho_m590_body_rail.override.wpn_fps_upg_o_specter.stance_mod)
-					
+
 					self.parts.wpn_fps_sho_m590_body_rail.override.wpn_fps_upg_o_acog.stance_mod = deep_clone(self.parts.wpn_fps_sho_m590_body_rail.override.wpn_fps_upg_o_specter.stance_mod)
 					for i, weap in pairs(self.parts.wpn_fps_sho_m590_body_rail.override.wpn_fps_upg_o_acog.stance_mod) do
 						if weap and weap.translation then
@@ -17152,20 +17152,20 @@ end)
 					table.insert(self.wpn_fps_sho_m590.uses_parts, "wpn_fps_upg_m4_s_mk46")
 					table.insert(self.wpn_fps_sho_m590.uses_parts, "wpn_fps_snp_victor_s_mod0")
 					table.insert(self.wpn_fps_sho_m590.uses_parts, "wpn_fps_upg_m4_s_ubr")
-					table.insert(self.wpn_fps_sho_m590.uses_parts, "wpn_fps_snp_tti_s_vltor")	
+					table.insert(self.wpn_fps_sho_m590.uses_parts, "wpn_fps_snp_tti_s_vltor")
 					table.insert(self.wpn_fps_sho_m590.uses_parts, "wpn_fps_sho_sko12_stock")
 
 					--Override Table
 					self.wpn_fps_sho_m590.override = {
 						wpn_fps_upg_a_slug = deep_clone(shot_ammo.a_slug_pump_override),
-						wpn_fps_upg_a_custom = deep_clone(shot_ammo.a_custom_pump_override),	
-						wpn_fps_upg_a_custom_free = deep_clone(shot_ammo.a_custom_pump_override),			
+						wpn_fps_upg_a_custom = deep_clone(shot_ammo.a_custom_pump_override),
+						wpn_fps_upg_a_custom_free = deep_clone(shot_ammo.a_custom_pump_override),
 						wpn_fps_upg_a_explosive = deep_clone(shot_ammo.a_explosive_pump_override),
 						wpn_fps_upg_a_rip = deep_clone(shot_ammo.a_rip_pump_override),
 						wpn_fps_upg_a_piercing = deep_clone(shot_ammo.a_piercing_pump_override),
 						wpn_fps_upg_a_dragons_breath = deep_clone(shot_ammo.a_dragons_breath_pump_override)
 					}
-					
+
 					attachment_list = {
 						"wpn_fps_upg_m4_s_pts",
 						"wpn_fps_upg_m4_s_crane",
@@ -17194,7 +17194,7 @@ end)
 
 			--R870
 				Hooks:PostHook(WeaponFactoryTweakData, "_init_r870", "resmod_r870", function(self)
-					
+
 					--Shell Rack
 					self.parts.wpn_fps_shot_r870_body_rack.pcs = {
 						10,
@@ -17212,7 +17212,7 @@ end)
 					self.parts.wpn_fps_shot_r870_body_rack.custom_stats = {
 						falloff_start_mult = 1,
 						falloff_end_mult = 1
-					}	
+					}
 
 					--Zombie Hunter Pump
 					self.parts.wpn_fps_shot_r870_fg_wood.pcs = {
@@ -17247,7 +17247,7 @@ end)
 					self.parts.wpn_fps_shot_r870_m_extended.custom_stats = {
 						ads_speed_mult = 1.025
 					}
-					
+
 					--Muldon Stock
 					self.parts.wpn_fps_shot_r870_s_folding.pcs = {
 						10,
@@ -17258,7 +17258,7 @@ end)
 					self.parts.wpn_fps_shot_r870_s_folding.supported = true
 					self.parts.wpn_fps_shot_r870_s_folding.stats = deep_clone(stocks.fixed_to_folded_stats)
 					self.parts.wpn_fps_shot_r870_s_folding.custom_stats = deep_clone(stocks.fixed_to_folded_stats)
-					
+
 					--Short Enough Tactical Stock
 					self.parts.wpn_fps_shot_r870_s_nostock_big.pcs = {
 						10,
@@ -17285,7 +17285,7 @@ end)
 					self.parts.wpn_fps_shot_r870_s_nostock.supported = true
 					self.parts.wpn_fps_shot_r870_s_nostock.stats = deep_clone(stocks.remove_fixed_stats)
 					self.parts.wpn_fps_shot_r870_s_nostock.custom_stats = deep_clone(stocks.remove_fixed_stats)
-					
+
 					--Government Issue Tactical Stock
 					self.parts.wpn_fps_shot_r870_s_solid_big.pcs = {
 						10,
@@ -17299,7 +17299,7 @@ end)
 						spread = -1,
 						recoil = 2
 					}
-					
+
 					--???
 					self.parts.wpn_fps_shot_r870_s_solid_single.supported = true
 					self.parts.wpn_fps_shot_r870_s_solid_single.stats = {
@@ -17311,12 +17311,12 @@ end)
 						falloff_start_mult = 1,
 						falloff_end_mult = 1
 					}
-					
+
 					--Override Table
 					self.wpn_fps_shot_r870.override = {
 						wpn_fps_upg_a_slug = deep_clone(shot_ammo.a_slug_pump_override),
-						wpn_fps_upg_a_custom = deep_clone(shot_ammo.a_custom_pump_override),	
-						wpn_fps_upg_a_custom_free = deep_clone(shot_ammo.a_custom_pump_override),			
+						wpn_fps_upg_a_custom = deep_clone(shot_ammo.a_custom_pump_override),
+						wpn_fps_upg_a_custom_free = deep_clone(shot_ammo.a_custom_pump_override),
 						wpn_fps_upg_a_explosive = deep_clone(shot_ammo.a_explosive_pump_override),
 						wpn_fps_upg_a_rip = deep_clone(shot_ammo.a_rip_pump_override),
 						wpn_fps_upg_a_piercing = deep_clone(shot_ammo.a_piercing_pump_override),
@@ -17339,11 +17339,11 @@ end)
 								self.wpn_fps_shot_r870.uses_parts[i] = "resmod_dummy"
 							end
 						end
-					end	
-						
-					table.insert(self.wpn_fps_shot_r870.uses_parts, "wpn_fps_upg_the_big_kahuna")	
-					table.insert(self.wpn_fps_shot_r870.uses_parts, "wpn_fps_shot_r870_s_folding_ext")	
-					
+					end
+
+					table.insert(self.wpn_fps_shot_r870.uses_parts, "wpn_fps_upg_the_big_kahuna")
+					table.insert(self.wpn_fps_shot_r870.uses_parts, "wpn_fps_shot_r870_s_folding_ext")
+
 					self.wpn_fps_shot_r870_npc.uses_parts = deep_clone(self.wpn_fps_shot_r870.uses_parts)
 				end)
 
@@ -17377,7 +17377,7 @@ end)
 						falloff_end_mult = 0.9,
 						ads_speed_mult = 0.95
 					}
-					
+
 					--Flip-up Sight
 					self.parts.wpn_fps_upg_o_mbus_rear.pcs = {}
 					self.parts.wpn_fps_upg_o_mbus_rear.supported = true
@@ -17403,7 +17403,7 @@ end)
 					--Ammunition Overrides
 					self.wpn_fps_sho_ksg.override.wpn_fps_upg_a_slug = deep_clone(shot_ammo.a_slug_pump_override)
 					self.wpn_fps_sho_ksg.override.wpn_fps_upg_a_custom = deep_clone(shot_ammo.a_custom_pump_override)
-					self.wpn_fps_sho_ksg.override.wpn_fps_upg_a_custom_free = deep_clone(shot_ammo.a_custom_pump_override)			
+					self.wpn_fps_sho_ksg.override.wpn_fps_upg_a_custom_free = deep_clone(shot_ammo.a_custom_pump_override)
 					self.wpn_fps_sho_ksg.override.wpn_fps_upg_a_explosive = deep_clone(shot_ammo.a_explosive_pump_override)
 					self.wpn_fps_sho_ksg.override.wpn_fps_upg_a_rip = deep_clone(shot_ammo.a_rip_pump_override)
 					self.wpn_fps_sho_ksg.override.wpn_fps_upg_a_piercing = deep_clone(shot_ammo.a_piercing_pump_override)
@@ -17421,12 +17421,12 @@ end)
 						10,
 						20,
 						30,
-						40	
+						40
 					}
 					self.parts.wpn_fps_shot_m1897_b_short.supported = true
 					self.parts.wpn_fps_shot_m1897_b_short.stats = deep_clone(barrels.short_b1_stats)
 					self.parts.wpn_fps_shot_m1897_b_short.custom_stats = deep_clone(barrels.short_b1_stats)
-					
+
 					--Long barrel
 					self.parts.wpn_fps_shot_m1897_b_long.pcs = {
 						10,
@@ -17437,7 +17437,7 @@ end)
 					self.parts.wpn_fps_shot_m1897_b_long.supported = true
 					self.parts.wpn_fps_shot_m1897_b_long.stats = deep_clone(barrels.long_b3_stats)
 					self.parts.wpn_fps_shot_m1897_b_long.custom_stats = deep_clone(barrels.long_b3_stats)
-					
+
 					--Short Stock
 					self.parts.wpn_fps_shot_m1897_s_short.pcs = {
 						10,
@@ -17452,11 +17452,11 @@ end)
 					--Override Table
 					self.wpn_fps_shot_m1897.override.wpn_fps_upg_a_slug = deep_clone(shot_ammo.a_slug_pump_override)
 					self.wpn_fps_shot_m1897.override.wpn_fps_upg_a_custom = deep_clone(shot_ammo.a_custom_pump_override)
-					self.wpn_fps_shot_m1897.override.wpn_fps_upg_a_custom_free = deep_clone(shot_ammo.a_custom_pump_override)	
+					self.wpn_fps_shot_m1897.override.wpn_fps_upg_a_custom_free = deep_clone(shot_ammo.a_custom_pump_override)
 					self.wpn_fps_shot_m1897.override.wpn_fps_upg_a_explosive = deep_clone(shot_ammo.a_explosive_pump_override)
 					self.wpn_fps_shot_m1897.override.wpn_fps_upg_a_rip = deep_clone(shot_ammo.a_rip_pump_override)
 					self.wpn_fps_shot_m1897.override.wpn_fps_upg_a_piercing = deep_clone(shot_ammo.a_piercing_pump_override)
-					self.wpn_fps_shot_m1897.override.wpn_fps_upg_a_dragons_breath = deep_clone(shot_ammo.a_dragons_breath_pump_override)		
+					self.wpn_fps_shot_m1897.override.wpn_fps_upg_a_dragons_breath = deep_clone(shot_ammo.a_dragons_breath_pump_override)
 				end)
 
 		--SECONDARIES
@@ -17478,9 +17478,9 @@ end)
 					self.wpn_fps_pis_judge.override.wpn_fps_upg_a_piercing.desc_id = "bm_wp_upg_a_piercing_9_auto_desc_per_pellet"
 					self.wpn_fps_pis_judge.override.wpn_fps_upg_a_piercing.custom_stats.rays = 9
 					self.wpn_fps_pis_judge.override.wpn_fps_upg_a_dragons_breath = deep_clone(shot_ammo.a_dragons_breath_pump_override)
-					
+
 					table.insert(self.wpn_fps_pis_judge.uses_parts, "wpn_fps_upg_judge_legend")
-					self.wpn_fps_pis_judge_npc.uses_parts = deep_clone(self.wpn_fps_pis_judge.uses_parts)	
+					self.wpn_fps_pis_judge_npc.uses_parts = deep_clone(self.wpn_fps_pis_judge.uses_parts)
 				end)
 				Hooks:PostHook(WeaponFactoryTweakData, "_init_x_judge", "resmod_x_judge", function(self)
 
@@ -17505,10 +17505,10 @@ end)
 					self.wpn_fps_pis_x_judge.override.wpn_fps_upg_a_piercing = deep_clone(shot_ammo.a_piercing_pump_override)
 					self.wpn_fps_pis_x_judge.override.wpn_fps_upg_a_piercing.desc_id = "bm_wp_upg_a_piercing_9_auto_desc_per_pellet"
 					self.wpn_fps_pis_x_judge.override.wpn_fps_upg_a_piercing.custom_stats.rays = 9
-					self.wpn_fps_pis_x_judge.override.wpn_fps_upg_a_dragons_breath = deep_clone(shot_ammo.a_dragons_breath_pump_override)	
+					self.wpn_fps_pis_x_judge.override.wpn_fps_upg_a_dragons_breath = deep_clone(shot_ammo.a_dragons_breath_pump_override)
 
 					self.wpn_fps_pis_x_judge.override.wpn_fps_pis_judge_body_standard = {
-						animations = {		
+						animations = {
 							reload_left = "reload",
 							fire = "recoil",
 							fire_steelsight = "recoil",
@@ -17531,18 +17531,18 @@ end)
 
 			--SHORT R870
 				Hooks:PostHook(WeaponFactoryTweakData, "_init_serbu", "resmod_serbu", function(self)
-					
+
 					--Extended Mag.
 					self.parts.wpn_fps_shot_shorty_m_extended_short.pcs = {
-						10,		
+						10,
 						20,
 						30,
 						40
 					}
 					self.parts.wpn_fps_shot_shorty_m_extended_short.supported = true
 					self.parts.wpn_fps_shot_shorty_m_extended_short.stats = {
-						value = 1, 
-						extra_ammo = 1, 
+						value = 1,
+						extra_ammo = 1,
 						concealment = -1
 					}
 					self.parts.wpn_fps_shot_shorty_m_extended_short.custom_stats = {
@@ -17573,7 +17573,7 @@ end)
 						falloff_start_mult = 1,
 						falloff_end_mult = 1
 					}
-					
+
 					--Police Shorty Stock
 					self.parts.wpn_fps_shot_shorty_s_solid_short.pcs = {
 						10,
@@ -17584,7 +17584,7 @@ end)
 					self.parts.wpn_fps_shot_shorty_s_solid_short.supported = true
 					self.parts.wpn_fps_shot_shorty_s_solid_short.stats = deep_clone(stocks.add_fixed_rec_stats)
 					self.parts.wpn_fps_shot_shorty_s_solid_short.custom_stats = deep_clone(stocks.add_fixed_rec_stats)
-					
+
 					--Vanilla No-stock
 					--self.parts.wpn_fps_shot_r870_s_nostock_vanilla.unit = "units/payday2/weapons/wpn_fps_shot_r870_pts/wpn_fps_shot_r870_s_solid"
 					--self.parts.wpn_fps_shot_r870_s_nostock_vanilla.third_unit = "units/payday2/weapons/wpn_third_shot_r870_pts/wpn_third_shot_r870_s_solid"
@@ -17592,12 +17592,12 @@ end)
 					--Locomotive 12g override table
 					self.wpn_fps_shot_serbu.override = {
 						wpn_fps_upg_a_slug = deep_clone(shot_ammo.a_slug_pump_override),
-						wpn_fps_upg_a_custom = deep_clone(shot_ammo.a_custom_pump_override),	
-						wpn_fps_upg_a_custom_free = deep_clone(shot_ammo.a_custom_pump_override),			
+						wpn_fps_upg_a_custom = deep_clone(shot_ammo.a_custom_pump_override),
+						wpn_fps_upg_a_custom_free = deep_clone(shot_ammo.a_custom_pump_override),
 						wpn_fps_upg_a_explosive = deep_clone(shot_ammo.a_explosive_pump_override),
 						wpn_fps_upg_a_rip = deep_clone(shot_ammo.a_rip_pump_override),
 						wpn_fps_upg_a_piercing = deep_clone(shot_ammo.a_piercing_pump_override),
-						wpn_fps_upg_a_dragons_breath = deep_clone(shot_ammo.a_dragons_breath_pump_override)			
+						wpn_fps_upg_a_dragons_breath = deep_clone(shot_ammo.a_dragons_breath_pump_override)
 					}
 
 					self.wpn_fps_shot_serbu.override.wpn_fps_shot_r870_s_solid = {
@@ -17612,7 +17612,7 @@ end)
 						stats = deep_clone(stocks.add_folded_stats),
 						custom_stats = deep_clone(stocks.add_folded_stats)
 					}
-					
+
 					for i, part_id in pairs(self.wpn_fps_shot_serbu.uses_parts) do
 						attachment_list = {
 							"wpn_fps_upg_m4_s_standard",
@@ -17629,12 +17629,12 @@ end)
 								self.wpn_fps_shot_serbu.uses_parts[i] = "resmod_dummy"
 							end
 						end
-					end	
-					
+					end
+
 					table.insert(self.wpn_fps_shot_serbu.uses_parts, "wpn_fps_upg_serbu_legend")
 					table.insert(self.wpn_fps_shot_serbu.uses_parts, "wpn_fps_shot_r870_s_folding_ext")
 					table.insert(self.wpn_fps_shot_serbu.uses_parts, "wpn_fps_upg_s_anton") -- fix for carl's Destiny legendary skin
-					
+
 					self.wpn_fps_shot_serbu_npc.uses_parts = deep_clone(self.wpn_fps_shot_serbu.uses_parts)
 				end)
 
@@ -17651,7 +17651,7 @@ end)
 					self.parts.wpn_fps_shot_m37_b_short.supported = true
 					self.parts.wpn_fps_shot_m37_b_short.stats = deep_clone(barrels.short_b2_stats)
 					self.parts.wpn_fps_shot_m37_b_short.custom_stats = deep_clone(barrels.short_b2_stats)
-					
+
 					--Stakeout Stock
 					self.parts.wpn_fps_shot_m37_s_short.pcs = {
 						10,
@@ -17662,16 +17662,16 @@ end)
 					self.parts.wpn_fps_shot_m37_s_short.supported = true
 					self.parts.wpn_fps_shot_m37_s_short.stats = deep_clone(stocks.remove_fixed_stats)
 					self.parts.wpn_fps_shot_m37_s_short.custom_stats = deep_clone(stocks.remove_fixed_stats)
-					
+
 					--Ammo overrides
 					self.wpn_fps_shot_m37.override.wpn_fps_upg_a_slug = deep_clone(shot_ammo.a_slug_pump_override)
 					self.wpn_fps_shot_m37.override.wpn_fps_upg_a_custom = deep_clone(shot_ammo.a_custom_pump_override)
-					self.wpn_fps_shot_m37.override.wpn_fps_upg_a_custom_free = deep_clone(shot_ammo.a_custom_pump_override)	
+					self.wpn_fps_shot_m37.override.wpn_fps_upg_a_custom_free = deep_clone(shot_ammo.a_custom_pump_override)
 					self.wpn_fps_shot_m37.override.wpn_fps_upg_a_explosive = deep_clone(shot_ammo.a_explosive_pump_override)
 					self.wpn_fps_shot_m37.override.wpn_fps_upg_a_rip = deep_clone(shot_ammo.a_rip_pump_override)
 					self.wpn_fps_shot_m37.override.wpn_fps_upg_a_piercing = deep_clone(shot_ammo.a_piercing_pump_override)
-					self.wpn_fps_shot_m37.override.wpn_fps_upg_a_dragons_breath = deep_clone(shot_ammo.a_dragons_breath_pump_override)		
-					
+					self.wpn_fps_shot_m37.override.wpn_fps_upg_a_dragons_breath = deep_clone(shot_ammo.a_dragons_breath_pump_override)
+
 					--[[
 					table.insert(self.wpn_fps_shot_m37.uses_parts, "wpn_fps_upg_o_specter")
 					table.insert(self.wpn_fps_shot_m37.uses_parts, "wpn_fps_upg_o_aimpoint")
@@ -17714,7 +17714,7 @@ end)
 						extra_ammo = -2
 					}
 					self.parts.wpn_fps_sho_boot_b_short.custom_stats = deep_clone(barrels.short_b2_stats)
-					
+
 					--Long Barrel
 					self.parts.wpn_fps_sho_boot_b_long.pcs = {
 						10,
@@ -17730,7 +17730,7 @@ end)
 						extra_ammo = 1
 					}
 					self.parts.wpn_fps_sho_boot_b_long.custom_stats = deep_clone(barrels.long_b3_stats)
-					
+
 					--Long Stock
 					self.parts.wpn_fps_sho_boot_s_long.pcs = {
 						10,
@@ -17755,9 +17755,9 @@ end)
 						recoil = 2,
 						concealment = -1
 					}
-					
+
 					--Override Table
-					self.wpn_fps_sho_boot.override = {}	
+					self.wpn_fps_sho_boot.override = {}
 
 					table.insert(self.wpn_fps_sho_boot.uses_parts, "wpn_fps_upg_boot_legend")
 					table.insert(self.wpn_fps_sho_boot.uses_parts, "wpn_fps_upg_boot_legend_optic")
@@ -17766,7 +17766,7 @@ end)
 
 			--MOSCONI
 				Hooks:PostHook(WeaponFactoryTweakData, "_init_huntsman", "resmod_huntsman", function(self)
-					
+
 					--Road Warrior Barrel
 					self.parts.wpn_fps_shot_huntsman_b_short.pcs = {
 						10,
@@ -17777,7 +17777,7 @@ end)
 					self.parts.wpn_fps_shot_huntsman_b_short.supported = true
 					self.parts.wpn_fps_shot_huntsman_b_short.stats = deep_clone(barrels.short_b3_stats)
 					self.parts.wpn_fps_shot_huntsman_b_short.custom_stats = deep_clone(barrels.short_b3_stats)
-					
+
 					--Gangsta Special Stock
 					self.parts.wpn_fps_shot_huntsman_s_short.pcs = {
 						10,
@@ -17791,13 +17791,13 @@ end)
 
 					--Mosconi Override Table
 					self.wpn_fps_shot_huntsman.override = {}
-					
+
 					self.wpn_fps_shot_huntsman_npc.uses_parts = deep_clone(self.wpn_fps_shot_huntsman.uses_parts)
 				end)
 
 			--B682
 				Hooks:PostHook(WeaponFactoryTweakData, "_init_b682", "resmod_b682", function(self)
-					
+
 					--Sawed Off Barrel
 					self.parts.wpn_fps_shot_b682_b_short.pcs = {
 						10,
@@ -17822,7 +17822,7 @@ end)
 					self.parts.wpn_fps_shot_b682_s_short.supported = true
 					self.parts.wpn_fps_shot_b682_s_short.stats = deep_clone(stocks.remove_fixed_stats)
 					self.parts.wpn_fps_shot_b682_s_short.custom_stats = deep_clone(stocks.remove_fixed_stats)
-					
+
 					--Luxurious Ammo Pouch
 					self.parts.wpn_fps_shot_b682_s_ammopouch.pcs = {
 						10,
@@ -17841,9 +17841,9 @@ end)
 						falloff_start_mult = 1,
 						falloff_end_mult = 1
 					}
-					
+
 					--Override table
-					self.wpn_fps_shot_b682.override = {}	
+					self.wpn_fps_shot_b682.override = {}
 				end)
 
 		--SECONDARIES
@@ -17861,7 +17861,7 @@ end)
 					self.parts.wpn_fps_sho_coach_b_short.supported = true
 					self.parts.wpn_fps_sho_coach_b_short.stats = deep_clone(barrels.short_b3_stats)
 					self.parts.wpn_fps_sho_coach_b_short.custom_stats = deep_clone(barrels.short_b3_stats)
-					
+
 					--Deadman's Stock
 					self.parts.wpn_fps_sho_coach_s_short.pcs = {
 						10,
@@ -17872,9 +17872,9 @@ end)
 					self.parts.wpn_fps_sho_coach_s_short.supported = true
 					self.parts.wpn_fps_sho_coach_s_short.stats = deep_clone(stocks.remove_fixed_stats)
 					self.parts.wpn_fps_sho_coach_s_short.custom_stats = deep_clone(stocks.remove_fixed_stats)
-					
+
 					--Override Table
-					self.wpn_fps_sho_coach.override = {}	
+					self.wpn_fps_sho_coach.override = {}
 				end)
 
 
@@ -17886,7 +17886,7 @@ end)
 
 			--M79
 				Hooks:PostHook(WeaponFactoryTweakData, "_init_gre_m79", "resmod_gre_m79", function(self)
-					
+
 					--Pirate Barrel
 					self.parts.wpn_fps_gre_m79_barrel_short.pcs = {}
 					self.parts.wpn_fps_gre_m79_barrel_short.supported = true
@@ -17920,10 +17920,10 @@ end)
 					table.insert(self.wpn_fps_gre_m79.uses_parts, "wpn_fps_upg_o_aimpoint_2")
 					table.insert(self.wpn_fps_gre_m79.uses_parts, "wpn_fps_upg_o_cs")
 					table.insert(self.wpn_fps_gre_m79.uses_parts, "wpn_fps_upg_o_rx30")
-					table.insert(self.wpn_fps_gre_m79.uses_parts, "wpn_fps_upg_o_rx01")	
-					table.insert(self.wpn_fps_gre_m79.uses_parts, "wpn_fps_upg_o_reflex")	
+					table.insert(self.wpn_fps_gre_m79.uses_parts, "wpn_fps_upg_o_rx01")
+					table.insert(self.wpn_fps_gre_m79.uses_parts, "wpn_fps_upg_o_reflex")
 					table.insert(self.wpn_fps_gre_m79.uses_parts, "wpn_fps_upg_o_eotech_xps")
-					table.insert(self.wpn_fps_gre_m79.uses_parts, "wpn_fps_upg_o_uh")	
+					table.insert(self.wpn_fps_gre_m79.uses_parts, "wpn_fps_upg_o_uh")
 					table.insert(self.wpn_fps_gre_m79.uses_parts, "wpn_fps_upg_o_fc1")
 					table.insert(self.wpn_fps_gre_m79.uses_parts, "wpn_fps_upg_o_tf90")
 					table.insert(self.wpn_fps_gre_m79.uses_parts, "wpn_fps_upg_o_spot")
@@ -17956,11 +17956,11 @@ end)
 					self.parts.wpn_fps_gre_m32_no_stock.supported = true
 					self.parts.wpn_fps_gre_m32_no_stock.stats = deep_clone(stocks.remove_adj_stats)
 					self.parts.wpn_fps_gre_m32_no_stock.custom_stats = deep_clone(stocks.remove_adj_stats)
-					
-					table.insert(self.wpn_fps_gre_m32.uses_parts, "wpn_fps_upg_i_ghosts_mk32")
-					table.insert(self.wpn_fps_gre_m32_npc.uses_parts, "wpn_fps_upg_i_ghosts_mk32")		
 
-					self.wpn_fps_gre_m32_npc.uses_parts = deep_clone(self.wpn_fps_gre_m32.uses_parts)	
+					table.insert(self.wpn_fps_gre_m32.uses_parts, "wpn_fps_upg_i_ghosts_mk32")
+					table.insert(self.wpn_fps_gre_m32_npc.uses_parts, "wpn_fps_upg_i_ghosts_mk32")
+
+					self.wpn_fps_gre_m32_npc.uses_parts = deep_clone(self.wpn_fps_gre_m32.uses_parts)
 				end)
 
 			--M202
@@ -17977,13 +17977,13 @@ end)
 					self.parts.wpn_fps_gre_arbiter_b_long.supported = true
 					self.parts.wpn_fps_gre_arbiter_b_long.stats = deep_clone(barrels.long_b3_stats)
 					self.parts.wpn_fps_gre_arbiter_b_long.custom_stats = deep_clone(barrels.long_b3_stats)
-					
+
 					--Bombardier Barrel
 					self.parts.wpn_fps_gre_arbiter_b_comp.pcs = {}
 					self.parts.wpn_fps_gre_arbiter_b_comp.supported = true
 					self.parts.wpn_fps_gre_arbiter_b_comp.stats = deep_clone(barrels.short_b1_stats)
 					self.parts.wpn_fps_gre_arbiter_b_comp.custom_stats = deep_clone(barrels.short_b1_stats)
-					
+
 					-- For use as an "adds" attachment
 					self.parts.wpn_fps_gre_arbiter_o_standard_no_forbid = deep_clone(self.parts.wpn_fps_gre_arbiter_o_standard)
 					self.parts.wpn_fps_gre_arbiter_o_standard_no_forbid.type = "sight_extra"
@@ -17999,7 +17999,7 @@ end)
 							rotation = Rotation(0, -5.25, 0)
 						}
 					}
-					
+
 					--Fang Barrel
 					self.parts.wpn_fps_gre_ms3gl_b_long.pcs = {
 						10,
@@ -18099,7 +18099,7 @@ end)
 
 			--CHINA LAKE
 				Hooks:PostHook(WeaponFactoryTweakData, "_init_china", "resmod_china", function(self)
-					
+
 					--Riot Stock
 					self.parts.wpn_fps_gre_china_s_short.pcs = {
 						10,
@@ -18116,7 +18116,7 @@ end)
 			--RPG-7
 				Hooks:PostHook(WeaponFactoryTweakData, "_init_rpg7", "resmod_rpg7", function(self)
 					table.insert(self.wpn_fps_rpg7.uses_parts, "wpn_fps_upg_green_grin_legend")
-					self.wpn_fps_rpg7_npc.uses_parts = deep_clone(self.wpn_fps_rpg7.uses_parts)	
+					self.wpn_fps_rpg7_npc.uses_parts = deep_clone(self.wpn_fps_rpg7.uses_parts)
 				end)
 
 	--[[     BOWS     ]]
@@ -18137,7 +18137,7 @@ end)
 					ammo_pickup_max_mul = 0.8,
 					ammo_pickup_min_mul = 0.8
 				}
-				
+
 				--Poisoned Arrows
 				self.parts.wpn_fps_upg_a_bow_poison.pcs = {}
 				self.parts.wpn_fps_upg_a_bow_poison.has_description = true
@@ -18152,7 +18152,7 @@ end)
 
 		--LONGBOW
 			Hooks:PostHook(WeaponFactoryTweakData, "_init_long", "resmod_long", function(self)
-				
+
 				--Explosive Arrow
 				self.parts.wpn_fps_bow_long_m_explosive.pcs = {}
 				self.parts.wpn_fps_bow_long_m_explosive.supported = true
@@ -18166,7 +18166,7 @@ end)
 					ammo_pickup_max_mul = 0.85,
 					ammo_pickup_min_mul = 0.85
 				}
-				
+
 				--Poison Arrow
 				self.parts.wpn_fps_bow_long_m_poison.pcs = {}
 				self.parts.wpn_fps_bow_long_m_poison.supported = true
@@ -18195,7 +18195,7 @@ end)
 					concealment = 1,
 					spread = -1
 				}
-				
+
 				--Wood Grip
 				self.parts.wpn_fps_bow_elastic_g_2.pcs = {
 					10,
@@ -18205,7 +18205,7 @@ end)
 				}
 				self.parts.wpn_fps_bow_elastic_g_2.supported = true
 				self.parts.wpn_fps_bow_elastic_g_2.stats = deep_clone(grips.acc_1)
-				
+
 				--Ergo Grip
 				self.parts.wpn_fps_bow_elastic_g_3.pcs = {
 					10,
@@ -18216,7 +18216,7 @@ end)
 				self.parts.wpn_fps_bow_elastic_g_3.supported = true
 				self.parts.wpn_fps_bow_elastic_g_3.stats = deep_clone(grips.quickdraw_acc)
 				self.parts.wpn_fps_bow_elastic_g_3.custom_stats = deep_clone(grips.quickdraw_acc)
-				
+
 				--Explosive Arrows
 				self.parts.wpn_fps_bow_elastic_m_explosive.pcs = {}
 				self.parts.wpn_fps_bow_elastic_m_explosive.has_description = true
@@ -18230,7 +18230,7 @@ end)
 					ammo_pickup_max_mul = 0.85,
 					ammo_pickup_min_mul = 0.85
 				}
-				
+
 				--Poison Arrows
 				self.parts.wpn_fps_bow_elastic_m_poison.pcs = {}
 				self.parts.wpn_fps_bow_elastic_m_poison.has_description = true
@@ -18249,7 +18249,7 @@ end)
 
 			--FRANKISH CROSSBOW
 				Hooks:PostHook(WeaponFactoryTweakData, "_init_frankish", "resmod_frankish", function(self)
-					
+
 					--Poison Bolt
 					self.parts.wpn_fps_bow_frankish_m_poison.pcs = {}
 					self.parts.wpn_fps_bow_frankish_m_poison.supported = true
@@ -18260,7 +18260,7 @@ end)
 						launcher_grenade = "frankish_poison_arrow",
 						dot_data_name = "ammo_proj_frankish"
 					}
-					
+
 					--Explosive Bolt
 					self.parts.wpn_fps_bow_frankish_m_explosive.pcs = {}
 					self.parts.wpn_fps_bow_frankish_m_explosive.supported = true
@@ -18280,7 +18280,7 @@ end)
 
 			--ARBALEST
 				Hooks:PostHook(WeaponFactoryTweakData, "_init_arblast", "resmod_arblast", function(self)
-					
+
 					--Poison Bolt
 					self.parts.wpn_fps_bow_arblast_m_poison.pcs = {}
 					self.parts.wpn_fps_bow_arblast_m_poison.has_description = true
@@ -18291,7 +18291,7 @@ end)
 						launcher_grenade = "arblast_poison_arrow",
 						dot_data_name = "ammo_proj_arblast"
 					}
-					
+
 					--Explosive Bolt
 					self.parts.wpn_fps_bow_arblast_m_explosive.pcs = {}
 					self.parts.wpn_fps_bow_arblast_m_explosive.supported = true
@@ -18364,7 +18364,7 @@ end)
 						}
 					}
 
-					
+
 					--Explosive Arrows
 					self.parts.wpn_fps_bow_ecp_m_arrows_explosive.is_a_unlockable = true
 					self.parts.wpn_fps_bow_ecp_m_arrows_explosive.pcs = {}
@@ -18372,8 +18372,8 @@ end)
 					self.parts.wpn_fps_bow_ecp_m_arrows_explosive.desc_id = "bm_w_bow_exp_desc"
 					self.parts.wpn_fps_bow_ecp_m_arrows_explosive.supported = true
 					self.parts.wpn_fps_bow_ecp_m_arrows_explosive.stats = {
-						damage = 45, 
-						total_ammo_mod = -204, 
+						damage = 45,
+						total_ammo_mod = -204,
 						spread = -12
 					}
 					self.parts.wpn_fps_bow_ecp_m_arrows_explosive.custom_stats = {
@@ -18384,7 +18384,7 @@ end)
 						ammo_pickup_max_mul = 0.85,
 						ammo_pickup_min_mul = 0.85
 					}
-					
+
 					--Poison Arrow
 					self.parts.wpn_fps_bow_ecp_m_arrows_poison.is_a_unlockable = true
 					self.parts.wpn_fps_bow_ecp_m_arrows_poison.pcs = {}
@@ -18399,55 +18399,55 @@ end)
 
 					self.wpn_fps_bow_ecp.override = self.wpn_fps_bow_ecp.override or {}
 
-					self.wpn_fps_bow_ecp.override.wpn_fps_upg_m4_g_ergo = { 
+					self.wpn_fps_bow_ecp.override.wpn_fps_upg_m4_g_ergo = {
 						forbids = {
 							"wpn_fps_upg_m4_g_standard_vanilla",
 							"wpn_fps_bow_ecp_s_bare_grip"
 						}
 					}
-					self.wpn_fps_bow_ecp.override.wpn_fps_upg_m4_g_sniper = { 
+					self.wpn_fps_bow_ecp.override.wpn_fps_upg_m4_g_sniper = {
 						forbids = {
 							"wpn_fps_upg_m4_g_standard_vanilla",
 							"wpn_fps_bow_ecp_s_bare_grip"
 						}
 					}
-					self.wpn_fps_bow_ecp.override.wpn_fps_upg_m4_g_hgrip = { 
+					self.wpn_fps_bow_ecp.override.wpn_fps_upg_m4_g_hgrip = {
 						forbids = {
 							"wpn_fps_upg_m4_g_standard_vanilla",
 							"wpn_fps_bow_ecp_s_bare_grip"
 						}
 					}
-					self.wpn_fps_bow_ecp.override.wpn_fps_upg_m4_g_mgrip = { 
+					self.wpn_fps_bow_ecp.override.wpn_fps_upg_m4_g_mgrip = {
 						forbids = {
 							"wpn_fps_upg_m4_g_standard_vanilla",
 							"wpn_fps_bow_ecp_s_bare_grip"
 						}
 					}
-					self.wpn_fps_bow_ecp.override.wpn_fps_snp_tti_g_grippy = { 
+					self.wpn_fps_bow_ecp.override.wpn_fps_snp_tti_g_grippy = {
 						forbids = {
 							"wpn_fps_upg_m4_g_standard_vanilla",
 							"wpn_fps_bow_ecp_s_bare_grip"
 						}
 					}
-					self.wpn_fps_bow_ecp.override.wpn_fps_upg_g_m4_surgeon = { 
+					self.wpn_fps_bow_ecp.override.wpn_fps_upg_g_m4_surgeon = {
 						forbids = {
 							"wpn_fps_upg_m4_g_standard_vanilla",
 							"wpn_fps_bow_ecp_s_bare_grip"
 						}
 					}
-					self.wpn_fps_bow_ecp.override.wpn_fps_ass_m4_g_fancy = { 
+					self.wpn_fps_bow_ecp.override.wpn_fps_ass_m4_g_fancy = {
 						forbids = {
 							"wpn_fps_upg_m4_g_standard_vanilla",
 							"wpn_fps_bow_ecp_s_bare_grip"
 						}
 					}
-					self.wpn_fps_bow_ecp.override.wpn_fps_m4_uupg_g_billet = { 
+					self.wpn_fps_bow_ecp.override.wpn_fps_m4_uupg_g_billet = {
 						forbids = {
 							"wpn_fps_upg_m4_g_standard_vanilla",
 							"wpn_fps_bow_ecp_s_bare_grip"
 						}
 					}
-					self.wpn_fps_bow_ecp.override.wpn_fps_snp_victor_g_mod3 = { 
+					self.wpn_fps_bow_ecp.override.wpn_fps_snp_victor_g_mod3 = {
 						forbids = {
 							"wpn_fps_upg_m4_g_standard_vanilla",
 							"wpn_fps_bow_ecp_s_bare_grip"
@@ -18461,14 +18461,14 @@ end)
 					table.insert(self.wpn_fps_bow_ecp.uses_parts, "wpn_fps_snp_tti_g_grippy")
 					table.insert(self.wpn_fps_bow_ecp.uses_parts, "wpn_fps_upg_g_m4_surgeon")
 
-					self.wpn_fps_bow_ecp_npc.uses_parts = deep_clone(self.wpn_fps_bow_ecp.uses_parts)	
+					self.wpn_fps_bow_ecp_npc.uses_parts = deep_clone(self.wpn_fps_bow_ecp.uses_parts)
 				end)
 
 		--SECONDARIES
 
 			--CB1-50
 				Hooks:PostHook(WeaponFactoryTweakData, "_init_hunter", "resmod_hunter", function(self)
-					
+
 
 					self.parts.wpn_fps_bow_hunter_body_standard.stance_mod = {
 						wpn_fps_bow_hunter = { translation = Vector3( 0, 20, 0 ) }
@@ -18484,7 +18484,7 @@ end)
 					self.parts.wpn_fps_bow_hunter_b_carbon.supported = true
 					self.parts.wpn_fps_bow_hunter_b_carbon.stats = {value = 1, spread = 2, recoil = -2, concealment = -1}
 					self.parts.wpn_fps_bow_hunter_b_carbon.custom_stats = { velocity_mult = 1.2 }
-					
+
 					--Skeletal Limb
 					self.parts.wpn_fps_bow_hunter_b_skeletal.pcs = {
 						10,
@@ -18495,7 +18495,7 @@ end)
 					self.parts.wpn_fps_bow_hunter_b_skeletal.supported = true
 					self.parts.wpn_fps_bow_hunter_b_skeletal.stats = {value = 3, spread = -1, concealment = 1}
 					self.parts.wpn_fps_bow_hunter_b_skeletal.custom_stats = { velocity_mult = 0.8 }
-					
+
 					--Camo Grip
 					self.parts.wpn_fps_bow_hunter_g_camo.pcs = {
 						10,
@@ -18506,7 +18506,7 @@ end)
 					self.parts.wpn_fps_bow_hunter_g_camo.supported = true
 					self.parts.wpn_fps_bow_hunter_g_camo.stats = deep_clone(grips.quickdraw_1)
 					self.parts.wpn_fps_bow_hunter_g_camo.custom_stats = deep_clone(grips.quickdraw_1)
-					
+
 					--Walnut Grip
 					self.parts.wpn_fps_bow_hunter_g_walnut.pcs = {
 						10,
@@ -18528,7 +18528,7 @@ end)
 						launcher_grenade = "crossbow_poison_arrow",
 						dot_data_name = "ammo_proj_crossbow"
 					}
-					
+
 					--Explosive Bolts
 					self.parts.wpn_fps_upg_a_crossbow_explosion.pcs = {}
 					self.parts.wpn_fps_upg_a_crossbow_explosion.supported = true
@@ -18569,7 +18569,7 @@ end)
 			self.parts.wpn_fps_upg_ns_ass_smg_large.stats = deep_clone(muzzle_device.supp_acc2_c)
 			self.parts.wpn_fps_upg_ns_ass_smg_large.custom_stats = deep_clone(muzzle_device.supp_acc2_c)
 			self.parts.wpn_fps_upg_ns_ass_smg_large.perks = {"silencer"}
-			
+
 			--Medium Suppressor
 			self.parts.wpn_fps_upg_ns_ass_smg_medium.pcs = {
 				10,
@@ -18582,7 +18582,7 @@ end)
 			self.parts.wpn_fps_upg_ns_ass_smg_medium.desc_id = "bm_wp_upg_suppressor"
 			self.parts.wpn_fps_upg_ns_ass_smg_medium.stats = deep_clone(muzzle_device.supp_rec_c)
 			self.parts.wpn_fps_upg_ns_ass_smg_medium.perks = {"silencer"}
-			
+
 			--Low Profile Suppressor
 			self.parts.wpn_fps_upg_ns_ass_smg_small.pcs = {
 				10,
@@ -18596,7 +18596,7 @@ end)
 			self.parts.wpn_fps_upg_ns_ass_smg_small.stats = deep_clone(muzzle_device.supp_con_a)
 			self.parts.wpn_fps_upg_ns_ass_smg_small.custom_stats = deep_clone(muzzle_device.supp_con_a)
 			self.parts.wpn_fps_upg_ns_ass_smg_small.perks = {"silencer"}
-			
+
 			--Monolith Suppressor
 			self.parts.wpn_fps_upg_ns_pis_large.pcs = {
 				10,
@@ -18637,20 +18637,20 @@ end)
 			self.parts.wpn_fps_upg_ns_pis_small.stats = deep_clone(muzzle_device.supp_con_a)
 			self.parts.wpn_fps_upg_ns_pis_small.custom_stats = deep_clone(muzzle_device.supp_con_a)
 			self.parts.wpn_fps_upg_ns_pis_small.perks = {"silencer"}
-			
+
 			--Silent Killer Suppressor
 			self.parts.wpn_fps_upg_ns_shot_thick.pcs = {
 				10,
 				20,
 				30,
 				40
-			}	
-			self.parts.wpn_fps_upg_ns_shot_thick.supported = true	
+			}
+			self.parts.wpn_fps_upg_ns_shot_thick.supported = true
 			self.parts.wpn_fps_upg_ns_shot_thick.has_description = true
 			self.parts.wpn_fps_upg_ns_shot_thick.desc_id = "bm_wp_upg_suppressor"
 			self.parts.wpn_fps_upg_ns_shot_thick.stats = deep_clone(muzzle_device.supp_rec_c)
-			self.parts.wpn_fps_upg_ns_shot_thick.custom_stats = {}		
-			self.parts.wpn_fps_upg_ns_shot_thick.perks = {"silencer"}	
+			self.parts.wpn_fps_upg_ns_shot_thick.custom_stats = {}
+			self.parts.wpn_fps_upg_ns_shot_thick.perks = {"silencer"}
 			self.parts.wpn_fps_upg_ns_shot_thick.forbids = {
 				"wpn_fps_upg_a_explosive"
 			}
@@ -18670,7 +18670,7 @@ end)
 			self.parts.wpn_fps_upg_ns_ass_smg_firepig.custom_stats = {
 				muzzleflash = "effects/payday2/particles/weapons/big_762_auto_fps"
 			}
-				
+
 			--Stubby Compensator
 			self.parts.wpn_fps_upg_ns_ass_smg_stubby.pcs = {
 				10,
@@ -18685,8 +18685,8 @@ end)
 			self.parts.wpn_fps_upg_ns_ass_smg_stubby.stats = deep_clone(muzzle_device.muzz_con_a)
 			self.parts.wpn_fps_upg_ns_ass_smg_stubby.custom_stats = deep_clone(muzzle_device.muzz_con_a)
 			self.parts.wpn_fps_upg_ns_ass_smg_stubby.custom_stats.muzzleflash = "effects/payday2/particles/weapons/9mm_auto_silence_fps"
-				
-			--The Tank Compensator	
+
+			--The Tank Compensator
 			self.parts.wpn_fps_upg_ns_ass_smg_tank.pcs = {
 				10,
 				20,
@@ -18707,7 +18707,7 @@ end)
 			}
 			self.parts.wpn_fps_upg_ns_shot_shark.supported = true
 			self.parts.wpn_fps_upg_ns_shot_shark.stats = deep_clone(muzzle_device.muzz_rec_c)
-			self.parts.wpn_fps_upg_ns_shot_shark.custom_stats = {}			
+			self.parts.wpn_fps_upg_ns_shot_shark.custom_stats = {}
 		end)
 	--Vanilla Gadgets
 		Hooks:PostHook(WeaponFactoryTweakData, "_init_gadgets", "resmod_gadgets", function(self)
@@ -18747,7 +18747,7 @@ end)
 
 			--Pocket Laser
 			self.parts.wpn_fps_upg_fl_pis_laser.pcs = {
-				10,	
+				10,
 				20,
 				30,
 				40
@@ -18795,7 +18795,7 @@ end)
 					concealment = -2
 				}
 			}
-			
+
 			--Stubby Vertical Grip
 			self.parts.wpn_fps_upg_vg_ass_smg_stubby = {
 				pcs = {},
@@ -18815,7 +18815,7 @@ end)
 					concealment = -1
 				}
 			}
-			
+
 			--AFG
 			self.parts.wpn_fps_upg_vg_ass_smg_afg = {
 				pcs = {},
@@ -18830,11 +18830,11 @@ end)
 				supported = true,
 				stats = {
 					value = 2,
-					spread = 1,				
+					spread = 1,
 					concealment = -1
 				}
 			}
-			
+
 			--Vanilla 'statless' variants for weapons that have vertical grips baseline
 			self.parts.wpn_fps_upg_vg_ass_smg_verticalgrip.third_unit = "units/payday2/weapons/wpn_third_upg_vg_ass_smg_verticalgrip/wpn_third_upg_vg_ass_smg_verticalgrip"
 			self.parts.wpn_fps_upg_vg_ass_smg_stubby.third_unit = "units/payday2/weapons/wpn_third_upg_vg_ass_smg_stubby/wpn_third_upg_vg_ass_smg_stubby"
@@ -18856,9 +18856,9 @@ end)
 
 			--Milspec Scope
 			self.parts.wpn_fps_upg_o_specter.pcs = {
-				10, 
+				10,
 				20,
-				30, 
+				30,
 				40
 			}
 			self.parts.wpn_fps_upg_o_specter.has_description = true
@@ -18890,7 +18890,7 @@ end)
 					self.parts.wpn_fps_upg_o_specter.stance_mod.wpn_fps_ass_famas = {
 						translation = Vector3(0, 2.1, -6.25)
 					}
-				
+
 					self.parts.wpn_fps_upg_o_specter.stance_mod.wpn_fps_ass_m4 = {
 						translation = Vector3(0, 13.2, -0.55)
 					}
@@ -18915,7 +18915,7 @@ end)
 					self.parts.wpn_fps_upg_o_specter.stance_mod.wpn_fps_ass_komodo = {
 						translation = Vector3(0, 15, 0.09)
 					}
-				
+
 					self.parts.wpn_fps_upg_o_specter.stance_mod.wpn_fps_ass_m16 = {
 						translation = Vector3(0, 9, -0.1)
 					}
@@ -18954,7 +18954,7 @@ end)
 					self.parts.wpn_fps_upg_o_specter.stance_mod.wpn_fps_ass_contraband = {
 						translation = Vector3(-0.005, 3.2, -1.69)
 					}
-				
+
 					self.parts.wpn_fps_upg_o_specter.stance_mod.wpn_fps_ass_m14 = {
 						translation = Vector3(-0.02, 2, -3.85)
 					}
@@ -18968,7 +18968,7 @@ end)
 						translation = Vector3(0, -10, 1.585),
 						rotation = Rotation(0, -0.5, 0)
 					}
-				
+
 					self.parts.wpn_fps_upg_o_specter.stance_mod.wpn_fps_ass_rsass = {
 						translation = Vector3(-0.02, 2.3, -0.27),
 						rotation = Rotation(-0.02, -0.06, -0.77)
@@ -18986,7 +18986,7 @@ end)
 					}
 					self.parts.wpn_fps_upg_o_specter.stance_mod.wpn_fps_snp_winchester = {
 						translation = Vector3(-0.004, -3.8, -3.36)
-					}	
+					}
 					self.parts.wpn_fps_upg_o_specter.stance_mod.wpn_fps_snp_r700 = {
 						translation = Vector3(0, -0.6, -3.785)
 					}
@@ -19001,7 +19001,7 @@ end)
 					self.parts.wpn_fps_upg_o_specter.stance_mod.wpn_fps_snp_awp = {
 						translation = Vector3(0, 32, 0.76)
 					}
-				
+
 					self.parts.wpn_fps_upg_o_specter.stance_mod.wpn_fps_snp_wa2000 = {
 						translation = Vector3(0, 4.3, 0.76)
 					}
@@ -19037,7 +19037,7 @@ end)
 					self.parts.wpn_fps_upg_o_specter.stance_mod.wpn_fps_snp_m95 = {
 						translation = Vector3(0, 9.4, -3.82)
 					}
-				
+
 					self.parts.wpn_fps_upg_o_specter.stance_mod.wpn_fps_shot_saiga = {
 						translation = Vector3(0.06, -2, -2.97)
 					}
@@ -19066,7 +19066,7 @@ end)
 					self.parts.wpn_fps_upg_o_specter.stance_mod.wpn_fps_sho_striker = {
 						translation = Vector3(0, 5.9, -2.8)
 					}
-				
+
 					self.parts.wpn_fps_upg_o_specter.stance_mod.wpn_fps_sho_ksg = {
 						translation = Vector3(0, 5.3, -1.315)
 					}
@@ -19090,7 +19090,7 @@ end)
 					self.parts.wpn_fps_upg_o_specter.stance_mod.wpn_fps_pis_judge = {
 						translation = Vector3(0.04, -6.5, -5.325)
 					}
-				
+
 					self.parts.wpn_fps_upg_o_specter.stance_mod.wpn_fps_ass_sub2000 = {
 						translation = Vector3(-0.005, -4.8, -0.025)
 					}
@@ -19103,7 +19103,7 @@ end)
 					}
 					self.parts.wpn_fps_upg_o_specter.stance_mod.wpn_fps_pis_shatters_fury = {
 						translation = Vector3(-0.03, -6, -4.62)
-					}	
+					}
 					self.parts.wpn_fps_upg_o_specter.stance_mod.wpn_fps_pis_rage = {
 						translation = Vector3(-0.03, -6, -4.62)
 					}
@@ -19111,7 +19111,7 @@ end)
 						translation = Vector3(0, -14, -4.23),
 						rotation = Rotation(0, -0.5, 0)
 					}
-				
+
 					self.parts.wpn_fps_upg_o_specter.stance_mod.wpn_fps_smg_p90 = {
 						translation = Vector3(-0.005, 1.6, -3.028)
 					}
@@ -19119,7 +19119,7 @@ end)
 						translation = Vector3(0.03, 7.7, -2.67),
 						rotation = Rotation(0.032, -0.2, 0)
 					}
-				
+
 					self.parts.wpn_fps_upg_o_specter.stance_mod.wpn_fps_smg_mp9 = {
 						translation = Vector3(0, 11.6, -3.47)
 					}
@@ -19136,7 +19136,7 @@ end)
 					self.parts.wpn_fps_upg_o_specter.stance_mod.wpn_fps_smg_sr2 = {
 						translation = Vector3(0, 17.2, -4.57)
 					}
-				
+
 					self.parts.wpn_fps_upg_o_specter.stance_mod.wpn_fps_smg_vityaz = {
 						translation = Vector3(0.01, 8.5, -3.321)
 					}
@@ -19152,7 +19152,7 @@ end)
 					self.parts.wpn_fps_upg_o_specter.stance_mod.wpn_fps_smg_mp5 = {
 						translation = Vector3(0, 9.4, -2.92)
 					}
-					
+
 					self.parts.wpn_fps_upg_o_specter.stance_mod.wpn_fps_smg_erma = {
 						translation = Vector3(0.005, 6.9, -4.152)
 					}
@@ -19177,7 +19177,7 @@ end)
 					self.parts.wpn_fps_upg_o_specter.stance_mod.wpn_fps_smg_uzi = {
 						translation = Vector3(0, 4.7, -5.1)
 					}
-				
+
 					self.parts.wpn_fps_upg_o_specter.stance_mod.wpn_fps_ass_tecci = {
 						translation = Vector3(-0.005, 13.2, -1.68)
 					}
@@ -19217,14 +19217,14 @@ end)
 						translation = Vector3(-4.905, 6.2, -2.647),
 						rotation = Rotation(-0.15, -0.33, -10.5)
 					}
-				
+
 					self.parts.wpn_fps_upg_o_specter.stance_mod.wpn_fps_bow_elastic = {
 						translation = Vector3(-0.003, 16, -1.5)
 					}
 					self.parts.wpn_fps_upg_o_specter.stance_mod.wpn_fps_bow_ecp = {
 						translation = Vector3(-0.001, -1, -3.325)
 					}
-				
+
 					self.parts.wpn_fps_upg_o_specter.stance_mod.wpn_fps_gre_m79 = {
 						translation = Vector3(0.05, -1.5, -0.2),
 						rotation = Rotation(0, -2.16, 0)
@@ -19245,7 +19245,7 @@ end)
 						translation = Vector3(0.018, 12, 2.465),
 						rotation = Rotation(0, -6, 0)
 					}
-			
+
 				--CUSTOM WEAPS
 					--VMP
 						self.parts.wpn_fps_upg_o_specter.stance_mod.wpn_fps_shot_amr12 = {
@@ -19307,7 +19307,7 @@ end)
 					self.parts.wpn_fps_upg_o_specter.stance_mod.wpn_fps_smg_fmgnine = {
 						translation = Vector3(0.0, 12.5, -4.55)
 					}
-				
+
 					self.parts.wpn_fps_upg_o_specter.stance_mod.wpn_fps_smg_crysis3_typhoon = {
 						translation = Vector3(-0.015, -1.2, -2.755)
 					}
@@ -19316,7 +19316,7 @@ end)
 						translation = Vector3(-0.028, 4.2, -0.149),
 						rotation = Rotation(-0.05, 0, -0.075)
 					}
-					
+
 					self.parts.wpn_fps_upg_o_specter.stance_mod.wpn_fps_smg_aug9mm = {
 						translation = Vector3(-0.004, 2.8, -3.448)
 					}
@@ -19465,7 +19465,7 @@ end)
 						translation = Vector3(-0.02, 4.3, -3.48)
 					}
 
-			
+
 					self.parts.wpn_fps_upg_o_specter.stance_mod.wpn_fps_ass_qbz95 = {
 						translation = Vector3(-0.005, 7.2, -4.74)
 					}
@@ -19642,7 +19642,7 @@ end)
 					self.parts.wpn_fps_upg_o_specter.stance_mod.wpn_fps_snp_sbeta = {
 						translation = Vector3(-0.015, 1, -3.79)
 					}
-					
+
 					self.parts.wpn_fps_upg_o_specter.stance_mod.wpn_fps_bow_stampede_ecs = {
 						translation = Vector3(0.048, 11.5, -3.435)
 					}
@@ -19666,15 +19666,15 @@ end)
 
 			--CASSIAN Sharp Combo Sight
 			self.parts.wpn_fps_upg_o_atibal.pcs = {
-				10, 
+				10,
 				20,
-				30, 
-				40	
+				30,
+				40
 			}
 			self.parts.wpn_fps_upg_o_atibal.has_description = true
 			self.parts.wpn_fps_upg_o_atibal.has_second_sight = true
-			self.parts.wpn_fps_upg_o_atibal.desc_id = "bm_wp_upg_o_3_rds"		
-			self.parts.wpn_fps_upg_o_atibal.supported = true		
+			self.parts.wpn_fps_upg_o_atibal.desc_id = "bm_wp_upg_o_3_rds"
+			self.parts.wpn_fps_upg_o_atibal.supported = true
 			self.parts.wpn_fps_upg_o_atibal.stats = {
 				value = 10,
 				zoom = 20
@@ -19702,15 +19702,15 @@ end)
 
 			--CASSIAN Elite Combo Sight/Trigonom SCRW Scope
 			self.parts.wpn_fps_upg_o_hamr.pcs = {
-				10, 
+				10,
 				20,
-				30, 
-				40	
+				30,
+				40
 			}
 			self.parts.wpn_fps_upg_o_hamr.has_description = true
 			self.parts.wpn_fps_upg_o_hamr.has_second_sight = true
-			self.parts.wpn_fps_upg_o_hamr.desc_id = "bm_wp_upg_o_4_rds"		
-			self.parts.wpn_fps_upg_o_hamr.supported = true		
+			self.parts.wpn_fps_upg_o_hamr.desc_id = "bm_wp_upg_o_4_rds"
+			self.parts.wpn_fps_upg_o_hamr.supported = true
 			self.parts.wpn_fps_upg_o_hamr.stats = {
 				value = 10,
 				zoom = 30
@@ -19730,14 +19730,14 @@ end)
 
 			--Military Red Dot
 			self.parts.wpn_fps_upg_o_aimpoint.pcs = {
-				10, 
+				10,
 				20,
-				30, 
-				40	
+				30,
+				40
 			}
 			self.parts.wpn_fps_upg_o_aimpoint.has_description = true
-			self.parts.wpn_fps_upg_o_aimpoint.desc_id = "bm_wp_upg_o_1_8"		
-			self.parts.wpn_fps_upg_o_aimpoint.supported = true		
+			self.parts.wpn_fps_upg_o_aimpoint.desc_id = "bm_wp_upg_o_1_8"
+			self.parts.wpn_fps_upg_o_aimpoint.supported = true
 			self.parts.wpn_fps_upg_o_aimpoint.stats = {
 				value = 8,
 				zoom = 8
@@ -19746,14 +19746,14 @@ end)
 			self.parts.wpn_fps_upg_o_aimpoint.stance_mod = deep_clone(self.parts.wpn_fps_upg_o_specter.stance_mod)
 				--Preorder Military Red Dot
 				self.parts.wpn_fps_upg_o_aimpoint_2.pcs = {
-					10, 
+					10,
 					20,
-					30, 
-					40	
+					30,
+					40
 				}
 				self.parts.wpn_fps_upg_o_aimpoint_2.has_description = true
-				self.parts.wpn_fps_upg_o_aimpoint_2.desc_id = "bm_wp_upg_o_1_8"		
-				self.parts.wpn_fps_upg_o_aimpoint_2.supported = true		
+				self.parts.wpn_fps_upg_o_aimpoint_2.desc_id = "bm_wp_upg_o_1_8"
+				self.parts.wpn_fps_upg_o_aimpoint_2.supported = true
 				self.parts.wpn_fps_upg_o_aimpoint_2.stats = {
 					value = 8,
 					zoom = 8
@@ -19762,9 +19762,9 @@ end)
 				self.parts.wpn_fps_upg_o_aimpoint_2.stance_mod = deep_clone(self.parts.wpn_fps_upg_o_aimpoint.stance_mod)
 				--Compact Tactical/Tech Force 90
 				self.parts.wpn_fps_upg_o_tf90.pcs = {
-					10, 
+					10,
 					20,
-					30, 
+					30,
 					40
 				}
 				self.parts.wpn_fps_upg_o_tf90.has_description = true
@@ -19774,7 +19774,7 @@ end)
 					value = 8,
 					zoom = 2
 				}
-				self.parts.wpn_fps_upg_o_tf90.perks = {"scope"}	
+				self.parts.wpn_fps_upg_o_tf90.perks = {"scope"}
 				self.parts.wpn_fps_upg_o_tf90.stance_mod = deep_clone(self.parts.wpn_fps_upg_o_aimpoint.stance_mod)
 
 			--Surgeon Sight
@@ -19803,21 +19803,21 @@ end)
 
 			--Owl Glass/BelOMO PO4x24P
 			self.parts.wpn_fps_upg_o_poe.pcs = {
-				10, 
+				10,
 				20,
-				30, 
-				40	
+				30,
+				40
 			}
 			self.parts.wpn_fps_upg_o_poe.has_description = true
-			self.parts.wpn_fps_upg_o_poe.desc_id = "bm_wp_upg_o_4"		
-			self.parts.wpn_fps_upg_o_poe.supported = true		
+			self.parts.wpn_fps_upg_o_poe.desc_id = "bm_wp_upg_o_4"
+			self.parts.wpn_fps_upg_o_poe.supported = true
 			self.parts.wpn_fps_upg_o_poe.stats = {
 				value = 8,
 				zoom = 30
 			}
 			self.parts.wpn_fps_upg_o_poe.perks = {"scope"}
-			self.parts.wpn_fps_upg_o_poe.stance_mod = deep_clone(self.parts.wpn_fps_upg_o_specter.stance_mod)	
-			
+			self.parts.wpn_fps_upg_o_poe.stance_mod = deep_clone(self.parts.wpn_fps_upg_o_specter.stance_mod)
+
 			--Holographic Sight
 			self.parts.wpn_fps_upg_o_eotech.pcs = {
 				10,
@@ -19826,8 +19826,8 @@ end)
 				40
 			}
 			self.parts.wpn_fps_upg_o_eotech.has_description = true
-			self.parts.wpn_fps_upg_o_eotech.desc_id = "bm_wp_upg_o_1_5"			
-			self.parts.wpn_fps_upg_o_eotech.supported = true			
+			self.parts.wpn_fps_upg_o_eotech.desc_id = "bm_wp_upg_o_1_5"
+			self.parts.wpn_fps_upg_o_eotech.supported = true
 			self.parts.wpn_fps_upg_o_eotech.stats = {
 				value = 3,
 				zoom = 5
@@ -19850,15 +19850,15 @@ end)
 				40
 			}
 			self.parts.wpn_fps_upg_o_t1micro.desc_id = "bm_wp_upg_o_1_2"
-			self.parts.wpn_fps_upg_o_t1micro.has_description = true		
-			self.parts.wpn_fps_upg_o_t1micro.supported = true		
+			self.parts.wpn_fps_upg_o_t1micro.has_description = true
+			self.parts.wpn_fps_upg_o_t1micro.supported = true
 			self.parts.wpn_fps_upg_o_t1micro.stats = {
 				value = 5,
 				zoom = 2
 			}
 			self.parts.wpn_fps_upg_o_t1micro.perks = {"scope"}
 			self.parts.wpn_fps_upg_o_t1micro.stance_mod = deep_clone(self.parts.wpn_fps_upg_o_specter.stance_mod)
-			
+
 			--Marksman Sight
 			self.parts.wpn_upg_o_marksmansight_rear.pcs = {
 					10,
@@ -19897,7 +19897,7 @@ end)
 			self.parts.wpn_fps_upg_o_45iron.stance_mod.wpn_fps_snp_winchester = {
 				translation = Vector3(-5.56, -5, -14.78),
 				rotation = Rotation(0, 0, -45)
-			}		
+			}
 			self.parts.wpn_fps_upg_o_45iron.stance_mod.wpn_fps_snp_scout = {
 				translation = Vector3(-2.6, -2, -7.2),
 				rotation = Rotation(0, 0, -45)
@@ -19931,7 +19931,7 @@ end)
 			self.parts.wpn_fps_upg_o_shortdot.perks = {"scope"}
 			self.parts.wpn_fps_upg_o_shortdot.reticle_obj = nil
 			self.parts.wpn_fps_upg_o_shortdot.stance_mod = deep_clone(self.parts.wpn_fps_upg_o_specter.stance_mod)
-				
+
 			for i, weap in pairs(self.parts.wpn_fps_upg_o_shortdot.stance_mod) do
 				if weap and weap.translation then
 					weap.translation = weap.translation + Vector3(0, -21.5, -0.76)
@@ -19959,7 +19959,7 @@ end)
 			self.parts.wpn_fps_upg_o_leupold.custom_stats = { big_scope = true }
 			self.parts.wpn_fps_upg_o_leupold.perks = {"scope"}
 			self.parts.wpn_fps_upg_o_leupold.stance_mod = deep_clone(self.parts.wpn_fps_upg_o_specter.stance_mod)
-	
+
 			for i, weap in pairs(self.parts.wpn_fps_upg_o_leupold.stance_mod) do
 				if weap and weap.translation then
 					weap.translation = weap.translation + Vector3(0, -22.5, -0.867)
@@ -20013,7 +20013,7 @@ end)
 			}
 			self.parts.wpn_fps_upg_i_singlefire.perks = {
 				"fire_mode_single"
-			}		
+			}
 			self.parts.wpn_fps_upg_i_singlefire.forbids = {
 				"wpn_fps_upg_extra_mp_lock"
 			}
@@ -20036,10 +20036,10 @@ end)
 				info_lock_auto = true,
 				falloff_start_mult = 0.85,
 				falloff_end_mult = 0.85
-			}			
+			}
 			self.parts.wpn_fps_upg_i_autofire.perks = {
 				"fire_mode_auto"
-			}				
+			}
 			self.parts.wpn_fps_upg_i_autofire.forbids = {
 				"wpn_fps_upg_extra_mp_lock"
 			}
@@ -20082,8 +20082,8 @@ end)
 			}
 			self.parts.wpn_fps_upg_o_acog.reticle_obj = nil
 			self.parts.wpn_fps_upg_o_acog.desc_id = "bm_wp_upg_o_4"
-			self.parts.wpn_fps_upg_o_acog.has_description = true		
-			self.parts.wpn_fps_upg_o_acog.supported = true		
+			self.parts.wpn_fps_upg_o_acog.has_description = true
+			self.parts.wpn_fps_upg_o_acog.supported = true
 			self.parts.wpn_fps_upg_o_acog.stats = {
 				value = 8,
 				zoom = 30
@@ -20123,7 +20123,7 @@ end)
 				unit = "units/pd2_dlc_spa/weapons/wpn_fps_snp_tti_pts/wpn_fps_snp_tti_vg_standard",
 				third_unit = "units/pd2_dlc_spa/weapons/wpn_third_snp_tti_pts/wpn_third_snp_tti_vg_standard"
 			}
-			
+
 			--Gazelle Rail
 			self.parts.wpn_fps_upg_fg_smr.pcs = {}
 			self.parts.wpn_fps_upg_fg_smr.supported = true
@@ -20150,7 +20150,7 @@ end)
 				reload = -6,
 				extra_ammo = 30
 			}
-			
+
 			--Battleproven Handguard
 			self.parts.wpn_fps_upg_ak_fg_tapco.pcs = {}
 			self.parts.wpn_fps_upg_ak_fg_tapco.supported = true
@@ -20162,7 +20162,7 @@ end)
 			self.parts.wpn_fps_upg_ak_fg_tapco.forbids = {
 				"wpn_fps_ak_extra_ris"
 			}
-			
+
 			--Lightweight Rail
 			self.parts.wpn_fps_upg_fg_midwest.pcs = {}
 			self.parts.wpn_fps_upg_fg_midwest.supported = true
@@ -20177,7 +20177,7 @@ end)
 			self.parts.wpn_fps_upg_ak_b_draco.supported = true
 			self.parts.wpn_fps_upg_ak_b_draco.stats = deep_clone(barrels.short_b2_stats)
 			self.parts.wpn_fps_upg_ak_b_draco.custom_stats = deep_clone(barrels.short_b2_stats)
-			
+
 			--AK Quadstacked Mag
 			self.parts.wpn_fps_upg_ak_m_quad.pcs = {}
 			self.parts.wpn_fps_upg_ak_m_quad.supported = true
@@ -20190,7 +20190,7 @@ end)
 			self.parts.wpn_fps_upg_ak_m_quad.custom_stats = {
 				ads_speed_mult = 1.1
 			}
-			
+
 			--AK Rubber Grip
 			self.parts.wpn_fps_upg_ak_g_hgrip.pcs = {}
 			self.parts.wpn_fps_upg_ak_g_hgrip.supported = true
@@ -20200,7 +20200,7 @@ end)
 				"wpn_upg_ak_g_standard",
 				"wpn_fps_ass_asval_g_standard"
 			}
-			
+
 			--AK Plastic Grip
 			self.parts.wpn_fps_upg_ak_g_pgrip.pcs = {}
 			self.parts.wpn_fps_upg_ak_g_pgrip.supported = true
@@ -20215,7 +20215,7 @@ end)
 			self.parts.wpn_fps_upg_ak_g_wgrip.pcs = {}
 			self.parts.wpn_fps_upg_ak_g_wgrip.supported = true
 			self.parts.wpn_fps_upg_ak_g_wgrip.stats = deep_clone(grips.recoil_acc)
-			self.parts.wpn_fps_upg_ak_g_wgrip.custom_stats = {}		
+			self.parts.wpn_fps_upg_ak_g_wgrip.custom_stats = {}
 			self.parts.wpn_fps_upg_ak_g_wgrip.forbids = {
 				"wpn_upg_ak_g_standard",
 				"wpn_fps_ass_asval_g_standard"
@@ -20226,7 +20226,7 @@ end)
 			self.parts.wpn_fps_upg_ass_ns_jprifles.supported = true
 			self.parts.wpn_fps_upg_ass_ns_jprifles.stats = deep_clone(muzzle_device.muzz_dual_c)
 			self.parts.wpn_fps_upg_ass_ns_jprifles.custom_stats = deep_clone(muzzle_device.muzz_dual_c)
-			
+
 			--Funnel of Fun Nozzle
 			self.parts.wpn_fps_upg_ass_ns_linear.pcs = {}
 			self.parts.wpn_fps_upg_ass_ns_linear.supported = true
@@ -20240,7 +20240,7 @@ end)
 			self.parts.wpn_fps_upg_ass_ns_surefire.supported = true
 			self.parts.wpn_fps_upg_ass_ns_surefire.stats = deep_clone(muzzle_device.muzz_acc_c)
 			self.parts.wpn_fps_upg_ass_ns_surefire.custom_stats = deep_clone(muzzle_device.muzz_acc_c)
-			
+
 			--Flash Hider
 			self.parts.wpn_fps_upg_pis_ns_flash.pcs = {}
 			self.parts.wpn_fps_upg_pis_ns_flash.supported = true
@@ -20250,13 +20250,13 @@ end)
 			self.parts.wpn_fps_upg_pis_ns_flash.stats = deep_clone(muzzle_device.muzz_con_a)
 			self.parts.wpn_fps_upg_pis_ns_flash.custom_stats = deep_clone(muzzle_device.muzz_con_a)
 			self.parts.wpn_fps_upg_pis_ns_flash.custom_stats.muzzleflash = "effects/payday2/particles/weapons/9mm_auto_silence_fps"
-			
+
 			--King's Crown Compensator
 			self.parts.wpn_fps_upg_shot_ns_king.pcs = {}
 			self.parts.wpn_fps_upg_shot_ns_king.supported = true
 			self.parts.wpn_fps_upg_shot_ns_king.stats = deep_clone(muzzle_device.muzz_acc_c)
 			self.parts.wpn_fps_upg_shot_ns_king.custom_stats = deep_clone(muzzle_device.muzz_acc_c)
-				
+
 			--Asepsis Suppressor
 			self.parts.wpn_fps_upg_ns_pis_medium_slim.pcs = {}
 			self.parts.wpn_fps_upg_ns_pis_medium_slim.supported = true
@@ -20265,7 +20265,7 @@ end)
 			self.parts.wpn_fps_upg_ns_pis_medium_slim.stats = deep_clone(muzzle_device.supp_acc_c)
 			self.parts.wpn_fps_upg_ns_pis_medium_slim.custom_stats = deep_clone(muzzle_device.supp_acc_c)
 			self.parts.wpn_fps_upg_ns_pis_medium_slim.perks = {"silencer"}
-			
+
 			--Compact Laser Module
 			self.parts.wpn_fps_upg_fl_ass_laser.pcs = {}
 			self.parts.wpn_fps_upg_fl_ass_laser.desc_id = "bm_wp_upg_fl_laser"
@@ -20289,7 +20289,7 @@ end)
 			self.parts.wpn_fps_upg_m4_s_crane.supported = true
 			self.parts.wpn_fps_upg_m4_s_crane.stats = deep_clone(stocks.adj_rec_stats)
 			self.parts.wpn_fps_upg_m4_s_crane.custom_stats = deep_clone(stocks.adj_rec_stats)
-			
+
 			--War-Torn Stock
 			self.parts.wpn_fps_upg_m4_s_mk46.pcs = {}
 			self.parts.wpn_fps_upg_m4_s_mk46.supported = true
@@ -20316,7 +20316,7 @@ end)
 					self.parts.wpn_fps_upg_o_rmr.stance_mod.wpn_fps_pis_maxim9 = {
 						translation = Vector3(0, -6, -1)
 					}
-				
+
 					self.parts.wpn_fps_upg_o_rmr.stance_mod.wpn_fps_pis_beer = {
 						translation = Vector3(0, 0, -0.6)
 					}
@@ -20329,7 +20329,7 @@ end)
 					self.parts.wpn_fps_upg_o_rmr.stance_mod.wpn_fps_pis_stech = {
 						translation = Vector3(0, 0, -0.6)
 					}
-				
+
 					self.parts.wpn_fps_upg_o_rmr.stance_mod.wpn_fps_pis_breech = {
 						translation = Vector3(0, 0, -0.4),
 						rotation = Rotation(0, -0.38, 0)
@@ -20349,7 +20349,7 @@ end)
 					self.parts.wpn_fps_upg_o_rmr.stance_mod.wpn_fps_pis_legacy = {
 						translation = Vector3(0, 5, -0.68)
 					}
-				
+
 					self.parts.wpn_fps_upg_o_rmr.stance_mod.wpn_fps_pis_beretta = {
 						translation = Vector3(0, 0, -0.4),
 						rotation = Rotation(0, -0.5, 0)
@@ -20360,7 +20360,7 @@ end)
 					self.parts.wpn_fps_upg_o_rmr.stance_mod.wpn_fps_pis_packrat = {
 						translation = Vector3(0, 0, -1.15)
 					}
-				
+
 					self.parts.wpn_fps_upg_o_rmr.stance_mod.wpn_fps_pis_g22c = {
 						translation = Vector3(0, 0, -0.45),
 						rotation = Rotation(0, -0.3, 0)
@@ -20374,7 +20374,7 @@ end)
 					self.parts.wpn_fps_upg_o_rmr.stance_mod.wpn_fps_pis_sparrow = {
 						translation = Vector3(0, 0, -0.93)
 					}
-				
+
 					self.parts.wpn_fps_upg_o_rmr.stance_mod.wpn_fps_pis_c96 = {
 						translation = Vector3(0, 0, -1.2)
 					}
@@ -20394,7 +20394,7 @@ end)
 						translation = Vector3(0, 5, 0),
 						rotation = Rotation(0, -1, 0)
 					}
-				
+
 					self.parts.wpn_fps_upg_o_rmr.stance_mod.wpn_fps_pis_chinchilla = {
 						translation = Vector3(0, 5, -0.75)
 					}
@@ -20405,11 +20405,11 @@ end)
 						translation = Vector3(0, 0, -0.48),
 						rotation = Rotation(0, -0.5, 0)
 					}
-				
+
 					self.parts.wpn_fps_upg_o_rmr.stance_mod.wpn_fps_bow_hunter = {
 						translation = Vector3(0, 8, 0.8)
 					}
-				
+
 					self.parts.wpn_fps_upg_o_rmr.stance_mod.wpn_fps_pis_shatters_fury = {
 						translation = Vector3(0, 0, -0.45)
 					}
@@ -20422,27 +20422,27 @@ end)
 			--Compact Holosight
 			self.parts.wpn_fps_upg_o_eotech_xps.pcs = {}
 			self.parts.wpn_fps_upg_o_eotech_xps.has_description = true
-			self.parts.wpn_fps_upg_o_eotech_xps.desc_id = "bm_wp_upg_o_1_5"	
-			self.parts.wpn_fps_upg_o_eotech_xps.supported = true	
+			self.parts.wpn_fps_upg_o_eotech_xps.desc_id = "bm_wp_upg_o_1_5"
+			self.parts.wpn_fps_upg_o_eotech_xps.supported = true
 			self.parts.wpn_fps_upg_o_eotech_xps.stats = {
 				value = 5,
 				zoom = 5
 			}
 			self.parts.wpn_fps_upg_o_eotech_xps.perks = {"scope"}
 			self.parts.wpn_fps_upg_o_eotech_xps.stance_mod = deep_clone(self.parts.wpn_fps_upg_o_eotech.stance_mod)
-			
+
 			--Speculator Sight
 			self.parts.wpn_fps_upg_o_reflex.pcs = {}
 			self.parts.wpn_fps_upg_o_reflex.has_description = true
-			self.parts.wpn_fps_upg_o_reflex.desc_id = "bm_wp_upg_o_1_1"			
-			self.parts.wpn_fps_upg_o_reflex.supported = true			
+			self.parts.wpn_fps_upg_o_reflex.desc_id = "bm_wp_upg_o_1_1"
+			self.parts.wpn_fps_upg_o_reflex.supported = true
 			self.parts.wpn_fps_upg_o_reflex.stats = {
 				value = 5,
 				zoom = 1
 			}
 			self.parts.wpn_fps_upg_o_reflex.perks = {"scope"}
 			self.parts.wpn_fps_upg_o_reflex.stance_mod = deep_clone(self.parts.wpn_fps_upg_o_docter.stance_mod)
-			
+
 			--Trigonom Sight
 			self.parts.wpn_fps_upg_o_rx01.pcs = {}
 			self.parts.wpn_fps_upg_o_rx01.has_description = true
@@ -20454,7 +20454,7 @@ end)
 			}
 			self.parts.wpn_fps_upg_o_rx01.perks = {"scope"}
 			self.parts.wpn_fps_upg_o_rx01.stance_mod = deep_clone(self.parts.wpn_fps_upg_o_docter.stance_mod)
-			
+
 			--Solar Sight
 			self.parts.wpn_fps_upg_o_rx30.pcs = {}
 			self.parts.wpn_fps_upg_o_rx30.has_description = true
@@ -20466,11 +20466,11 @@ end)
 			}
 			self.parts.wpn_fps_upg_o_rx30.perks = {"scope"}
 			self.parts.wpn_fps_upg_o_rx30.stance_mod = deep_clone(self.parts.wpn_fps_upg_o_docter.stance_mod)
-			
+
 			--Combat Sight
 			self.parts.wpn_fps_upg_o_cs.pcs = {}
 			self.parts.wpn_fps_upg_o_cs.has_description = true
-			self.parts.wpn_fps_upg_o_cs.desc_id = "bm_wp_upg_o_1_8"		
+			self.parts.wpn_fps_upg_o_cs.desc_id = "bm_wp_upg_o_1_8"
 			self.parts.wpn_fps_upg_o_cs.reticle_obj = nil
 			self.parts.wpn_fps_upg_o_cs.supported = true
 			self.parts.wpn_fps_upg_o_cs.stats = {
@@ -20482,7 +20482,7 @@ end)
 			self.parts.wpn_fps_upg_o_cs.adds = nil -- no
 			--Combat Sight Back-up Irons (lmao)
 			self.parts.wpn_fps_upg_o_cs_piggyback.stance_mod = deep_clone(self.parts.wpn_fps_upg_o_cs.stance_mod)
-			
+
 			for i, weap in pairs(self.parts.wpn_fps_upg_o_cs_piggyback.stance_mod) do
 				if weap and weap.translation then
 					weap.translation = weap.translation + Vector3(0, -10, -3.3)
@@ -20497,7 +20497,7 @@ end)
 			self.parts.wpn_fps_ak_extra_ris.override = nil
 
 			--Default Handguard
-			self.parts.wpn_upg_ak_fg_standard.override.wpn_fps_upg_o_specter.stance_mod = { 
+			self.parts.wpn_upg_ak_fg_standard.override.wpn_fps_upg_o_specter.stance_mod = {
 				wpn_fps_ass_akm = {
 					translation = Vector3(-0.006, -2, -3.145)
 				},
@@ -20579,7 +20579,7 @@ end)
 
 			self.parts.wpn_upg_ak_fg_standard.override.wpn_fps_upg_o_spot.stance_mod = deep_clone(self.parts.wpn_upg_ak_fg_standard.override.wpn_fps_upg_o_specter.stance_mod)
 			self.parts.wpn_upg_ak_fg_standard.override.wpn_fps_upg_o_poe.stance_mod = deep_clone(self.parts.wpn_upg_ak_fg_standard.override.wpn_fps_upg_o_specter.stance_mod)
-			
+
 			self.parts.wpn_upg_ak_fg_standard.override.wpn_fps_upg_o_acog.stance_mod = deep_clone(self.parts.wpn_upg_ak_fg_standard.override.wpn_fps_upg_o_specter.stance_mod)
 			for i, weap in pairs(self.parts.wpn_upg_ak_fg_standard.override.wpn_fps_upg_o_acog.stance_mod) do
 				if weap and weap.translation then
@@ -20606,7 +20606,7 @@ end)
 				concealment = -1,
 				spread = 1
 			}
-			
+
 			--The Tactical Russian Handguard
 			self.parts.wpn_upg_ak_fg_combo3.pcs = {
 				10,
@@ -20621,7 +20621,7 @@ end)
 				recoil = 2,
 				concealment = -2
 			}
-			
+
 			--(AK) Drum Mag
 			self.parts.wpn_upg_ak_m_drum = {
 				pcs = {},
@@ -20648,7 +20648,7 @@ end)
 			self.parts.wpn_upg_ak_m_drum_vanilla = deep_clone(self.parts.wpn_upg_ak_m_drum)
 			self.parts.wpn_upg_ak_m_drum_vanilla.stats = nil
 			self.parts.wpn_upg_ak_m_drum_vanilla.pcs = nil
-			
+
 			--(AK) Folding Stock
 			self.parts.wpn_upg_ak_s_folding.pcs = {
 				10,
@@ -20659,7 +20659,7 @@ end)
 			self.parts.wpn_upg_ak_s_folding.supported = true
 			self.parts.wpn_upg_ak_s_folding.stats = deep_clone(stocks.folder_to_nocheeks_stats)
 			self.parts.wpn_upg_ak_s_folding.custom_stats = deep_clone(stocks.folder_to_nocheeks_stats)
-			
+
 			--Wooden Sniper Stock
 			self.parts.wpn_upg_ak_s_psl.pcs = {
 				10,
@@ -20682,7 +20682,7 @@ end)
 				wpn_fps_ass_flint_g_standard = {
 					unit = "units/payday2/weapons/wpn_upg_dummy/wpn_upg_dummy",
 					third_unit = "units/payday2/weapons/wpn_upg_dummy/wpn_upg_dummy",
-				},	
+				},
 				wpn_fps_smg_coal_g_standard = {
 					unit = "units/payday2/weapons/wpn_upg_dummy/wpn_upg_dummy",
 					third_unit = "units/payday2/weapons/wpn_upg_dummy/wpn_upg_dummy",
@@ -20697,7 +20697,7 @@ end)
 				"wpn_fps_upg_ak_g_edg",
 				"wpn_fps_upg_ak_g_rk9"
 			}
-			
+
 			--(AK) Folding Stock
 			self.parts.wpn_upg_ak_s_skfoldable.pcs = {
 				10,
@@ -20712,7 +20712,7 @@ end)
 
 	--M4/AK pack
 		Hooks:PostHook(WeaponFactoryTweakData, "_init_modpack_m4_ak", "resmod_modpack_m4_ak", function(self)
-			
+
 			--DMR Kit
 			self.parts.wpn_fps_upg_ass_ak_b_zastava.pcs = {}
 			self.parts.wpn_fps_upg_ass_ak_b_zastava.supported = true
@@ -20724,7 +20724,7 @@ end)
 			self.parts.wpn_fps_upg_ak_b_ak105.supported = true
 			self.parts.wpn_fps_upg_ak_b_ak105.stats = deep_clone(barrels.short_b1_stats)
 			self.parts.wpn_fps_upg_ak_b_ak105.custom_stats = deep_clone(barrels.short_b1_stats)
-			
+
 			--Crabs Rail
 			self.parts.wpn_fps_upg_ak_fg_krebs.pcs = {}
 			self.parts.wpn_fps_upg_ak_fg_krebs.supported = true
@@ -20733,7 +20733,7 @@ end)
 				recoil = 2,
 				concealment = -1
 			}
-			self.parts.wpn_fps_upg_ak_fg_krebs.override.wpn_fps_upg_o_specter.stance_mod = { 
+			self.parts.wpn_fps_upg_ak_fg_krebs.override.wpn_fps_upg_o_specter.stance_mod = {
 				wpn_fps_ass_akm = {
 					translation = Vector3(-0.006, -2, -3.745)
 				},
@@ -20814,7 +20814,7 @@ end)
 
 			self.parts.wpn_fps_upg_ak_fg_krebs.override.wpn_fps_upg_o_spot.stance_mod = deep_clone(self.parts.wpn_fps_upg_ak_fg_krebs.override.wpn_fps_upg_o_specter.stance_mod)
 			self.parts.wpn_fps_upg_ak_fg_krebs.override.wpn_fps_upg_o_poe.stance_mod = deep_clone(self.parts.wpn_fps_upg_ak_fg_krebs.override.wpn_fps_upg_o_specter.stance_mod)
-			
+
 			self.parts.wpn_fps_upg_ak_fg_krebs.override.wpn_fps_upg_o_acog.stance_mod = deep_clone(self.parts.wpn_fps_upg_ak_fg_krebs.override.wpn_fps_upg_o_specter.stance_mod)
 			for i, weap in pairs(self.parts.wpn_fps_upg_ak_fg_krebs.override.wpn_fps_upg_o_acog.stance_mod) do
 				if weap and weap.translation then
@@ -20827,7 +20827,7 @@ end)
 					weap.translation = weap.translation + Vector3(0,10,0)
 				end
 			end
-			
+
 			--Keymod Rail
 			self.parts.wpn_fps_upg_ak_fg_trax.pcs = {}
 			self.parts.wpn_fps_upg_ak_fg_trax.supported = true
@@ -20837,7 +20837,7 @@ end)
 				recoil = 4,
 				concealment = -1
 			}
-			self.parts.wpn_fps_upg_ak_fg_trax.override.wpn_fps_upg_o_specter.stance_mod = { 
+			self.parts.wpn_fps_upg_ak_fg_trax.override.wpn_fps_upg_o_specter.stance_mod = {
 				wpn_fps_ass_akm = {
 					translation = Vector3(-0.006, -2, -3.745)
 				},
@@ -20918,7 +20918,7 @@ end)
 
 			self.parts.wpn_fps_upg_ak_fg_trax.override.wpn_fps_upg_o_spot.stance_mod = deep_clone(self.parts.wpn_fps_upg_ak_fg_trax.override.wpn_fps_upg_o_specter.stance_mod)
 			self.parts.wpn_fps_upg_ak_fg_trax.override.wpn_fps_upg_o_poe.stance_mod = deep_clone(self.parts.wpn_fps_upg_ak_fg_trax.override.wpn_fps_upg_o_specter.stance_mod)
-			
+
 			self.parts.wpn_fps_upg_ak_fg_trax.override.wpn_fps_upg_o_acog.stance_mod = deep_clone(self.parts.wpn_fps_upg_ak_fg_trax.override.wpn_fps_upg_o_specter.stance_mod)
 			for i, weap in pairs(self.parts.wpn_fps_upg_ak_fg_trax.override.wpn_fps_upg_o_acog.stance_mod) do
 				if weap and weap.translation then
@@ -20940,7 +20940,7 @@ end)
 			table.insert(self.parts.wpn_fps_upg_ak_fg_zenit.forbids, "wpn_fps_pis_usp_fl_adapter")
 			self.parts.wpn_fps_upg_ak_fg_zenit.override.wpn_fps_upg_o_specter = {
 				a_obj = "a_o_zenit",
-				stance_mod = { 
+				stance_mod = {
 					wpn_fps_smg_akmsu = {
 						translation = Vector3(-0.006, -1, -3.24)
 					}
@@ -21011,7 +21011,7 @@ end)
 			end
 
 			self.parts.wpn_fps_smg_akmsu_fg_standard.override.wpn_fps_upg_o_poe.stance_mod = deep_clone(self.parts.wpn_fps_smg_akmsu_fg_standard.override.wpn_fps_upg_o_specter.stance_mod)
-			
+
 			self.parts.wpn_fps_smg_akmsu_fg_standard.override.wpn_fps_upg_o_acog.stance_mod = deep_clone(self.parts.wpn_fps_smg_akmsu_fg_standard.override.wpn_fps_upg_o_specter.stance_mod)
 			for i, weap in pairs(self.parts.wpn_fps_smg_akmsu_fg_standard.override.wpn_fps_upg_o_acog.stance_mod) do
 				if weap and weap.translation then
@@ -21025,7 +21025,7 @@ end)
 				end
 			end
 
-			
+
 			--Aluminum Grip
 			self.parts.wpn_fps_upg_ak_g_rk3.pcs = {}
 			self.parts.wpn_fps_upg_ak_g_rk3.supported = true
@@ -21035,7 +21035,7 @@ end)
 				"wpn_upg_ak_g_standard",
 				"wpn_fps_ass_asval_g_standard"
 			}
-			
+
 			--Low Drag Magazine
 			self.parts.wpn_fps_upg_ak_m_uspalm.pcs = {}
 			self.parts.wpn_fps_upg_ak_m_uspalm.supported = true
@@ -21044,13 +21044,13 @@ end)
 				recoil = -2,
 				concealment = 1
 			}
-			
+
 			--Classic Stock
 			self.parts.wpn_fps_upg_ak_s_solidstock.pcs = {}
 			self.parts.wpn_fps_upg_ak_s_solidstock.supported = true
 			self.parts.wpn_fps_upg_ak_s_solidstock.stats = deep_clone(stocks.nocheeks_to_fixed_rec3_stats)
 			self.parts.wpn_fps_upg_ak_s_solidstock.custom_stats = deep_clone(stocks.nocheeks_to_fixed_rec3_stats)
-			
+
 			--PBS Suppressor
 			self.parts.wpn_fps_upg_ns_ass_pbs1.pcs = {}
 			self.parts.wpn_fps_upg_ns_ass_pbs1.has_description = true
@@ -21062,7 +21062,7 @@ end)
 				alert_size = -1
 			}
 			self.parts.wpn_fps_upg_ns_ass_pbs1.perks = {"silencer"}
-			
+
 			--Scope Mount
 			self.parts.wpn_fps_upg_o_ak_scopemount.pcs = {}
 			self.parts.wpn_fps_upg_o_ak_scopemount.supported = true
@@ -21214,18 +21214,18 @@ end)
 
 
 			--OVAL Foregrip
-			self.parts.wpn_fps_upg_ass_m4_fg_lvoa.pcs = {}	
-			self.parts.wpn_fps_upg_ass_m4_fg_lvoa.forbids = { "wpn_fps_addon_ris" }	
+			self.parts.wpn_fps_upg_ass_m4_fg_lvoa.pcs = {}
+			self.parts.wpn_fps_upg_ass_m4_fg_lvoa.forbids = { "wpn_fps_addon_ris" }
 			self.parts.wpn_fps_upg_ass_m4_fg_lvoa.supported = true
 			self.parts.wpn_fps_upg_ass_m4_fg_lvoa.stats = {
 				value = 5,
 				concealment = -1,
 				recoil = 2
 			}
-			
+
 			--E.M.O. Foregrip
 			self.parts.wpn_fps_upg_ass_m4_fg_moe.pcs = {}
-			self.parts.wpn_fps_upg_ass_m4_fg_moe.forbids = { "wpn_fps_addon_ris" }	
+			self.parts.wpn_fps_upg_ass_m4_fg_moe.forbids = { "wpn_fps_addon_ris" }
 			self.parts.wpn_fps_upg_ass_m4_fg_moe.override.wpn_fps_m4_uupg_fg_rail_ext_dummy = {
 				unit = "units/pd2_dlc_opera/weapons/wpn_fps_ass_tecci_pts/wpn_fps_ass_tecci_b_standard",
 				third_unit = "units/pd2_dlc_opera/weapons/wpn_fps_ass_tecci_pts/wpn_third_ass_tecci_b_standard"
@@ -21240,7 +21240,7 @@ end)
 				spread = -1,
 				recoil = 2
 			}
-			
+
 			--Long Ergo Foregrip
 			self.parts.wpn_fps_upg_ass_m16_fg_stag.pcs = {}
 			self.parts.wpn_fps_upg_ass_m16_fg_stag.supported = true
@@ -21250,7 +21250,7 @@ end)
 				recoil = -2,
 				spread = 1
 			}
-			
+
 			--Aftermarket Shorty
 			self.parts.wpn_fps_upg_smg_olympic_fg_lr300.pcs = {}
 			self.parts.wpn_fps_upg_smg_olympic_fg_lr300.supported = true
@@ -21259,7 +21259,7 @@ end)
 				recoil = -2,
 				concealment = 1
 			}
-			
+
 			--LW Upper Receiver
 			self.parts.wpn_fps_upg_ass_m4_upper_reciever_ballos.pcs = {}
 			self.parts.wpn_fps_upg_ass_m4_upper_reciever_ballos.supported = true
@@ -21277,7 +21277,7 @@ end)
 				recoil = -2,
 				spread = 1
 			}
-			
+
 			--THRUST Upper Receiver
 			self.parts.wpn_fps_upg_ass_m4_upper_reciever_core.pcs = {}
 			self.parts.wpn_fps_upg_ass_m4_upper_reciever_core.supported = true
@@ -21295,7 +21295,7 @@ end)
 				recoil = 2,
 				concealment = -1
 			}
-			
+
 			--THRUST Lower Receiver
 			self.parts.wpn_fps_upg_ass_m4_lower_reciever_core.pcs = {}
 			self.parts.wpn_fps_upg_ass_m4_lower_reciever_core.supported = true
@@ -21304,7 +21304,7 @@ end)
 				recoil = -2,
 				reload = 1
 			}
-			
+
 			--L5 Magazine
 			self.parts.wpn_fps_upg_m4_m_l5.pcs = {}
 			self.parts.wpn_fps_upg_m4_m_l5.supported = true
@@ -21313,13 +21313,13 @@ end)
 				recoil = 2,
 				concealment = -1
 			}
-			
+
 			--2 Piece Stock
 			self.parts.wpn_fps_upg_m4_s_ubr.pcs = {}
 			self.parts.wpn_fps_upg_m4_s_ubr.supported = true
 			self.parts.wpn_fps_upg_m4_s_ubr.stats = deep_clone(stocks.adj_hvy_rec_stats)
 			self.parts.wpn_fps_upg_m4_s_ubr.custom_stats = deep_clone(stocks.adj_hvy_rec_stats)
-			
+
 			--DMR Kit
 			self.parts.wpn_fps_upg_ass_m4_b_beowulf.pcs = {}
 			self.parts.wpn_fps_upg_ass_m4_b_beowulf.override = {
@@ -21353,10 +21353,10 @@ end)
 				ignore_rof_mult_anims = true,
 				rof_mult = 0.85
 			}
-			self.parts.wpn_fps_saw_body_silent.perks = {"silencer"}	
+			self.parts.wpn_fps_saw_body_silent.perks = {"silencer"}
 			self.parts.wpn_fps_saw_body_silent.has_description = true
 			self.parts.wpn_fps_saw_body_silent.desc_id = "bm_slow_motor_sc_desc"
-			
+
 			--Fast Motor
 			self.parts.wpn_fps_saw_body_speed.pcs = {}
 			self.parts.wpn_fps_saw_body_speed.supported = true
@@ -21370,7 +21370,7 @@ end)
 			}
 			self.parts.wpn_fps_saw_body_speed.has_description = true
 			self.parts.wpn_fps_saw_body_speed.desc_id = "bm_fast_motor_sc_desc"
-			
+
 			--Durable Blade
 			self.parts.wpn_fps_saw_m_blade_durable.pcs = {}
 			self.parts.wpn_fps_saw_m_blade_durable.supported = true
@@ -21381,7 +21381,7 @@ end)
 				damage = -30,
 				total_ammo_mod = 202
 			}
-			
+
 			--Sharp Blade
 			self.parts.wpn_fps_saw_m_blade_sharp.pcs = {}
 			self.parts.wpn_fps_saw_m_blade_sharp.supported = true
@@ -21392,7 +21392,7 @@ end)
 				damage = 30,
 				total_ammo_mod = -102
 			}
-			
+
 			--Raptor Polymer Body/Thales F88/90 Stock
 			self.parts.wpn_fps_aug_body_f90.pcs = {}
 			self.parts.wpn_fps_aug_body_f90.supported = true
@@ -21406,7 +21406,7 @@ end)
 				ads_speed_mult = 1.05
 			}
 			self.parts.wpn_fps_aug_body_f90.adds = nil
-			
+
 			--CQB Barrel
 			self.parts.wpn_fps_ass_ak5_b_short.pcs = {}
 			self.parts.wpn_fps_ass_ak5_b_short.supported = true
@@ -21420,7 +21420,7 @@ end)
 				falloff_end_mult = 0.9,
 				ads_speed_mult = 0.95
 			}
-			
+
 			--Straight Magazine
 			self.parts.wpn_fps_smg_mp5_m_straight.pcs = {}
 			self.parts.wpn_fps_smg_mp5_m_straight.supported = true
@@ -21433,7 +21433,7 @@ end)
 				damage_min_mult = 2,
 				rof_mult = 0.975
 			}
-			
+
 			--Tactical Suppressor
 			self.parts.wpn_fps_smg_mp9_b_suppressed.pcs = {}
 			self.parts.wpn_fps_smg_mp9_b_suppressed.supported = true
@@ -21445,13 +21445,13 @@ end)
 				alert_size = -1
 			}
 			self.parts.wpn_fps_smg_mp9_b_suppressed.perks = {"silencer"}
-			
+
 			--Civilian Market Barrel
 			self.parts.wpn_fps_smg_p90_b_civilian.pcs = {}
 			self.parts.wpn_fps_smg_p90_b_civilian.supported = true
 			self.parts.wpn_fps_smg_p90_b_civilian.stats = deep_clone(barrels.long_b3_stats)
 			self.parts.wpn_fps_smg_p90_b_civilian.custom_stats = deep_clone(barrels.long_b3_stats)
-			
+
 			--Mall Ninja Barrel
 			self.parts.wpn_fps_smg_p90_b_ninja.pcs = {}
 			self.parts.wpn_fps_smg_p90_b_ninja.supported = true
@@ -21463,7 +21463,7 @@ end)
 				alert_size = -1
 			}
 			self.parts.wpn_fps_smg_p90_b_ninja.perks = {"silencer"}
-			
+
 			--Scope Mount
 			self.parts.wpn_fps_upg_o_m14_scopemount.pcs = {}
 			self.parts.wpn_fps_upg_o_m14_scopemount.depends_on = nil
@@ -21477,7 +21477,7 @@ end)
 			self.parts.wpn_fps_upg_o_m14_scopemount.override.wpn_fps_gre_arbiter_o_standard = {
 				a_obj = "a_o_sm",
 				stance_mod = {
-					wpn_fps_ass_m14 = { 
+					wpn_fps_ass_m14 = {
 						translation = Vector3(-0.02, -9, -5.05),
 						rotation = Rotation(0, 0.43, 0)
 					}
@@ -21552,7 +21552,7 @@ end)
 
 			self.parts.wpn_fps_upg_o_m14_scopemount.override.wpn_fps_upg_o_spot.stance_mod = deep_clone(self.parts.wpn_fps_upg_o_m14_scopemount.override.wpn_fps_upg_o_specter.stance_mod)
 			self.parts.wpn_fps_upg_o_m14_scopemount.override.wpn_fps_upg_o_poe.stance_mod = deep_clone(self.parts.wpn_fps_upg_o_m14_scopemount.override.wpn_fps_upg_o_specter.stance_mod)
-			
+
 			self.parts.wpn_fps_upg_o_m14_scopemount.override.wpn_fps_upg_o_acog.stance_mod = deep_clone(self.parts.wpn_fps_upg_o_m14_scopemount.override.wpn_fps_upg_o_specter.stance_mod)
 			for i, weap in pairs(self.parts.wpn_fps_upg_o_m14_scopemount.override.wpn_fps_upg_o_acog.stance_mod) do
 				if weap and weap.translation then
@@ -21597,12 +21597,12 @@ end)
 					weap.rotation = (weap.rotation or Rotation(0,0,0)) * Rotation(-0.07, 0, 0)
 				end
 			end
-			
+
 			--Engraved Crosskill Grips
 			self.parts.wpn_fps_pis_1911_g_engraved.pcs = {}
 			self.parts.wpn_fps_pis_1911_g_engraved.supported = true
 			self.parts.wpn_fps_pis_1911_g_engraved.stats = deep_clone(grips.acc_dual)
-			
+
 			--Engraved Bernetti Grips
 			self.parts.wpn_fps_pis_beretta_g_engraved.pcs = {}
 			self.parts.wpn_fps_pis_beretta_g_engraved.supported = true
@@ -21616,7 +21616,7 @@ end)
 				value = 5
 			}
 			self.parts.wpn_fps_upg_fl_ass_utg.perks = {"gadget"}
-			
+
 			--Polymer Flashlight
 			self.parts.wpn_fps_upg_fl_pis_m3x.pcs = {}
 			self.parts.wpn_fps_upg_fl_pis_m3x.supported = true
@@ -21624,13 +21624,13 @@ end)
 			self.parts.wpn_fps_upg_fl_pis_m3x.stats = {
 				value = 3
 			}
-			
+
 			--Ported Compensator
 			self.parts.wpn_fps_upg_ass_ns_battle.pcs = {}
 			self.parts.wpn_fps_upg_ass_ns_battle.supported = true
 			self.parts.wpn_fps_upg_ass_ns_battle.stats = deep_clone(muzzle_device.muzz_rec_a)
 			self.parts.wpn_fps_upg_ass_ns_battle.custom_stats = deep_clone(muzzle_device.muzz_rec_a)
-			
+
 			--Budget Suppressor
 			self.parts.wpn_fps_upg_ns_ass_filter.pcs = {}
 			self.parts.wpn_fps_upg_ns_ass_filter.supported = true
@@ -21642,7 +21642,7 @@ end)
 				alert_size = -1
 			}
 			self.parts.wpn_fps_upg_ns_ass_filter.perks = {"silencer"}
-			
+
 			--Jungle Ninja Suppressor
 			self.parts.wpn_fps_upg_ns_pis_jungle.pcs = {}
 			self.parts.wpn_fps_upg_ns_pis_jungle.supported = true
@@ -21651,7 +21651,7 @@ end)
 			self.parts.wpn_fps_upg_ns_pis_jungle.stats = deep_clone(muzzle_device.supp_dual2_c)
 			self.parts.wpn_fps_upg_ns_pis_jungle.custom_stats= deep_clone(muzzle_device.supp_dual2_c)
 			self.parts.wpn_fps_upg_ns_pis_jungle.perks = {"silencer"}
-			
+
 			--Shh!
 			self.parts.wpn_fps_upg_ns_sho_salvo_large.pcs = {}
 			self.parts.wpn_fps_upg_ns_sho_salvo_large.supported = true
@@ -21678,7 +21678,7 @@ end)
 			self.parts.wpn_fps_upg_bp_lmg_lionbipod.desc_id = "bm_sc_bipod_desc"
 			self.parts.wpn_fps_upg_bp_lmg_lionbipod.supported = true
 			self.parts.wpn_fps_upg_bp_lmg_lionbipod.stats = {
-				value = 5, 
+				value = 5,
 				concealment = -3,
 				recoil = 2
 			}
@@ -21695,12 +21695,12 @@ end)
 			self.parts.wpn_fps_sho_saiga_b_short.supported = true
 			self.parts.wpn_fps_sho_saiga_b_short.stats = deep_clone(barrels.short_b3_stats)
 			self.parts.wpn_fps_sho_saiga_b_short.custom_stats = deep_clone(barrels.short_b3_stats)
-			
+
 			--Hollow Handle
 			self.parts.wpn_fps_sho_saiga_fg_holy.pcs = {}
 			self.parts.wpn_fps_sho_saiga_fg_holy.supported = true
 			self.parts.wpn_fps_sho_saiga_fg_holy.stats = {value = 3, recoil = -2, concealment = 1}
-			
+
 			--45 RDS
 			self.parts.wpn_fps_upg_o_45rds.pcs = {}
 			self.parts.wpn_fps_upg_o_45rds.desc_id = "bm_wp_upg_o_angled_1_1_desc"
@@ -21716,11 +21716,11 @@ end)
 				translation = Vector3(-0.75, 0, -12.8),
 				rotation = Rotation(0, 0, -45)
 			}
-			
+
 			--Reconnaissance Sight/NcSTAR Advance Dual Optic
 			self.parts.wpn_fps_upg_o_spot.pcs = {}
 			self.parts.wpn_fps_upg_o_spot.has_description = true
-			self.parts.wpn_fps_upg_o_spot.desc_id = "bm_wp_upg_o_3_range"	
+			self.parts.wpn_fps_upg_o_spot.desc_id = "bm_wp_upg_o_3_range"
 			self.parts.wpn_fps_upg_o_spot.supported = true
 			self.parts.wpn_fps_upg_o_spot.stats = {
 				value = 8,
@@ -21737,7 +21737,7 @@ end)
 				--"wpn_fps_ass_shak12_o_carry_dummy"
 			}
 			self.parts.wpn_fps_upg_o_spot.stance_mod = deep_clone(self.parts.wpn_fps_upg_o_specter.stance_mod)
-			
+
 			--Box Buddy Sight/Pulsar Digisight LRF
 			self.parts.wpn_fps_upg_o_box.pcs = {}
 			self.parts.wpn_fps_upg_o_box.desc_id = "bm_wp_upg_o_4_range"
@@ -21836,9 +21836,9 @@ end)
 				steelsight_id = part_id .. "_steelsight"
 				self.parts[part_id].steelsight_visible = false
 				self.parts[part_id].adds = self.parts[part_id].adds or {}
-			
+
 				table.insert(self.parts[part_id].adds, steelsight_id)
-			
+
 				self.parts[steelsight_id] = steelsight_data
 				self.parts[steelsight_id].steelsight_visible = true
 				self.parts[steelsight_id].steelsight_parent = part_id
@@ -21865,7 +21865,7 @@ end)
 			--Vintage Sight
 			self.parts.wpn_fps_ass_g36_o_vintage.pcs = {}
 			self.parts.wpn_fps_ass_g36_o_vintage.has_description = true
-			self.parts.wpn_fps_ass_g36_o_vintage.desc_id = "bm_wp_upg_o_1_8"	
+			self.parts.wpn_fps_ass_g36_o_vintage.desc_id = "bm_wp_upg_o_1_8"
 			self.parts.wpn_fps_ass_g36_o_vintage.reticle_obj = nil
 			self.parts.wpn_fps_ass_g36_o_vintage.supported = true
 			self.parts.wpn_fps_ass_g36_o_vintage.stance_mod = {
@@ -21879,13 +21879,13 @@ end)
 				zoom = 8
 			}
 			self.parts.wpn_fps_ass_g36_o_vintage.perks = {"scope"}
-			
+
 			--JP36 Long Foregrip
 			self.parts.wpn_fps_upg_g36_fg_long.pcs = {}
 			self.parts.wpn_fps_upg_g36_fg_long.supported = true
 			self.parts.wpn_fps_upg_g36_fg_long.stats = deep_clone(barrels.long_b3_stats)
 			self.parts.wpn_fps_upg_g36_fg_long.custom_stats = deep_clone(barrels.long_b3_stats)
-			
+
 			--Enlightened Foregrip
 			self.parts.wpn_fps_smg_mp5_fg_flash.pcs = {}
 			self.parts.wpn_fps_smg_mp5_fg_flash.supported = true
@@ -21897,13 +21897,13 @@ end)
 			}
 			self.parts.wpn_fps_smg_mp5_fg_flash.perks = {"gadget"}
 			self.parts.wpn_fps_smg_mp5_fg_flash.sub_type = "flashlight"
-			
+
 			--Spartan Stock
 			self.parts.wpn_fps_smg_mp5_s_folding.pcs = {}
 			self.parts.wpn_fps_smg_mp5_s_folding.supported = true
 			self.parts.wpn_fps_smg_mp5_s_folding.stats = deep_clone(stocks.fixed_to_folder_stats)
 			self.parts.wpn_fps_smg_mp5_s_folding.custom_stats = deep_clone(stocks.fixed_to_folder_stats)
-			
+
 			--Donald's Horizontal Leveller
 			self.parts.wpn_fps_upg_ns_duck.pcs = {}
 			self.parts.wpn_fps_upg_ns_duck.desc_id = "bm_wp_ns_duck_desc_sc"
@@ -21914,7 +21914,7 @@ end)
 				spread_multi = {1.5, 0.5}
 			}
 			self.parts.wpn_fps_upg_ns_duck.custom_stats = {}
-			
+
 			self.parts.wpn_fps_pis_usp_m_big.pcs = {}
 			self.parts.wpn_fps_pis_usp_m_big.supported = true
 			self.parts.wpn_fps_pis_usp_m_big.stats = {
@@ -21926,19 +21926,19 @@ end)
 			self.parts.wpn_fps_pis_usp_m_big.custom_stats = {
 				ads_speed_mult = 1.075
 			}
-			
+
 			self.parts.wpn_fps_pis_1911_m_big.pcs = {}
 			self.parts.wpn_fps_pis_1911_m_big.supported = true
 			self.parts.wpn_fps_pis_1911_m_big.stats = {
 				value = 2,
 				concealment = -2,
-				extra_ammo = 6,	
+				extra_ammo = 6,
 				reload = -4
 			}
 			self.parts.wpn_fps_pis_1911_m_big.custom_stats = {
 				ads_speed_mult = 1.05
 			}
-			
+
 			self.parts.wpn_fps_smg_p90_m_strap.pcs = {}
 			self.parts.wpn_fps_smg_p90_m_strap.supported = true
 			self.parts.wpn_fps_smg_p90_m_strap.stats = {
@@ -21947,7 +21947,7 @@ end)
 				concealment = -1,
 				reload = 3
 			}
-			
+
 			self.parts.wpn_fps_ass_aug_m_quick.pcs = {}
 			self.parts.wpn_fps_ass_aug_m_quick.supported = true
 			self.parts.wpn_fps_ass_aug_m_quick.stats = {
@@ -21956,7 +21956,7 @@ end)
 				concealment = -1,
 				reload = 3
 			}
-			
+
 			self.parts.wpn_fps_m4_upg_m_quick.pcs = {}
 			self.parts.wpn_fps_m4_upg_m_quick.supported = true
 			self.parts.wpn_fps_m4_upg_m_quick.stats = {
@@ -21965,7 +21965,7 @@ end)
 				concealment = -1,
 				reload = 3
 			}
-			
+
 			self.parts.wpn_fps_upg_ak_m_quick.pcs = {}
 			self.parts.wpn_fps_upg_ak_m_quick.supported = true
 			self.parts.wpn_fps_upg_ak_m_quick.stats = {
@@ -21974,16 +21974,16 @@ end)
 				concealment = -1,
 				reload = 3
 			}
-			
+
 			self.parts.wpn_fps_ass_g36_m_quick.pcs = {}
-			self.parts.wpn_fps_ass_g36_m_quick.supported = true		
+			self.parts.wpn_fps_ass_g36_m_quick.supported = true
 			self.parts.wpn_fps_ass_g36_m_quick.stats = {
 				value = 2,
 				spread = -1,
 				concealment = -1,
 				reload = 3
 			}
-			
+
 			self.parts.wpn_fps_smg_mac10_m_quick.pcs = {}
 			self.parts.wpn_fps_smg_mac10_m_quick.supported = true
 			self.parts.wpn_fps_smg_mac10_m_quick.stats = {
@@ -21995,8 +21995,8 @@ end)
 			self.parts.wpn_fps_smg_mac10_m_quick.custom_stats = {
 				ads_speed_mult = 1.025
 			}
-			
-			
+
+
 			self.parts.wpn_fps_smg_sr2_m_quick.pcs = {}
 			self.parts.wpn_fps_smg_sr2_m_quick.supported = true
 			self.parts.wpn_fps_smg_sr2_m_quick.stats = {
@@ -22026,7 +22026,7 @@ end)
 			}
 			self.parts.wpn_fps_upg_o_xpsg33_magnifier.perks = {"gadget"}
 			self.parts.wpn_fps_upg_o_xpsg33_magnifier.stance_mod = deep_clone(self.parts.wpn_fps_upg_o_specter.stance_mod)
-			
+
 			--Angled Sight v2
 			self.parts.wpn_fps_upg_o_45rds_v2.pcs = {
 				10,
@@ -22058,7 +22058,7 @@ end)
 			self.parts.wpn_fps_upg_ns_ass_smg_v6.supported = true
 			self.parts.wpn_fps_upg_ns_ass_smg_v6.stats = deep_clone(muzzle_device.muzz_rec2_a)
 			self.parts.wpn_fps_upg_ns_ass_smg_v6.custom_stats = deep_clone(muzzle_device.muzz_rec2_a)
-			
+
 			--Titanuim Skeleton Grip
 			self.parts.wpn_fps_upg_g_m4_surgeon.pcs = {
 				10,
@@ -22088,7 +22088,7 @@ end)
 				"gadget"
 			}
 			self.parts.wpn_fps_upg_o_sig.stance_mod = deep_clone(self.parts.wpn_fps_upg_o_xpsg33_magnifier.stance_mod)
-			
+
 			--Advanced Combat/Trijicon ACOG 6x48
 			self.parts.wpn_fps_upg_o_bmg.reticle_obj = nil
 			self.parts.wpn_fps_upg_o_bmg.has_description = true
@@ -22119,7 +22119,7 @@ end)
 				"wpn_fps_upg_o_xpsg33_magnifier",
 				"wpn_fps_upg_o_sig"
 			}
-			
+
 			self.parts.wpn_fps_upg_o_rms.has_description = true
 			self.parts.wpn_fps_upg_o_rms.desc_id = "bm_wp_upg_o_1_1"
 			self.parts.wpn_fps_upg_o_rms.pcs = {
@@ -22146,7 +22146,7 @@ end)
 				translation = Vector3(0.005, 9, -2.12* 1.425),
 				--rotation = Rotation(0.13, 0,0 )
 			}
-			
+
 			self.parts.wpn_fps_upg_o_rikt.has_description = true
 			self.parts.wpn_fps_upg_o_rikt.desc_id = "bm_wp_upg_o_1_2"
 			self.parts.wpn_fps_upg_o_rikt.pcs = {
@@ -22192,7 +22192,7 @@ end)
 				"scope"
 			}
 			self.parts.wpn_fps_upg_o_uh.stance_mod = deep_clone(self.parts.wpn_fps_upg_o_eotech.stance_mod)
-			
+
 			--Compact Profile/DI Optical FC1 Sight
 			self.parts.wpn_fps_upg_o_fc1.has_description = true
 			self.parts.wpn_fps_upg_o_fc1.desc_id = "bm_wp_upg_o_1_5_pris"
@@ -22211,7 +22211,7 @@ end)
 				"scope"
 			}
 			self.parts.wpn_fps_upg_o_fc1.stance_mod = deep_clone(self.parts.wpn_fps_upg_o_eotech.stance_mod)
-			
+
 			self.parts.wpn_fps_upg_o_45steel.pcs = {
 				10,
 				20,
@@ -22243,7 +22243,7 @@ end)
 
 	--ATW Mods
 		Hooks:PostHook(WeaponFactoryTweakData, "_init_atw_mod", "resmod_atw_mod", function(self)
-			
+
 			--B-Team Stock
 			self.parts.wpn_fps_ass_m14_body_ruger.pcs = {
 				10,
@@ -22532,7 +22532,7 @@ end)
 				if weap and weap.translation then
 					weap.translation = weap.translation + Vector3(0,10,0)
 				end
-			end	
+			end
 
 			self.parts.wpn_fps_upg_ak_body_upperreceiver_zenitco.override.wpn_fps_upg_o_northtac = deep_clone(self.parts.wpn_fps_upg_ak_body_upperreceiver_zenitco.override.wpn_fps_upg_o_specter)
 			for i, weap in pairs(self.parts.wpn_fps_upg_ak_body_upperreceiver_zenitco.override.wpn_fps_upg_o_northtac.stance_mod) do
@@ -22645,7 +22645,7 @@ end)
 
 			self.parts.wpn_fps_upg_o_northtac.supported = true
 			self.parts.wpn_fps_upg_o_northtac.desc_id = "bm_wp_upg_o_4_rds_mount"
-			self.parts.wpn_fps_upg_o_northtac.has_description = true		
+			self.parts.wpn_fps_upg_o_northtac.has_description = true
 			self.parts.wpn_fps_upg_o_northtac.has_second_sight = true
 			self.parts.wpn_fps_upg_o_northtac.stats = {
 				value = 8,
@@ -22707,7 +22707,7 @@ end)
 					weap.rotation = (weap.rotation or Rotation(0,0,0)) * Rotation(-0.07, 0, 0)
 				end
 			end
-			
+
 
 			--Verge
 			self.parts.wpn_fps_upg_ak_g_edg.supported = true
@@ -22717,7 +22717,7 @@ end)
 				"wpn_upg_ak_g_standard",
 				"wpn_fps_ass_asval_g_standard"
 			}
-			
+
 			--Ergonomic
 			self.parts.wpn_fps_upg_ak_g_gradus.supported = true
 			self.parts.wpn_fps_upg_ak_g_gradus.stats = deep_clone(grips.quickdraw_1)
@@ -22730,7 +22730,7 @@ end)
 			--Ultimatum
 			self.parts.wpn_fps_upg_ak_g_rk9.supported = true
 			self.parts.wpn_fps_upg_ak_g_rk9.stats = deep_clone(grips.dual_stat_1)
-			self.parts.wpn_fps_upg_ak_g_rk9.custom_stats = deep_clone(grips.dual_stat_1)	
+			self.parts.wpn_fps_upg_ak_g_rk9.custom_stats = deep_clone(grips.dual_stat_1)
 			self.parts.wpn_fps_upg_ak_g_rk9.forbids = {
 				"wpn_upg_ak_g_standard",
 				"wpn_fps_ass_asval_g_standard"
@@ -22739,7 +22739,7 @@ end)
 			self.parts.wpn_fps_upg_ak_ns_jmac.supported = true
 			self.parts.wpn_fps_upg_ak_ns_jmac.stats = deep_clone(muzzle_device.muzz_acc_c)
 			self.parts.wpn_fps_upg_ak_ns_jmac.custom_stats = deep_clone(muzzle_device.muzz_acc_c)
-			
+
 			self.parts.wpn_fps_upg_ak_ns_tgp.supported = true
 			self.parts.wpn_fps_upg_ak_ns_tgp.has_description = true
 			self.parts.wpn_fps_upg_ak_ns_tgp.desc_id = "bm_wp_upg_suppressor"
@@ -22787,13 +22787,13 @@ end)
 
 	--Promotional mods
 		Hooks:PostHook(WeaponFactoryTweakData, "_init_icc", "resmod_icc", function(self)
-			
+
 			--OMNIA Assault Frame
 			self.parts.wpn_fps_smg_p90_body_boxy.pcs = {}
 			self.parts.wpn_fps_smg_p90_body_boxy.supported = true
 			self.parts.wpn_fps_smg_p90_body_boxy.stats = {value = 0}
 			self.parts.wpn_fps_smg_p90_body_boxy.forbids = { "wpn_fps_addon_ris" }
-			
+
 			--Custom Built Frame
 			self.parts.wpn_fps_smg_mac10_body_modern.pcs = {}
 			self.parts.wpn_fps_smg_mac10_body_modern.supported = true
@@ -22801,7 +22801,7 @@ end)
 			self.parts.wpn_fps_smg_mac10_body_modern.adds = {
 				"wpn_fps_smg_mac10_vg_block"
 			}
-			
+
 			--Custom Milled Barrel
 			self.parts.wpn_fps_pis_deagle_b_modern.pcs = {}
 			self.parts.wpn_fps_pis_deagle_b_modern.supported = true
@@ -22820,7 +22820,7 @@ end)
 			self.parts.wpn_fps_pis_beretta_body_modern.pcs = {}
 			self.parts.wpn_fps_pis_beretta_body_modern.supported = true
 			self.parts.wpn_fps_pis_beretta_body_modern.stats = {value = 0}
-			
+
 			--Custom Reinforced Frame
 			self.parts.wpn_fps_pis_judge_body_modern.pcs = {}
 			self.parts.wpn_fps_pis_judge_body_modern.supported = true
@@ -22837,13 +22837,13 @@ end)
 			self.parts.wpn_fps_upg_a_slug.supported = true
 			self.parts.wpn_fps_upg_a_slug.stats = deep_clone(shot_ammo.a_slug_heavy_override.stats)
 			self.parts.wpn_fps_upg_a_slug.custom_stats = deep_clone(shot_ammo.a_slug_heavy_override.custom_stats)
-			
+
 			--000 Buck
 			self.parts.wpn_fps_upg_a_custom.pcs = {}
 			self.parts.wpn_fps_upg_a_custom.supported = true
 			self.parts.wpn_fps_upg_a_custom.stats = deep_clone(shot_ammo.a_custom_heavy_override.stats)
 			self.parts.wpn_fps_upg_a_custom.custom_stats = deep_clone(shot_ammo.a_custom_heavy_override.custom_stats)
-			
+
 			--000 Buck (Free)
 			self.parts.wpn_fps_upg_a_custom_free = deep_clone(self.parts.wpn_fps_upg_a_custom)
 			self.parts.wpn_fps_upg_a_custom_free.dlc = nil
@@ -22856,7 +22856,7 @@ end)
 			self.parts.wpn_fps_upg_a_explosive.supported = true
 			self.parts.wpn_fps_upg_a_explosive.stats = deep_clone(shot_ammo.a_explosive_heavy_override.stats)
 			self.parts.wpn_fps_upg_a_explosive.custom_stats = deep_clone(shot_ammo.a_explosive_heavy_override.custom_stats)
-			
+
 			--Flechettes
 			self.parts.wpn_fps_upg_a_piercing.name_id = "bm_wp_upg_a_piercing"
 			self.parts.wpn_fps_upg_a_piercing.desc_id = shot_ammo.a_piercing_heavy_override.desc_id
@@ -22895,7 +22895,7 @@ end)
 			self.parts.wpn_fps_upg_a_underbarrel_frag_groza.stats = {}
 			self.parts.wpn_fps_upg_a_underbarrel_frag_groza.custom_stats = {
 				launcher_grenade = "launcher_m203"
-			}	
+			}
 			--Underbarrel Electric Grenades
 			self.parts.wpn_fps_upg_a_underbarrel_electric.pcs = {}
 			self.parts.wpn_fps_upg_a_underbarrel_electric.has_description = true
@@ -22904,7 +22904,7 @@ end)
 			self.parts.wpn_fps_upg_a_underbarrel_electric.stats = {}
 			self.parts.wpn_fps_upg_a_underbarrel_electric.custom_stats = {
 				launcher_grenade = "underbarrel_electric"
-			}		
+			}
 
 			--Incendiary Round
 			self.parts.wpn_fps_upg_a_grenade_launcher_incendiary.pcs = {}
@@ -22924,7 +22924,7 @@ end)
 			self.parts.wpn_fps_upg_a_grenade_launcher_electric.stats = { damage = -36 }
 			self.parts.wpn_fps_upg_a_grenade_launcher_electric.custom_stats = {
 				launcher_grenade = "launcher_electric"
-			}			
+			}
 			--Poison Gas (Normal GLs)
 			self.parts.wpn_fps_upg_a_grenade_launcher_poison.pcs = {}
 			self.parts.wpn_fps_upg_a_grenade_launcher_poison.has_description = true
@@ -22939,8 +22939,8 @@ end)
 			self.parts.wpn_fps_upg_a_underbarrel_poison.has_description = true
 			self.parts.wpn_fps_upg_a_underbarrel_poison.desc_id = "bm_wp_upg_a_grenade_launcher_poison_desc_sc"
 			self.parts.wpn_fps_upg_a_underbarrel_poison.supported = true
-			
-			
+
+
 			--Incendiary Round (Arbiter)
 			self.parts.wpn_fps_upg_a_grenade_launcher_incendiary_arbiter.pcs = {}
 			self.parts.wpn_fps_upg_a_grenade_launcher_incendiary_arbiter.has_description = true
@@ -22994,7 +22994,7 @@ end)
 			self.parts.wpn_fps_upg_a_grenade_launcher_poison_ms3gl.stats = { damage = -33 }
 			self.parts.wpn_fps_upg_a_grenade_launcher_poison_ms3gl.custom_stats = {
 				launcher_grenade = "launcher_poison"
-			}			
+			}
 			self.parts.wpn_fps_gre_ms3gl_conversion_grenade_poison.pcs = {}
 			self.parts.wpn_fps_gre_ms3gl_conversion_grenade_poison.has_description = true
 			self.parts.wpn_fps_gre_ms3gl_conversion_grenade_poison.desc_id = "bm_wp_upg_a_grenade_launcher_poison_ms3gl_desc_sc"
@@ -23192,42 +23192,42 @@ end)
 				end
 			end
 
-				
+
 			-- [[
 			--Underbarrel Slug Single Launcher (Temporarily disabled)
 			self.parts.wpn_fps_pis_type54_underbarrel_slug.pcs = nil
 			self.parts.wpn_fps_pis_type54_underbarrel_slug.supported = true
-			self.parts.wpn_fps_pis_type54_underbarrel_slug.stats = {}	
-			self.parts.wpn_fps_pis_type54_underbarrel_slug.custom_stats = {}	
+			self.parts.wpn_fps_pis_type54_underbarrel_slug.stats = {}
+			self.parts.wpn_fps_pis_type54_underbarrel_slug.custom_stats = {}
 
 			--Underbarrel Slug Double Launcher
 			self.parts.wpn_fps_pis_x_type54_underbarrel_slug.pcs = nil
 			self.parts.wpn_fps_pis_x_type54_underbarrel_slug.supported = true
 			self.parts.wpn_fps_pis_x_type54_underbarrel_slug.stats = {}
 			self.parts.wpn_fps_pis_x_type54_underbarrel_slug.custom_stats = {}
-			
+
 			--Underbarrel Slug Ammo
 			self.parts.wpn_fps_upg_a_slug_underbarrel.pcs = nil
 			self.parts.wpn_fps_upg_a_slug_underbarrel.supported = true
 			self.parts.wpn_fps_upg_a_slug_underbarrel.stats = {}
-			self.parts.wpn_fps_upg_a_slug_underbarrel.custom_stats = {}	
-			
+			self.parts.wpn_fps_upg_a_slug_underbarrel.custom_stats = {}
+
 			--Underbarrel Flechettes (Ditto)
 			self.parts.wpn_fps_pis_type54_underbarrel_piercing.pcs = nil
 			self.parts.wpn_fps_pis_type54_underbarrel_piercing.supported = true
-			self.parts.wpn_fps_pis_type54_underbarrel_piercing.stats = {}	
-			self.parts.wpn_fps_pis_type54_underbarrel_piercing.custom_stats = {}	
-			
+			self.parts.wpn_fps_pis_type54_underbarrel_piercing.stats = {}
+			self.parts.wpn_fps_pis_type54_underbarrel_piercing.custom_stats = {}
+
 			self.parts.wpn_fps_pis_x_type54_underbarrel_piercing.pcs = nil
 			self.parts.wpn_fps_pis_x_type54_underbarrel_piercing.supported = true
-			self.parts.wpn_fps_pis_x_type54_underbarrel_piercing.stats = {}	
-			self.parts.wpn_fps_pis_x_type54_underbarrel_piercing.custom_stats = {}	
-			
+			self.parts.wpn_fps_pis_x_type54_underbarrel_piercing.stats = {}
+			self.parts.wpn_fps_pis_x_type54_underbarrel_piercing.custom_stats = {}
+
 			--Underbarrel Flechettes Ammo
 			self.parts.wpn_fps_upg_a_piercing_underbarrel.pcs = nil
 			self.parts.wpn_fps_upg_a_piercing_underbarrel.supported = true
 			self.parts.wpn_fps_upg_a_piercing_underbarrel.stats = {}
-			self.parts.wpn_fps_upg_a_piercing_underbarrel.custom_stats = {}		
+			self.parts.wpn_fps_upg_a_piercing_underbarrel.custom_stats = {}
 			--]]
 
 			--You're pretty good
@@ -23265,7 +23265,7 @@ end)
 				third_unit = "units/payday2/weapons/wpn_upg_dummy/wpn_upg_dummy",
 				supported = true,
 				stats = {value = 1, concealment = 1, recoil = -2},
-				custom_stats = { 
+				custom_stats = {
 					empire = true,
 					ads_speed_mult = 0.975
 				},
@@ -23274,7 +23274,7 @@ end)
 				texture_bundle_folder = "boost_in_lootdrop",
 				sub_type = "bonus_stats"
 			}
-			
+
 			--Large Conceal
 			self.parts.wpn_fps_upg_bonus_concealment_p2 = {
 				pcs = {},
@@ -23286,7 +23286,7 @@ end)
 				third_unit = "units/payday2/weapons/wpn_upg_dummy/wpn_upg_dummy",
 				supported = true,
 				stats = {value = 1, concealment = 2, recoil = -4},
-				custom_stats = { 
+				custom_stats = {
 					empire = true,
 					ads_speed_mult = 0.95
 				},
@@ -23295,7 +23295,7 @@ end)
 				texture_bundle_folder = "boost_in_lootdrop",
 				sub_type = "bonus_stats"
 			}
-			
+
 			--Massive Conceal
 			self.parts.wpn_fps_upg_bonus_concealment_p3 = {
 				pcs = {},
@@ -23307,7 +23307,7 @@ end)
 				alt_icon = "guis/dlcs/boost_in_lootdrop/textures/pd2/blackmarket/icons/mods/wpn_fps_upg_bonus_concealment_p3_sc",
 				supported = true,
 				stats = {value = 1, concealment = 3, recoil = -6},
-				custom_stats = { 
+				custom_stats = {
 					empire = true,
 					ads_speed_mult = 0.925
 				},
@@ -23329,7 +23329,7 @@ end)
 				alt_icon = "guis/dlcs/boost_in_lootdrop/textures/pd2/blackmarket/icons/mods/wpn_fps_upg_bonus_spread_p1_sc",
 				supported = true,
 				stats = {value = 1, spread = 1, concealment = -1},
-				custom_stats = { 
+				custom_stats = {
 					mandalorian = true,
 					falloff_start_mult = 1.075,
 					falloff_end_mult = 1.075,
@@ -23340,8 +23340,8 @@ end)
 				texture_bundle_folder = "boost_in_lootdrop",
 				sub_type = "bonus_stats",
 				exclude_from_challenge = true
-			}		
-			
+			}
+
 			--Large Accuracy Modifier
 			self.parts.wpn_fps_upg_bonus_damage_p2 = {
 				pcs = {},
@@ -23353,7 +23353,7 @@ end)
 				alt_icon = "guis/dlcs/boost_in_lootdrop/textures/pd2/blackmarket/icons/mods/wpn_fps_upg_bonus_damage_p1_sc",
 				supported = true,
 				stats = {value = 1, spread = 2, concealment = -2},
-				custom_stats = { 
+				custom_stats = {
 					empire = true,
 					mandalorian = true,
 					falloff_start_mult = 1.15,
@@ -23365,8 +23365,8 @@ end)
 				texture_bundle_folder = "boost_in_lootdrop",
 				sub_type = "bonus_stats",
 				exclude_from_challenge = true
-			}		
-			
+			}
+
 			--Massive Accuracy Modifier
 			self.parts.wpn_fps_upg_bonus_recoil_p1 = {
 				pcs = {},
@@ -23378,7 +23378,7 @@ end)
 				alt_icon = "guis/dlcs/boost_in_lootdrop/textures/pd2/blackmarket/icons/mods/wpn_fps_upg_bonus_damage_p2_sc",
 				supported = true,
 				stats = {value = 1, spread = 3, concealment = -3},
-				custom_stats = { 
+				custom_stats = {
 					mandalorian = true,
 					falloff_start_mult = 1.225,
 					falloff_end_mult = 1.225,
@@ -23388,8 +23388,8 @@ end)
 				perks = {"bonus"},
 				texture_bundle_folder = "boost_in_lootdrop",
 				sub_type = "bonus_stats"
-			}		
-			
+			}
+
 			--Small Stability Modifier
 			self.parts.wpn_fps_upg_bonus_spread_n1 = {
 				pcs = {},
@@ -23411,9 +23411,9 @@ end)
 				perks = {"bonus"},
 				texture_bundle_folder = "boost_in_lootdrop",
 				sub_type = "bonus_stats"
-			}		
-			
-			--Large Stability Modifier		
+			}
+
+			--Large Stability Modifier
 			self.parts.wpn_fps_upg_bonus_spread_p1 = {
 				pcs = {},
 				type = "bonus",
@@ -23447,7 +23447,7 @@ end)
 				alt_icon = "guis/dlcs/boost_in_lootdrop/textures/pd2/blackmarket/icons/mods/wpn_fps_upg_bonus_spread_n1_sc",
 				supported = true,
 				stats = {value = 1, spread = -3, recoil = 6},
-				custom_stats = { 
+				custom_stats = {
 					republic = true,
 					hip_mult = 1.3,
 					falloff_start_mult = 0.775,
@@ -23457,8 +23457,8 @@ end)
 				perks = {"bonus"},
 				texture_bundle_folder = "boost_in_lootdrop",
 				sub_type = "bonus_stats"
-			}		
-			
+			}
+
 
 			local function peepee(factory_id)
 				for id, data in pairs(tweak_data.upgrades.definitions) do
@@ -23474,15 +23474,15 @@ end)
 					if tweak_data.weapon[ weapon_id ] then
 						local tww = tweak_data.weapon[ weapon_id ]
 						if tww.categories then
-							if table.contains( tww.categories , "snp") or 
-							table.contains( tww.categories , "dmr_h") or 
-							table.contains( tww.categories , "shotgun") or 
+							if table.contains( tww.categories , "snp") or
+							table.contains( tww.categories , "dmr_h") or
+							table.contains( tww.categories , "shotgun") or
 							table.contains( tww.categories , "grenade_launcher") or
 							table.contains( tww.categories , "handcannon") then
 								self[ factory_id ].override = self[ factory_id ].override or {}
 								self[ factory_id ].override.wpn_fps_upg_bonus_concealment_p1 = {
 									stats = {value = 1, concealment = 1, spread = -2},
-									custom_stats = { 
+									custom_stats = {
 										empire = true,
 										falloff_start_mult = 0.925,
 										falloff_end_mult = 0.925,
@@ -23491,7 +23491,7 @@ end)
 								}
 								self[ factory_id ].override.wpn_fps_upg_bonus_concealment_p2 = {
 									stats = {value = 1, concealment = 2, spread = -4},
-									custom_stats = { 
+									custom_stats = {
 										empire = true,
 										falloff_start_mult = 0.85,
 										falloff_end_mult = 0.85,
@@ -23500,7 +23500,7 @@ end)
 								}
 								self[ factory_id ].override.wpn_fps_upg_bonus_concealment_p3 = {
 									stats = {value = 1, concealment = 3, spread = -6},
-									custom_stats = { 
+									custom_stats = {
 										empire = true,
 										falloff_start_mult = 0.775,
 										falloff_end_mult = 0.775,
@@ -23512,7 +23512,7 @@ end)
 								self[ factory_id ].override = self[ factory_id ].override or {}
 								for k, used_part_id in pairs(self[ factory_id ].uses_parts) do
 									if self.parts[used_part_id] and self.parts[used_part_id].pcs and self.parts[used_part_id].type then
-										if self.parts[ used_part_id ].type == "magazine" and 
+										if self.parts[ used_part_id ].type == "magazine" and
 										not (self[ factory_id ].override[ used_part_id ] and self[ factory_id ].override[ used_part_id ].stats) and
 										self.parts[ used_part_id ].stats and self.parts[ used_part_id ].stats.extra_ammo then
 											self[ factory_id ].override[ used_part_id ] = self[ factory_id ].override[ used_part_id ] or {}
@@ -23541,7 +23541,7 @@ end)
 											end
 										end
 									end
-								end 
+								end
 							end
 
 							if table.contains( tww.categories , "shotgun") then
@@ -23578,7 +23578,7 @@ end)
 				texture_bundle_folder = "boost_in_lootdrop",
 				sub_type = "bonus_team",
 				exclude_from_challenge = true
-			}		
+			}
 
 			--Money Boost
 			self.parts.wpn_fps_upg_bonus_total_ammo_p1 = {
@@ -23599,7 +23599,7 @@ end)
 				has_description = true,
 				exclude_from_challenge = true
 			}
-			
+
 			self.parts.wpn_fps_upg_bonus_sc_none = {
 				pcs = {},
 				type = "bonus",
@@ -23679,7 +23679,7 @@ end)
 		end
 
 
---Resmod Custom Content					
+--Resmod Custom Content
 Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(self)
 
 	--disables the VR renderscreen for this scope as it gets in the way of the non-VR view
@@ -24140,7 +24140,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 		}
 	}
 
-	
+
 	self.parts.wpn_fps_upg_i_93r = {
 		pcs = {},
 		type = "custom",
@@ -24163,13 +24163,13 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 		stats = {
 			value = 5,
 			spread = -5,
-			recoil = -8			
+			recoil = -8
 		},
 		internal_part = true,
 		dlc = "sc"
-	}	
+	}
 
-	
+
 	self.parts.wpn_fps_upg_i_csglock = {
 		pcs = {},
 		type = "custom",
@@ -24184,8 +24184,8 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 				rof_mult = 3,
 				spread_mult = 1.5
 			},
-			info_add_burst = true, 
-			rof_mult = 0.5882352, 
+			info_add_burst = true,
+			rof_mult = 0.5882352,
 			ignore_rof_mult_anims = true
 		},
 		alt_icon = "guis/textures/pd2/blackmarket/icons/mods/wpn_fps_upg_i_autofire",
@@ -24195,12 +24195,12 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 		stats = {
 			value = 6,
 			spread = 4,
-			recoil = 4		
+			recoil = 4
 		},
 		internal_part = true,
 		dlc = "sc"
 	}
-	
+
 	self.parts.wpn_fps_upg_i_abakan = {
 		pcs = {},
 		type = "custom",
@@ -24218,7 +24218,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 				rof_mult = 3,
 				delay = 0.09,
 			},
-			rof_mult = 0.85714, 
+			rof_mult = 0.85714,
 			ignore_rof_mult_anims = true
 		},
 		alt_icon = "guis/textures/pd2/blackmarket/icons/mods/wpn_fps_upg_i_autofire",
@@ -24348,7 +24348,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 		stats = {
 			value = 5,
 			spread = -5,
-			recoil = -8			
+			recoil = -8
 		},
 		internal_part = true,
 		dlc = "sc"
@@ -24827,14 +24827,14 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 		name_id = "bm_wp_upg_s_fixed",
 		a_obj = "a_s",
 		alt_icon = "guis/textures/pd2/blackmarket/icons/melee_weapons/weapon",
-		unit = "units/payday2/weapons/wpn_fps_ass_m16_pts/wpn_fps_m16_s_solid", 
-		third_unit = "units/payday2/weapons/wpn_third_ass_m16_pts/wpn_third_m16_s_solid", 
+		unit = "units/payday2/weapons/wpn_fps_ass_m16_pts/wpn_fps_m16_s_solid",
+		third_unit = "units/payday2/weapons/wpn_third_ass_m16_pts/wpn_third_m16_s_solid",
 		supported = true,
 		custom_stats = deep_clone(stocks.adj_to_fixed_acc_stats),
 		stats = deep_clone(stocks.adj_to_fixed_acc_stats),
 		dlc = "sc"
-	}	
-	
+	}
+
 	--OVERKILL Kit (Bernetti Auto autofire)
 	self.parts.wpn_fps_upg_i_b93o = {
 		pcs = {},
@@ -25023,7 +25023,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 		internal_part = true,
 		dlc = "sc"
 	}
-	
+
 	self.parts.wpn_fps_smg_mac10_s_no = {
 		pcs = {},
 		type = "stock",
@@ -25031,19 +25031,19 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 		a_obj = "a_s",
 		alt_icon = "guis/textures/pd2/blackmarket/icons/mods/wpn_fps_smg_mac10_s_no",
 		unit = "units/payday2/weapons/wpn_upg_dummy/wpn_upg_dummy",
-		third_unit = "units/payday2/weapons/wpn_upg_dummy/wpn_upg_dummy",			
-		supported = true,			
-		is_a_unlockable = true,			
+		third_unit = "units/payday2/weapons/wpn_upg_dummy/wpn_upg_dummy",
+		supported = true,
+		is_a_unlockable = true,
 		stats = {
 			value = 0,
 			spread = -1,
 			recoil = -4,
 			concealment = 3,
 			ads_speed_mult = 0.925
-		},		
-		custom_stats = deep_clone(stocks.remove_folder_stats),		
-		dlc = "sc"			
-	}								
+		},
+		custom_stats = deep_clone(stocks.remove_folder_stats),
+		dlc = "sc"
+	}
 	self.parts.wpn_fps_shot_r870_s_folding_ext = { -- thanks jarey_!
 		pcs = {},
 		type = "stock",
@@ -25051,33 +25051,33 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 		a_obj = "a_s",
 		alt_icon = "guis/dlcs/mods/textures/pd2/blackmarket/icons/mods/wpn_fps_shot_r870_s_muldonunfolded",
 		unit = "units/mods/weapons/wpn_fps_shot_r870_pts_mod/wpn_fps_shot_r870_s_muldonunfolded",
-		third_unit = "units/mods/weapons/wpn_fps_shot_r870_pts_mod/wpn_third_shot_r870_s_muldonunfolded",			
-		supported = true,			
+		third_unit = "units/mods/weapons/wpn_fps_shot_r870_pts_mod/wpn_third_shot_r870_s_muldonunfolded",
+		supported = true,
 		stats = deep_clone(stocks.fixed_to_nocheeks_stats),
 		custom_stats = deep_clone(stocks.fixed_to_nocheeks_stats),
-		dlc = "sc"			
+		dlc = "sc"
 	}
 
 
 	self.parts.avelyn = {
-		pcs = {}, 
-		type = "custom", 
-		name_id = "bm_wp_avelyn", 
-		has_description = true, 
-		a_obj = "a_body", 
-		unit = "units/payday2/weapons/wpn_upg_dummy/wpn_upg_dummy", 
-		third_unit = "units/payday2/weapons/wpn_upg_dummy/wpn_upg_dummy", 
-		dlc = "sc", 		
+		pcs = {},
+		type = "custom",
+		name_id = "bm_wp_avelyn",
+		has_description = true,
+		a_obj = "a_body",
+		unit = "units/payday2/weapons/wpn_upg_dummy/wpn_upg_dummy",
+		third_unit = "units/payday2/weapons/wpn_upg_dummy/wpn_upg_dummy",
+		dlc = "sc",
 		supported = true,
-		alt_icon = "guis/textures/pd2/blackmarket/icons/mods/wpn_fps_upg_i_autofire", 
+		alt_icon = "guis/textures/pd2/blackmarket/icons/mods/wpn_fps_upg_i_autofire",
 		stats = {
-			value = 10, 
-			recoil = -10, 
+			value = 10,
+			recoil = -10,
 			extra_ammo = 2,
 			reload = -6
-		}, 
-		custom_stats = { 
-			alt_desc = "bm_wp_avelyn_override_desc", 
+		},
+		custom_stats = {
+			alt_desc = "bm_wp_avelyn_override_desc",
 			burst_fire = {
 				count = 3,
 				delay = 0.2,
@@ -25089,14 +25089,14 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 			rms = 0.6,
 			sms = 0.6,
 			info_lock_burst = true
-		}, 
-		internal_part = true, 
-		sub_type = "autofire", 
+		},
+		internal_part = true,
+		sub_type = "autofire",
 		forbids = { "wpn_fps_bow_frankish_m_explosive", "wpn_fps_bow_frankish_m_poison" }
 	}
 
 --Custom weapon shit here--
-	
+
 	--[[ PAWCIO'S MODS ]]
 
 		--ATTACHMENTS
@@ -25108,7 +25108,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 					"wpn_fps_upg_o_snp_troym4_rear",
 					"wpn_fps_upg_o_snp_scorpionevo_rear",
 					"wpn_fps_upg_o_snp_kac_rear",
-		
+
 					--Lite
 					"wpn_fps_upg_o_snp_cheap_rear",
 					"wpn_fps_upg_o_snp_dd_a1_rear",
@@ -25123,8 +25123,8 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 						self.parts[part_id].stats = { value = 0 }
 						self.parts[part_id].custom_stats = nil
 					end
-				end									
-			end			
+				end
+			end
 
 			if self.parts.wpn_fps_upg_1911_tritium then --Pawcio's Illuminated Ironsights Pack
 				local iron_sights = {
@@ -25340,27 +25340,27 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 				self.parts.wpn_fps_upg_xm8_handguard_compact.supported = true
 				self.parts.wpn_fps_upg_xm8_handguard_compact.stats = deep_clone(barrels.short_b2_stats)
 				self.parts.wpn_fps_upg_xm8_handguard_compact.custom_stats = deep_clone(barrels.short_b2_stats)
-					
+
 				self.parts.wpn_fps_ass_xm8_insight_ismv.supported = true
 				self.parts.wpn_fps_ass_xm8_insight_ismv.desc_id = "bm_wp_upg_o_1_1"
 				self.parts.wpn_fps_ass_xm8_insight_ismv.stats = {
 					value = 3,
 					zoom = 1
-				}	
-					
+				}
+
 				self.parts.wpn_fps_upg_xm8_cmag.supported = true
 				self.parts.wpn_fps_upg_xm8_cmag.has_description = false
 				self.parts.wpn_fps_upg_xm8_cmag.stats = deep_clone(self.parts.wpn_fps_upg_m4_m_drum.stats)
 				self.parts.wpn_fps_upg_xm8_cmag.custom_stats = deep_clone(self.parts.wpn_fps_upg_m4_m_drum.custom_stats)
-					
+
 				self.parts.wpn_fps_upg_xm8_mag_magpul.supported = true
 				self.parts.wpn_fps_upg_xm8_mag_magpul.has_description = false
 				self.parts.wpn_fps_upg_xm8_mag_magpul.stats = deep_clone(self.parts.wpn_fps_m4_upg_m_quick.stats)
 				self.parts.wpn_fps_upg_xm8_mag_magpul.custom_stats = nil
-					
+
 				self.parts.wpn_fps_upg_xm8_stock_collapsed.supported = true
 				self.parts.wpn_fps_upg_xm8_stock_collapsed.stats = deep_clone(stocks.adj_to_fold_stats)
-				self.parts.wpn_fps_upg_xm8_stock_collapsed.custom_stats = deep_clone(stocks.adj_to_fold_stats)	
+				self.parts.wpn_fps_upg_xm8_stock_collapsed.custom_stats = deep_clone(stocks.adj_to_fold_stats)
 
 				table.insert(self.wpn_fps_ass_xm8.uses_parts, "wpn_fps_upg_i_m8a1")
 				for k, used_part_id in ipairs(self.wpn_fps_ass_xm8.uses_parts) do
@@ -25372,39 +25372,39 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 						end
 					end
 				end
-			end				
-		
-			if self.parts.wpn_fps_upg_o_okp7_dove then --Pawcio's Russian Sight Pack 
-				self.parts.wpn_fps_upg_o_okp7_dove.supported = true 
+			end
+
+			if self.parts.wpn_fps_upg_o_okp7_dove then --Pawcio's Russian Sight Pack
+				self.parts.wpn_fps_upg_o_okp7_dove.supported = true
 				self.parts.wpn_fps_upg_o_okp7_dove.stats = {
 					value = 3,
-					zoom = 2	
-				}	
-				self.parts.wpn_fps_upg_o_pso1.supported = true	
+					zoom = 2
+				}
+				self.parts.wpn_fps_upg_o_pso1.supported = true
 				self.parts.wpn_fps_upg_o_pso1.stats = {
 					value = 8,
 					zoom = 40
-				}				
-				self.parts.wpn_fps_upg_o_pso1_rifle.supported = true				
+				}
+				self.parts.wpn_fps_upg_o_pso1_rifle.supported = true
 				self.parts.wpn_fps_upg_o_pso1_rifle.stats = {
 					value = 8,
 					zoom = 40
-				}	
-				self.parts.wpn_fps_upg_o_1pn93.supported = true	
+				}
+				self.parts.wpn_fps_upg_o_1pn93.supported = true
 				self.parts.wpn_fps_upg_o_1pn93.stats = {
 					value = 8,
 					zoom = 30
-				}	
-				self.parts.wpn_fps_upg_o_ekp_1s_03.supported = true	
+				}
+				self.parts.wpn_fps_upg_o_ekp_1s_03.supported = true
 				self.parts.wpn_fps_upg_o_ekp_1s_03.stats = {
 					value = 3,
-					zoom = 2	
-				}									
-				self.parts.wpn_fps_upg_o_1p29.supported = true									
+					zoom = 2
+				}
+				self.parts.wpn_fps_upg_o_1p29.supported = true
 				self.parts.wpn_fps_upg_o_1p29.stats = {
 					value = 8,
 					zoom = 30
-				}															
+				}
 			end
 
 			if self.parts.wpn_fps_upg_o_c79 then --Pawcio's ELCAN C79
@@ -25437,7 +25437,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 				self.parts.wpn_fps_snp_mosin_body_obrez.supported = true
 				self.parts.wpn_fps_snp_mosin_body_obrez.stats = deep_clone(stocks.remove_fixed_stats)
 				self.parts.wpn_fps_snp_mosin_body_obrez.custom_stats = deep_clone(stocks.remove_fixed_stats)
-		
+
 				self.parts.wpn_fps_snp_mosin_b_obrez.supported = true
 				self.parts.wpn_fps_snp_mosin_b_obrez.stats = deep_clone(barrels.short_b3_stats)
 				self.parts.wpn_fps_snp_mosin_b_obrez.stats.bayonet_range = -50
@@ -25511,14 +25511,14 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 				self.parts.wpn_fps_ass_skspug_mag.stats = { value = 0 }
 
 				self.parts.wpn_fps_upg_skspug_handguard_short.supported = true
-				self.parts.wpn_fps_upg_skspug_handguard_short.stats = { 
+				self.parts.wpn_fps_upg_skspug_handguard_short.stats = {
 					value = 5,
 					recoil = -4,
 					concealment = 2
 				}
 
 				self.parts.wpn_fps_upg_skspug_stock_ext.supported = true
-				self.parts.wpn_fps_upg_skspug_stock_ext.stats = { 
+				self.parts.wpn_fps_upg_skspug_stock_ext.stats = {
 					value = 2,
 					recoil = 2,
 					concealment = -1
@@ -25534,13 +25534,13 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 
 				self.parts.wpn_fps_upg_skspug_mag_30.supported = true
 				self.parts.wpn_fps_upg_skspug_mag_30.has_description = false
-				self.parts.wpn_fps_upg_skspug_mag_30.stats = { 
+				self.parts.wpn_fps_upg_skspug_mag_30.stats = {
 					value = 2,
 					extra_ammo = 10,
 					reload = -3,
 					concealment = -1
 				}
-				self.parts.wpn_fps_upg_skspug_mag_30.custom_stats = { 
+				self.parts.wpn_fps_upg_skspug_mag_30.custom_stats = {
 					ads_speed_mult = 0.975
 				}
 			end
@@ -25595,11 +25595,11 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 				self.parts.wpn_fps_upg_arisaka38_scope_type99.pcs = nil	-- broken
 				self.parts.wpn_fps_upg_arisaka38_scope_type99.desc_id = "bm_wp_upg_o_4_irons"
 				self.parts.wpn_fps_upg_arisaka38_scope_type99.stats = { value = 0, zoom = 30 }
-				
+
 				self.parts.wpn_fps_upg_arisaka38_stock_sawnoff.supported = true
 				self.parts.wpn_fps_upg_arisaka38_stock_sawnoff.stats = deep_clone(stocks.remove_fixed_stats)
 				self.parts.wpn_fps_upg_arisaka38_stock_sawnoff.custom_stats = deep_clone(stocks.remove_fixed_stats)
-				
+
 				self.parts.wpn_fps_upg_arisaka38_stock_shellholder.supported = true
 				self.parts.wpn_fps_upg_arisaka38_stock_shellholder.has_description = false
 				self.parts.wpn_fps_upg_arisaka38_stock_shellholder.stats = {
@@ -25608,7 +25608,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 					concealment = -1,
 					reload = 3
 				}
-				
+
 				self.parts.wpn_fps_upg_arisaka38_bolt_nocover.supported = true
 				self.parts.wpn_fps_upg_arisaka38_bolt_nocover.stats = {
 					value = 2,
@@ -25617,22 +25617,22 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 				self.parts.wpn_fps_upg_arisaka38_bolt_nocover.custom_stats = { rof_mult = 1.07 }
 			end
 
-			if self.wpn_fps_shot_ks23 then 	-- Pawcio's KS-23	
-				self.parts.wpn_fps_upg_ks23_ammo_slug.supported = true	
+			if self.wpn_fps_shot_ks23 then 	-- Pawcio's KS-23
+				self.parts.wpn_fps_upg_ks23_ammo_slug.supported = true
 				self.parts.wpn_fps_upg_ks23_ammo_slug.desc_id = "bm_wp_upg_a_slug_heavy_desc_sc"
 				self.parts.wpn_fps_upg_ks23_ammo_slug.stats = {
 					value = 10,
 					concealment = -4,
 					total_ammo_mod = -104,
-					damage = 30,	
+					damage = 30,
 					recoil = -20,
 					spread = 12,
-					spread_multi = {1, 1},	
+					spread_multi = {1, 1},
 					suppression = -1,
 					moving_spread = 0
 				}
 				self.parts.wpn_fps_upg_ks23_ammo_slug.custom_stats = {
-					muzzleflash = "effects/payday2/particles/weapons/762_auto_fps",																
+					muzzleflash = "effects/payday2/particles/weapons/762_auto_fps",
 					rays = 1,
 					hip_mult = 3,
 					armor_piercing_add = 1,
@@ -25646,44 +25646,44 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 					falloff_end_mult = 2.00,
 					ads_speed_mult = 1.10
 				}
-		
+
 				self.parts.wpn_fps_upg_ks23_barrel_short.supported = true
 				self.parts.wpn_fps_upg_ks23_barrel_short.stats = deep_clone(barrels.short_b3_stats)
 				self.parts.wpn_fps_upg_ks23_barrel_short.custom_stats = deep_clone(barrels.short_b3_stats)
-		
-				self.parts.wpn_fps_upg_ks23_stock_pistolgrip.supported = true	
+
+				self.parts.wpn_fps_upg_ks23_stock_pistolgrip.supported = true
 				self.parts.wpn_fps_upg_ks23_stock_pistolgrip.stats = deep_clone(stocks.remove_fixed_stats)
 				self.parts.wpn_fps_upg_ks23_stock_pistolgrip.custom_stats = deep_clone(stocks.remove_fixed_stats)
-		
+
 				self.parts.wpn_fps_upg_ks23_stock_pistolgrip_wire.supported = true
 				self.parts.wpn_fps_upg_ks23_stock_pistolgrip_wire.stats = deep_clone(stocks.fixed_to_nocheeks_stats)
 				self.parts.wpn_fps_upg_ks23_stock_pistolgrip_wire.custom_stats = deep_clone(stocks.fixed_to_nocheeks_stats)
-		
+
 				self.parts.wpn_fps_upg_ks23_ammo_buckshot_20pellet.pcs = nil
-				self.parts.wpn_fps_upg_ks23_ammo_buckshot_8pellet.pcs = nil											
+				self.parts.wpn_fps_upg_ks23_ammo_buckshot_8pellet.pcs = nil
 			end
-	
+
 			if self.wpn_fps_snp_moss464spx then -- Pawcio's SPX Centerfire
 				self.parts.wpn_fps_snp_moss464spx_stock.stats = nil
-				self.parts.wpn_fps_snp_moss464spx_stock.pcs = nil --already comes with this pre-attached, so it's disabled from being selectable in the stocks category.	
-				self.parts.wpn_fps_upg_moss464spx_barrel_short.supported = true	
+				self.parts.wpn_fps_snp_moss464spx_stock.pcs = nil --already comes with this pre-attached, so it's disabled from being selectable in the stocks category.
+				self.parts.wpn_fps_upg_moss464spx_barrel_short.supported = true
 				self.parts.wpn_fps_upg_moss464spx_barrel_short.stats = deep_clone(barrels.short_b1_stats)
 				self.parts.wpn_fps_upg_moss464spx_barrel_short.stats.extra_ammo = -1
 				self.parts.wpn_fps_upg_moss464spx_barrel_short.stats.concealment = 2
-				self.parts.wpn_fps_upg_moss464spx_barrel_short.custom_stats = deep_clone(barrels.short_b1_stats)	
+				self.parts.wpn_fps_upg_moss464spx_barrel_short.custom_stats = deep_clone(barrels.short_b1_stats)
 				self.parts.wpn_fps_upg_moss464spx_barrel_short.override_weapon_add = nil
-		
+
 				self.parts.wpn_fps_snp_moss464spx_supp_maxim.supported = true
 				self.parts.wpn_fps_snp_moss464spx_supp_maxim.stats = {
 					value = 5,
 					suppression = 12,
 					alert_size = -1
-				}				
+				}
 				self.parts.wpn_fps_snp_moss464spx_supp_maxim.custom_stats = nil
-		
+
 				self.parts.wpn_fps_upg_moss464spx_stock_cheekpiece.supported = true
-				self.parts.wpn_fps_upg_moss464spx_stock_cheekpiece.stats = deep_clone(stocks.adj_acc_stats)			
-		
+				self.parts.wpn_fps_upg_moss464spx_stock_cheekpiece.stats = deep_clone(stocks.adj_acc_stats)
+
 				if not self.wpn_fps_snp_moss464spx.override then
 					self.wpn_fps_snp_moss464spx.override = {}
 				end
@@ -25696,40 +25696,40 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 			if self.wpn_fps_snp_m1894 then -- Pawcio's Marlin 1894
 				self.parts.wpn_fps_snp_m1894_loading_spring.supported = true
 				self.parts.wpn_fps_snp_m1894_loading_spring.adds = nil
-		
+
 				self.parts.wpn_fps_upg_m1894_supp_gemtech_gm45.supported = true
 				self.parts.wpn_fps_upg_m1894_supp_gemtech_gm45.stats = {
 					value = 5,
 					suppression = 12,
 					alert_size = -1
-				}				
+				}
 				self.parts.wpn_fps_upg_m1894_supp_gemtech_gm45.custom_stats = nil
 				self.parts.wpn_fps_upg_m1894_supp_gemtech_gm45.sound_switch = {
 					suppressed = "suppressed_a"
 				}
-			end	
+			end
 
 			if self.wpn_fps_shot_quadbarrel then -- Pawcio's Doomstick
 				self.parts.wpn_fps_upg_quadbarrel_barrel_short.supported = true
 				self.parts.wpn_fps_upg_quadbarrel_barrel_short.stats = deep_clone(barrels.short_b3_stats)
 				self.parts.wpn_fps_upg_quadbarrel_barrel_short.custom_stats = deep_clone(barrels.short_b3_stats)
-	
+
 				self.parts.wpn_fps_upg_quadbarrel_stock_collapsed.supported = true
 				self.parts.wpn_fps_upg_quadbarrel_stock_collapsed.stats = deep_clone(stocks.adj_to_folded_stats)
 				self.parts.wpn_fps_upg_quadbarrel_stock_collapsed.custom_stats = deep_clone(stocks.adj_to_folded_stats)
-				
+
 				self.parts.wpn_fps_upg_quadbarrel_ammo_buckshot_close.desc_id = "bm_wp_upg_a_custom_desc"
 				self.parts.wpn_fps_upg_quadbarrel_ammo_buckshot_close.stats = deep_clone(self.parts.wpn_fps_upg_a_custom.stats)
 				self.parts.wpn_fps_upg_quadbarrel_ammo_buckshot_close.custom_stats = deep_clone(self.parts.wpn_fps_upg_a_custom.custom_stats)
-	
+
 				self.parts.wpn_fps_upg_quadbarrel_ammo_buckshot_med.desc_id = "bm_wp_upg_a_piercing_heavy_desc_sc"
 				self.parts.wpn_fps_upg_quadbarrel_ammo_buckshot_med.stats = deep_clone(self.parts.wpn_fps_upg_a_piercing.stats)
 				self.parts.wpn_fps_upg_quadbarrel_ammo_buckshot_med.custom_stats = deep_clone(self.parts.wpn_fps_upg_a_piercing.custom_stats)
-	
+
 				self.parts.wpn_fps_upg_quadbarrel_ammo_slug.desc_id = "bm_wp_upg_a_slug_heavy_desc_sc"
 				self.parts.wpn_fps_upg_quadbarrel_ammo_slug.stats = deep_clone(self.parts.wpn_fps_upg_a_slug.stats)
 				self.parts.wpn_fps_upg_quadbarrel_ammo_slug.custom_stats = deep_clone(self.parts.wpn_fps_upg_a_slug.custom_stats)
-			end	
+			end
 
 			if self.wpn_fps_snp_winchester1894 then -- Pawcio's Winchester 1894
 				self.parts.wpn_fps_upg_winchester1894_stock_shellholder.has_description = false
@@ -25739,7 +25739,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 					spread = -1,
 					concealment = -1,
 					reload = 3
-				}	
+				}
 				self.parts.wpn_fps_upg_winchester1894_stock_shellholder.override_weapon_add = nil
 			end
 
@@ -25865,7 +25865,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 
 				self.parts.wpn_fps_upg_lewis_sight_zfg42.supported = true
 				self.parts.wpn_fps_upg_lewis_sight_zfg42.has_description = true
-				self.parts.wpn_fps_upg_lewis_sight_zfg42.desc_id = "bm_wp_upg_o_1_5_scope"	
+				self.parts.wpn_fps_upg_lewis_sight_zfg42.desc_id = "bm_wp_upg_o_1_5_scope"
 				self.parts.wpn_fps_upg_lewis_sight_zfg42.stats = {
 					value = 0,
 					zoom = 5
@@ -25883,7 +25883,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 					}
 				}
 
-				self.wpn_fps_lmg_lewis.adds = { 
+				self.wpn_fps_lmg_lewis.adds = {
 					wpn_fps_upg_o_specter = { "wpn_fps_rpg7_sight_adapter" },
 					wpn_fps_upg_o_aimpoint = { "wpn_fps_rpg7_sight_adapter" },
 					wpn_fps_upg_o_aimpoint_2 = { "wpn_fps_rpg7_sight_adapter" },
@@ -25908,8 +25908,8 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 				table.insert(self.wpn_fps_lmg_lewis.uses_parts, "wpn_fps_upg_o_t1micro")
 				table.insert(self.wpn_fps_lmg_lewis.uses_parts, "wpn_fps_upg_o_cmore")
 				table.insert(self.wpn_fps_lmg_lewis.uses_parts, "wpn_fps_upg_o_aimpoint_2")
-				table.insert(self.wpn_fps_lmg_lewis.uses_parts, "wpn_fps_upg_o_cs")	
-				table.insert(self.wpn_fps_lmg_lewis.uses_parts, "wpn_fps_upg_o_rx30")	
+				table.insert(self.wpn_fps_lmg_lewis.uses_parts, "wpn_fps_upg_o_cs")
+				table.insert(self.wpn_fps_lmg_lewis.uses_parts, "wpn_fps_upg_o_rx30")
 				table.insert(self.wpn_fps_lmg_lewis.uses_parts, "wpn_fps_upg_o_rx01")
 				table.insert(self.wpn_fps_lmg_lewis.uses_parts, "wpn_fps_upg_o_reflex")
 				table.insert(self.wpn_fps_lmg_lewis.uses_parts, "wpn_fps_upg_o_eotech_xps")
@@ -25930,15 +25930,15 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 				self.parts.wpn_fps_upg_hx25_sight_iron_il.stats = {
 					value = 1
 				}
-		
+
 				self.parts.wpn_fps_upg_hx25_buckshot_ammo.supported = true
 				self.parts.wpn_fps_upg_hx25_buckshot_ammo.desc_id = "bm_hx25_buck_sc_desc"
 				self.parts.wpn_fps_upg_hx25_buckshot_ammo.pcs = nil
-		
+
 				if not self.wpn_fps_gre_hx25.override then
 					self.wpn_fps_gre_hx25.override = {}
 				end
-		
+
 				self.wpn_fps_gre_hx25.override.wpn_fps_upg_hx25_buckshot_ammo = {
 					supported = true,
 					stats = {
@@ -25951,7 +25951,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 						bullet_class = "InstantExplosiveBulletBase"
 					}
 				}
-				
+
 				self.wpn_fps_gre_hx25.override.wpn_fps_gre_hx25_explosive_ammo = {
 					supported = true,
 					stats = {
@@ -25972,10 +25972,10 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 				self.parts.wpn_fps_upg_xeno_stock_ext.custom_stats = deep_clone(stocks.unfold_folded_stats)
 
 				self.parts.wpn_fps_upg_xeno_underbarrel_sg.pcs = nil
-		
+
 				self.parts.wpn_fps_ass_xeno_underbarrel_gl.supported = true
 				--self.parts.wpn_fps_ass_xeno_underbarrel_gl.adds = {"wpn_fps_ass_xeno_underbarrel_gl_ammo"}
-		
+
 				self.parts.wpn_fps_ass_xeno_underbarrel_gl_ammo = deep_clone(self.parts.wpn_fps_ass_contraband_g_standard)
 				self.parts.wpn_fps_ass_xeno_underbarrel_gl_ammo.unit = "units/payday2/weapons/wpn_upg_dummy/wpn_upg_dummy"
 				self.parts.wpn_fps_ass_xeno_underbarrel_gl_ammo.third_unit = "units/payday2/weapons/wpn_upg_dummy/wpn_upg_dummy"
@@ -25984,25 +25984,25 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 				self.parts.wpn_fps_ass_xeno_underbarrel_gl_ammo.stats = { value = 0 }
 				self.parts.wpn_fps_ass_xeno_underbarrel_gl_ammo.custom_stats = {
 					launcher_grenade = "launcher_frag_arbiter"
-				} 
+				}
 			end
 
 			if self.parts.wpn_fps_snp_m200_barrel then --Pawcio's M200
 				self.parts.wpn_fps_upg_m200_barrel_med.supported = true
 				self.parts.wpn_fps_upg_m200_barrel_med.stats = deep_clone(barrels.short_b1_stats)
 				self.parts.wpn_fps_upg_m200_barrel_med.custom_stats = deep_clone(barrels.short_b1_stats)
-		
+
 				self.parts.wpn_fps_upg_m200_barrel_short.supported = true
 				self.parts.wpn_fps_upg_m200_barrel_short.stats = deep_clone(barrels.short_b2_stats)
 				self.parts.wpn_fps_upg_m200_barrel_short.custom_stats = deep_clone(barrels.short_b2_stats)
-		
+
 				self.parts.wpn_fps_upg_m200_bipod.supported = true
 				self.parts.wpn_fps_upg_m200_bipod.stats = { value = 0 }
 				self.parts.wpn_fps_upg_m200_bipod.custom_stats = nil
 				self.parts.wpn_fps_upg_m200_bipod_fold.supported = true
 				self.parts.wpn_fps_upg_m200_bipod_fold.stats = { value = 0 }
 				self.parts.wpn_fps_upg_m200_bipod_fold.custom_stats = nil
-		
+
 				self.parts.wpn_fps_upg_m200_supp.has_description = true
 				self.parts.wpn_fps_upg_m200_supp.desc_id = "bm_wp_upg_suppressor"
 				self.parts.wpn_fps_upg_m200_supp.supported = true
@@ -26013,16 +26013,16 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 				}
 				self.parts.wpn_fps_upg_m200_supp.custom_stats = nil
 				self.parts.wpn_fps_upg_m200_supp.perks = {"silencer"}
-				
+
 				table.insert(self.wpn_fps_snp_m200.uses_parts, "wpn_fps_upg_i_iw_widowmaker")
 				table.insert(self.wpn_fps_snp_m200.uses_parts, "wpn_fps_upg_o_arbiter_irons_dmc")
 
 				self.wpn_fps_snp_m200.override = self.wpn_fps_snp_m200.override or {}
-				
+
 				self.wpn_fps_snp_m200_npc.override = deep_clone(self.wpn_fps_snp_m200.override)
 				self.wpn_fps_snp_m200_npc.uses_parts = deep_clone(self.wpn_fps_snp_m200.uses_parts)
 			end
-		
+
 			if self.parts.wpn_fps_upg_amr2_barrel_short then --Pawcio's AMR-2
 				self.parts.wpn_fps_upg_amr2_bipod.supported = true
 				self.parts.wpn_fps_upg_amr2_bipod.stats = { value = 0 }
@@ -26039,7 +26039,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 				table.insert(self.wpn_fps_snp_amr2.uses_parts, "wpn_fps_upg_o_arbiter_irons_dmc")
 
 				self.wpn_fps_snp_amr2.override = self.wpn_fps_snp_amr2.override or {}
-				self.wpn_fps_snp_amr2.override.wpn_fps_upg_o_arbiter_irons_dmc = { 
+				self.wpn_fps_snp_amr2.override.wpn_fps_upg_o_arbiter_irons_dmc = {
 					unit = "units/pd2_dlc_born/weapons/wpn_fps_smg_hajk_pts/wpn_fps_smg_hajk_o_standard",
 					third_unit = "units/pd2_dlc_born/weapons/wpn_third_smg_hajk_pts/wpn_third_smg_hajk_o_standard"
 				}
@@ -26074,11 +26074,11 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 				self.parts.wpn_fps_upg_m107cq_ammo_416.supported = true
 				self.parts.wpn_fps_upg_m107cq_ammo_416.stats = { value = 0 }
 				self.parts.wpn_fps_upg_m107cq_ammo_416.custom_stats = nil
-		
+
 				self.parts.wpn_fps_upg_m107cq_barrel_long.supported = true
 				self.parts.wpn_fps_upg_m107cq_barrel_long.stats = deep_clone(barrels.long_b2_stats)
 				self.parts.wpn_fps_upg_m107cq_barrel_long.custom_stats = deep_clone(barrels.long_b2_stats)
-		
+
 				self.parts.wpn_fps_upg_m107cq_barrel_supp.has_description = true
 				self.parts.wpn_fps_upg_m107cq_barrel_supp.desc_id = "bm_wp_upg_suppressor"
 				self.parts.wpn_fps_upg_m107cq_barrel_supp.supported = true
@@ -26089,23 +26089,23 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 				}
 				self.parts.wpn_fps_upg_m107cq_barrel_supp.custom_stats = nil
 				self.parts.wpn_fps_upg_m107cq_barrel_supp.perks = {"silencer"}
-		
+
 				self.parts.wpn_fps_upg_m107cq_bipod.supported = true
 				self.parts.wpn_fps_upg_m107cq_bipod.stats = { value = 0}
 				self.parts.wpn_fps_upg_m107cq_bipod.custom_stats = nil
-		
+
 				self.parts.wpn_fps_upg_m107cq_iron_sights.supported = true
 				self.parts.wpn_fps_upg_m107cq_iron_sights.stats = { value = 0 }
 				self.parts.wpn_fps_upg_m107cq_iron_sights.custom_stats = nil
 			end
-		
+
 			if self.parts.wpn_fps_snp_musket_lead then --Pawcio's Musket
 				self.parts.wpn_fps_snp_musket_lead.pcs = nil
 				self.parts.wpn_fps_snp_musket_lead.supported = true
 				self.parts.wpn_fps_snp_musket_lead.stats = { value = 0 }
 				self.parts.wpn_fps_snp_musket_lead.custom_stats = nil
-		
-				self.wpn_fps_snp_musket.adds = { 
+
+				self.wpn_fps_snp_musket.adds = {
 					wpn_fps_upg_o_specter = { "wpn_fps_snp_model70_o_rail" },
 					wpn_fps_upg_o_aimpoint = { "wpn_fps_snp_model70_o_rail" },
 					wpn_fps_upg_o_aimpoint_2 = { "wpn_fps_snp_model70_o_rail" },
@@ -26130,21 +26130,21 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 					wpn_fps_upg_o_atibal = { "wpn_fps_snp_model70_o_rail" },
 					wpn_fps_upg_o_arbiter_irons_dmc = { "wpn_fps_snp_model70_o_rail" }
 				}
-		
+
 				self.wpn_fps_snp_musket_npc.adds = deep_clone(self.wpn_fps_snp_musket.adds)
-		
+
 				self.wpn_fps_snp_musket.override = self.wpn_fps_snp_musket.override or {}
-		
-		
-				table.insert(self.wpn_fps_snp_musket.uses_parts, "wpn_fps_upg_o_arbiter_irons_dmc")	
-				table.insert(self.wpn_fps_snp_musket.uses_parts, "wpn_fps_upg_o_specter")	
-				table.insert(self.wpn_fps_snp_musket.uses_parts, "wpn_fps_upg_o_aimpoint")	
+
+
+				table.insert(self.wpn_fps_snp_musket.uses_parts, "wpn_fps_upg_o_arbiter_irons_dmc")
+				table.insert(self.wpn_fps_snp_musket.uses_parts, "wpn_fps_upg_o_specter")
+				table.insert(self.wpn_fps_snp_musket.uses_parts, "wpn_fps_upg_o_aimpoint")
 				table.insert(self.wpn_fps_snp_musket.uses_parts, "wpn_fps_upg_o_docter")
 				table.insert(self.wpn_fps_snp_musket.uses_parts, "wpn_fps_upg_o_eotech")
 				table.insert(self.wpn_fps_snp_musket.uses_parts, "wpn_fps_upg_o_t1micro")
 				table.insert(self.wpn_fps_snp_musket.uses_parts, "wpn_fps_upg_o_rx30")
-				table.insert(self.wpn_fps_snp_musket.uses_parts, "wpn_fps_upg_o_rx01")	
-				table.insert(self.wpn_fps_snp_musket.uses_parts, "wpn_fps_upg_o_reflex")	
+				table.insert(self.wpn_fps_snp_musket.uses_parts, "wpn_fps_upg_o_rx01")
+				table.insert(self.wpn_fps_snp_musket.uses_parts, "wpn_fps_upg_o_reflex")
 				table.insert(self.wpn_fps_snp_musket.uses_parts, "wpn_fps_upg_o_eotech_xps")
 				table.insert(self.wpn_fps_snp_musket.uses_parts, "wpn_fps_upg_o_cmore")
 				table.insert(self.wpn_fps_snp_musket.uses_parts, "wpn_fps_upg_o_aimpoint_2")
@@ -26161,14 +26161,14 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 				table.insert(self.wpn_fps_snp_musket.uses_parts, "wpn_fps_upg_o_atibal")
 				table.insert(self.wpn_fps_snp_musket.uses_parts, "wpn_fps_upg_o_xpsg33_magnifier")
 				table.insert(self.wpn_fps_snp_musket.uses_parts, "wpn_fps_upg_o_sig")
-		
+
 				table.insert(self.wpn_fps_snp_musket.uses_parts, "wpn_fps_upg_fl_ass_smg_sho_peqbox")
 				table.insert(self.wpn_fps_snp_musket.uses_parts, "wpn_fps_upg_fl_ass_smg_sho_surefire")
 				table.insert(self.wpn_fps_snp_musket.uses_parts, "wpn_fps_upg_fl_ass_utg")
 				table.insert(self.wpn_fps_snp_musket.uses_parts, "wpn_fps_upg_fl_ass_peq15")
 				table.insert(self.wpn_fps_snp_musket.uses_parts, "wpn_fps_upg_fl_ass_laser")
 				table.insert(self.wpn_fps_snp_musket.uses_parts, "wpn_fps_upg_fl_ass_laser")
-		
+
 				table.insert(self.wpn_fps_snp_musket.uses_parts, "wpn_fps_upg_ass_ns_battle")
 				table.insert(self.wpn_fps_snp_musket.uses_parts, "wpn_fps_upg_ass_ns_jprifles")
 				table.insert(self.wpn_fps_snp_musket.uses_parts, "wpn_fps_upg_ass_ns_linear")
@@ -26178,7 +26178,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 				table.insert(self.wpn_fps_snp_musket.uses_parts, "wpn_fps_ass_shak12_ns_muzzle")
 				table.insert(self.wpn_fps_snp_musket.uses_parts, "wpn_fps_upg_ns_ass_smg_v6")
 				table.insert(self.wpn_fps_snp_musket.uses_parts, "wpn_fps_lmg_hk51b_ns_jcomp")
-		
+
 				self.wpn_fps_snp_musket_npc.uses_parts = deep_clone(self.wpn_fps_snp_musket.uses_parts)
 			end
 
@@ -26216,7 +26216,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 				self.parts.wpn_fps_upg_mp153_tube_ext_2.supported = true
 				self.parts.wpn_fps_upg_mp153_tube_ext_2.has_description = nil
 				--self.parts.wpn_fps_upg_mp153_tube_ext_2.adds = { "wpn_fps_upg_mp153_tube_forbid_2" }
-				self.parts.wpn_fps_upg_mp153_tube_ext_2.stats = { 
+				self.parts.wpn_fps_upg_mp153_tube_ext_2.stats = {
 					value = 2,
 					extra_ammo = 2,
 					concealment = -1
@@ -26227,7 +26227,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 
 				self.parts.wpn_fps_upg_mp153_tube_ext_4.supported = true
 				self.parts.wpn_fps_upg_mp153_tube_ext_4.has_description = nil
-				self.parts.wpn_fps_upg_mp153_tube_ext_4.stats = { 
+				self.parts.wpn_fps_upg_mp153_tube_ext_4.stats = {
 					value = 4,
 					extra_ammo = 4,
 					concealment = -2
@@ -26238,7 +26238,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 
 				self.parts.wpn_fps_upg_mp153_tube_ext_6.supported = true
 				self.parts.wpn_fps_upg_mp153_tube_ext_6.has_description = nil
-				self.parts.wpn_fps_upg_mp153_tube_ext_6.stats = { 
+				self.parts.wpn_fps_upg_mp153_tube_ext_6.stats = {
 					value = 6,
 					extra_ammo = 6,
 					concealment = -3
@@ -26265,11 +26265,11 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 				self.wpn_fps_shot_mp153.override = {
 					wpn_fps_upg_a_slug = deep_clone(shot_ammo.a_slug_semi_override),
 					wpn_fps_upg_a_custom = deep_clone(shot_ammo.a_custom_semi_override),
-					wpn_fps_upg_a_custom_free = deep_clone(shot_ammo.a_custom_semi_override),			
+					wpn_fps_upg_a_custom_free = deep_clone(shot_ammo.a_custom_semi_override),
 					wpn_fps_upg_a_explosive = deep_clone(shot_ammo.a_explosive_semi_override),
 					wpn_fps_upg_a_rip = deep_clone(shot_ammo.a_rip_semi_override),
 					wpn_fps_upg_a_piercing = deep_clone(shot_ammo.a_piercing_semi_override),
-					wpn_fps_upg_a_dragons_breath = deep_clone(shot_ammo.a_dragons_breath_semi_override)			
+					wpn_fps_upg_a_dragons_breath = deep_clone(shot_ammo.a_dragons_breath_semi_override)
 				}
 				table.insert(self.wpn_fps_shot_mp153.uses_parts, "wpn_fps_upg_a_dragons_breath")
 			end
@@ -26384,20 +26384,20 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 					custom_stats = deep_clone(stocks.fixed_to_hvy_rec_stats)
 				}
 
-				table.insert(self.wpn_fps_ass_scarl.uses_parts, "wpn_fps_upg_m4_m_straight")	
+				table.insert(self.wpn_fps_ass_scarl.uses_parts, "wpn_fps_upg_m4_m_straight")
 				table.insert(self.wpn_fps_ass_scarl_npc.uses_parts, "wpn_fps_upg_m4_m_straight")
-				table.insert(self.wpn_fps_ass_scarl.uses_parts, "wpn_fps_upg_m4_m_pmag")	
+				table.insert(self.wpn_fps_ass_scarl.uses_parts, "wpn_fps_upg_m4_m_pmag")
 				table.insert(self.wpn_fps_ass_scarl_npc.uses_parts, "wpn_fps_upg_m4_m_pmag")
-				table.insert(self.wpn_fps_ass_scarl.uses_parts, "wpn_fps_ass_l85a2_m_emag")	
+				table.insert(self.wpn_fps_ass_scarl.uses_parts, "wpn_fps_ass_l85a2_m_emag")
 				table.insert(self.wpn_fps_ass_scarl_npc.uses_parts, "wpn_fps_ass_l85a2_m_emag")
-				table.insert(self.wpn_fps_ass_scarl.uses_parts, "wpn_fps_upg_m4_m_l5")	
+				table.insert(self.wpn_fps_ass_scarl.uses_parts, "wpn_fps_upg_m4_m_l5")
 				table.insert(self.wpn_fps_ass_scarl_npc.uses_parts, "wpn_fps_upg_m4_m_l5")
-				table.insert(self.wpn_fps_ass_scarl.uses_parts, "wpn_fps_upg_m4_m_quad")	
+				table.insert(self.wpn_fps_ass_scarl.uses_parts, "wpn_fps_upg_m4_m_quad")
 				table.insert(self.wpn_fps_ass_scarl_npc.uses_parts, "wpn_fps_upg_m4_m_quad")
-				table.insert(self.wpn_fps_ass_scarl.uses_parts, "wpn_fps_upg_m4_m_drum")	
-				table.insert(self.wpn_fps_ass_scarl_npc.uses_parts, "wpn_fps_upg_m4_m_drum")	
-				table.insert(self.wpn_fps_ass_scarl.uses_parts, "wpn_fps_m4_upg_m_quick")	
-				table.insert(self.wpn_fps_ass_scarl_npc.uses_parts, "wpn_fps_m4_upg_m_quick")	
+				table.insert(self.wpn_fps_ass_scarl.uses_parts, "wpn_fps_upg_m4_m_drum")
+				table.insert(self.wpn_fps_ass_scarl_npc.uses_parts, "wpn_fps_upg_m4_m_drum")
+				table.insert(self.wpn_fps_ass_scarl.uses_parts, "wpn_fps_m4_upg_m_quick")
+				table.insert(self.wpn_fps_ass_scarl_npc.uses_parts, "wpn_fps_m4_upg_m_quick")
 			end
 
 			if self.parts.wpn_fps_snp_l115_stock then --Pawcio's L115
@@ -26475,7 +26475,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 				}
 
 				self.parts.wpn_fps_shot_super_body.supported = true
-				self.parts.wpn_fps_shot_super_body.stats = { 
+				self.parts.wpn_fps_shot_super_body.stats = {
 					spread_multi = {1.5, 0.75}
 				}
 
@@ -26563,7 +26563,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 				self.parts.wpn_fps_upg_p99_barrel_threaded.supported = true
 				self.parts.wpn_fps_upg_p99_barrel_threaded.stats = deep_clone(barrels.long_b1_stats)
 				self.parts.wpn_fps_upg_p99_barrel_threaded.custom_stats = deep_clone(barrels.long_b1_stats)
-				
+
 				--Extendo Clipazine
 				self.parts.wpn_fps_upg_p99_mag_ext.supported = true
 				self.parts.wpn_fps_upg_p99_mag_ext.stats = {
@@ -26616,39 +26616,39 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 				self.parts.wpn_fps_upg_g36k_fg_hkg36c.stats.value = nil
 				self.parts.wpn_fps_upg_g36k_fg_hkg36c.custom_stats = deep_clone(barrels.short_b1_stats)
 				self.parts.wpn_fps_upg_g36k_fg_hkg36k.supported = true
-				self.parts.wpn_fps_upg_g36k_fg_hkg36k.stats = { 
+				self.parts.wpn_fps_upg_g36k_fg_hkg36k.stats = {
 					spread = 1,
 					concealment = -1
 				}
 				self.parts.wpn_fps_upg_g36k_fg_hkg36.supported = true
-				self.parts.wpn_fps_upg_g36k_fg_hkg36.stats = { 
+				self.parts.wpn_fps_upg_g36k_fg_hkg36.stats = {
 					spread = 2,
 					concealment = -2
 				}
 
 				self.parts.wpn_fps_upg_g36k_fg_kacshort.supported = true
-				self.parts.wpn_fps_upg_g36k_fg_kacshort.stats = { 
+				self.parts.wpn_fps_upg_g36k_fg_kacshort.stats = {
 					concealment = 1,
 					recoil = -2
 				}
 				self.parts.wpn_fps_upg_g36k_fg_kac.supported = true
-				self.parts.wpn_fps_upg_g36k_fg_kac.stats = { 
+				self.parts.wpn_fps_upg_g36k_fg_kac.stats = {
 					spread = -1,
 					recoil = 2
 				}
 				self.parts.wpn_fps_upg_g36k_fg_kaclong.supported = true
-				self.parts.wpn_fps_upg_g36k_fg_kaclong.stats = { 
+				self.parts.wpn_fps_upg_g36k_fg_kaclong.stats = {
 					spread = -2,
 					recoil = 4
 				}
-				
+
 				self.parts.wpn_fps_upg_g36k_fg_hk243.supported = true
 				self.parts.wpn_fps_upg_g36k_fg_hk243.stats = {
 					spread = 1,
 					concealment = -1
 				}
 				self.parts.wpn_fps_upg_g36k_fg_hk243long.supported = true
-				self.parts.wpn_fps_upg_g36k_fg_hk243long.stats = { 
+				self.parts.wpn_fps_upg_g36k_fg_hk243long.stats = {
 					spread = 2,
 					concealment = -2
 				}
@@ -26659,7 +26659,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 					recoil = -2
 				}
 				self.parts.wpn_fps_upg_g36k_fg_btlong.supported = true
-				self.parts.wpn_fps_upg_g36k_fg_btlong.stats = { 
+				self.parts.wpn_fps_upg_g36k_fg_btlong.stats = {
 					recoil = 2,
 					concealment = -1
 				}
@@ -26732,7 +26732,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 					spread = -1,
 					reload = 3
 				}
-				
+
 				self.parts.wpn_fps_upg_g36k_mag_cmag.supported = true
 				self.parts.wpn_fps_upg_g36k_mag_cmag.has_description = nil
 				self.parts.wpn_fps_upg_g36k_mag_cmag.stats = deep_clone(self.parts.wpn_fps_upg_m4_m_drum.stats)
@@ -26780,10 +26780,10 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 					custom_stats = deep_clone(stocks.adj_hvy_acc_stats)
 				}
 
-				table.insert(self.wpn_fps_ass_g36.uses_parts, "wpn_fps_upg_g36k_mag20")	
-				table.insert(self.wpn_fps_ass_g36.uses_parts, "wpn_fps_upg_g36k_mag20magpul")	
-				table.insert(self.wpn_fps_ass_g36.uses_parts, "wpn_fps_upg_g36k_mag_dual30")	
-				table.insert(self.wpn_fps_ass_g36.uses_parts, "wpn_fps_upg_g36k_mag_cmag")	
+				table.insert(self.wpn_fps_ass_g36.uses_parts, "wpn_fps_upg_g36k_mag20")
+				table.insert(self.wpn_fps_ass_g36.uses_parts, "wpn_fps_upg_g36k_mag20magpul")
+				table.insert(self.wpn_fps_ass_g36.uses_parts, "wpn_fps_upg_g36k_mag_dual30")
+				table.insert(self.wpn_fps_ass_g36.uses_parts, "wpn_fps_upg_g36k_mag_cmag")
 				self.wpn_fps_ass_g36_npc.uses_parts = deep_clone(self.wpn_fps_ass_g36.uses_parts)
 			end
 
@@ -26819,10 +26819,10 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 				self.parts.wpn_fps_upg_ppsh_barrel_k50m.supported = true
 				self.parts.wpn_fps_upg_ppsh_barrel_k50m.stats = deep_clone(barrels.short_b2_stats)
 				self.parts.wpn_fps_upg_ppsh_barrel_k50m.custom_stats = deep_clone(barrels.short_b2_stats)
-				
+
 				self.parts.wpn_fps_upg_ppsh_stock_k50m.supported = true
 				self.parts.wpn_fps_upg_ppsh_stock_k50m.stats = deep_clone(stocks.fixed_to_nocheeks_stats)
-				self.parts.wpn_fps_upg_ppsh_stock_k50m.custom_stats = deep_clone(stocks.fixed_to_nocheeks_stats)		
+				self.parts.wpn_fps_upg_ppsh_stock_k50m.custom_stats = deep_clone(stocks.fixed_to_nocheeks_stats)
 			end
 
 			if self.parts.wpn_fps_upg_pps43_mag_window then
@@ -26838,7 +26838,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 				self.parts.wpn_fps_upg_pps43_stock_folded.supported = true
 				self.parts.wpn_fps_upg_pps43_stock_folded.stats = deep_clone(stocks.fold_nocheeks_stats)
 				self.parts.wpn_fps_upg_pps43_stock_folded.custom_stats = deep_clone(stocks.fold_nocheeks_stats)
-				
+
 				self.parts.wpn_fps_upg_pps43_barrel_nobrake.supported = true
 				self.parts.wpn_fps_upg_pps43_barrel_nobrake.stats = { value = 0, recoil = -2, concealment = 1 }
 				self.parts.wpn_fps_upg_pps43_barrel_nobrake.custom_stats = nil
@@ -26856,12 +26856,12 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 					concealment = 1,
 					recoil = -2
 				}
-				self.parts.wpn_fps_aug_body_aug_a1.override = { 
+				self.parts.wpn_fps_aug_body_aug_a1.override = {
 					wpn_fps_upg_vg_ass_smg_verticalgrip_vanilla = {
 						unit = "units/payday2/weapons/wpn_upg_dummy/wpn_upg_dummy"
 					}
 				}
-				self.parts.wpn_fps_aug_body_aug_a1.forbids = { 
+				self.parts.wpn_fps_aug_body_aug_a1.forbids = {
 					"wpn_fps_upg_vg_ass_smg_stubby",
 					"wpn_fps_smg_schakal_vg_surefire",
 					"wpn_fps_vg_vmp_vert",
@@ -26876,12 +26876,12 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 					concealment = 1,
 					recoil = -2
 				}
-				self.parts.wpn_fps_aug_body_aug_a3.override = { 
+				self.parts.wpn_fps_aug_body_aug_a3.override = {
 					wpn_fps_upg_vg_ass_smg_verticalgrip_vanilla = {
 						unit = "units/payday2/weapons/wpn_upg_dummy/wpn_upg_dummy"
 					}
 				}
-				self.parts.wpn_fps_aug_body_aug_a3.forbids = { 
+				self.parts.wpn_fps_aug_body_aug_a3.forbids = {
 					"wpn_fps_upg_vg_ass_smg_stubby",
 					"wpn_fps_smg_schakal_vg_surefire",
 					"wpn_fps_vg_vmp_vert",
@@ -26904,7 +26904,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 				self.parts.wpn_fps_aug_m_a1_42.custom_stats = {
 					ads_speed_mult = 1.05
 				}
-				
+
 				self.parts.wpn_fps_aug_o_scope_a1.supported = true
 				self.parts.wpn_fps_aug_o_scope_a1.has_description = true
 				self.parts.wpn_fps_aug_o_scope_a1.desc_id = "bm_wp_upg_o_1_5_scope"
@@ -26998,7 +26998,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 				self.parts.wpn_fps_upg_svd_barrel_short.stats = deep_clone(barrels.short_b2_stats)
 				self.parts.wpn_fps_upg_svd_barrel_short.custom_stats = deep_clone(barrels.short_b2_stats)
 
-				self.parts.wpn_fps_upg_svd_supp_pbs1.supported = true	
+				self.parts.wpn_fps_upg_svd_supp_pbs1.supported = true
 				self.parts.wpn_fps_upg_svd_supp_pbs1.stats = {
 					value = 2,
 					suppression = 12,
@@ -27042,7 +27042,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 				self.parts.wpn_fps_ass_sks_mag.has_description = nil
 				self.parts.wpn_fps_ass_sks_mag.desc_id = "bm_wp_upg_m_sksclip"
 				self.parts.wpn_fps_ass_sks_mag.stats = { value = 0 }
-				self.parts.wpn_fps_ass_sks_mag.custom_stats = { 
+				self.parts.wpn_fps_ass_sks_mag.custom_stats = {
 					tactical_reload = false
 				}
 
@@ -27065,7 +27065,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 				self.parts.wpn_fps_upg_sks_mag_detach20.desc_id = "bm_wp_wpn_fps_ass_sks_mags_reload"
 				self.parts.wpn_fps_upg_sks_mag_detach20.has_description = true
 				self.parts.wpn_fps_upg_sks_mag_detach20.stats = { extra_ammo = 10, reload = -10, concealment = -2 }
-				self.parts.wpn_fps_upg_sks_mag_detach20.custom_stats = { 
+				self.parts.wpn_fps_upg_sks_mag_detach20.custom_stats = {
 					tactical_reload = 1,
 					ads_speed_mult = 1.05,
 					reload_not_empty_speed_multiplier = 3,
@@ -27151,7 +27151,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 						concealment = 1,
 						recoil = -2
 					}
-	
+
 					self.parts.wpn_fps_upg_m1a1_mag_30.supported = true
 					self.parts.wpn_fps_upg_m1a1_mag_30.stats = {
 						value = 2,
@@ -27173,7 +27173,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 					self.parts.wpn_fps_upg_m1a1_mag_30dual.custom_stats = {
 						ads_speed_mult = 1.05
 					}
-	
+
 					self.parts.wpn_fps_upg_m1a1_stock_ammopounches.supported = true
 					self.parts.wpn_fps_upg_m1a1_stock_ammopounches.stats = {
 						value = 2,
@@ -27186,11 +27186,11 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 					self.parts.wpn_fps_upg_m1a1_stock_m2.supported = true
 					self.parts.wpn_fps_upg_m1a1_stock_m2.stats = deep_clone(stocks.folder_to_fixed_acc1_rec2_stats)
 					self.parts.wpn_fps_upg_m1a1_stock_m2.custom_stats = deep_clone(stocks.folder_to_fixed_acc1_rec2_stats)
-	
+
 					self.parts.wpn_fps_upg_m1a1_stock_m2cheekrest.supported = true
 					self.parts.wpn_fps_upg_m1a1_stock_m2cheekrest.stats = deep_clone(stocks.folder_to_fixed_rec3_stats)
 					self.parts.wpn_fps_upg_m1a1_stock_m2cheekrest.custom_stats = deep_clone(stocks.folder_to_fixed_rec3_stats)
-	
+
 					self.parts.wpn_fps_upg_m1a1_stock_m2ammopounches.supported = true
 					self.parts.wpn_fps_upg_m1a1_stock_m2ammopounches.stats = {
 						value = 6,
@@ -27208,19 +27208,19 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 						concealment = -1,
 						recoil = 2
 					}
-	
+
 					self.parts.wpn_fps_upg_m2_mag_15.supported = true
 					self.parts.wpn_fps_upg_m2_mag_15.stats = { value = 1, reload = 5, concealment = 2, extra_ammo = -15}
 					self.parts.wpn_fps_upg_m2_mag_15.custom_stats = { ads_speed_mult = 0.95 }
-	
+
 					self.parts.wpn_fps_upg_m2_mag_30dual.supported = true
 					self.parts.wpn_fps_upg_m2_mag_30dual.stats = { value = 2, reload = 3, concealment = -1, spread = -1}
 					self.parts.wpn_fps_upg_m2_mag_30dual.custom_stats = nil
-	
+
 					self.parts.wpn_fps_upg_m2_stock_cheekrest.supported = true
 					self.parts.wpn_fps_upg_m2_stock_cheekrest.stats = { value = 2, recoil = 2, spread = -1}
 					self.parts.wpn_fps_upg_m2_stock_cheekrest.custom_stats = nil
-	
+
 					self.parts.wpn_fps_upg_m2_stock_ammopounches.supported = true
 					self.parts.wpn_fps_upg_m2_stock_ammopounches.stats = {
 						value = 2,
@@ -27229,11 +27229,11 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 						reload = 3
 					}
 					self.parts.wpn_fps_upg_m2_stock_ammopounches.custom_stats = nil
-	
+
 					self.parts.wpn_fps_upg_m2_stock_m1a1.supported = true
 					self.parts.wpn_fps_upg_m2_stock_m1a1.stats = deep_clone(stocks.fixed_to_folder_stats)
 					self.parts.wpn_fps_upg_m2_stock_m1a1.custom_stats = deep_clone(stocks.fixed_to_folder_stats)
-	
+
 					self.parts.wpn_fps_upg_m2_stock_m1a1ammopounches.supported = true
 					self.parts.wpn_fps_upg_m2_stock_m1a1ammopounches.stats = {
 						value = 4,
@@ -27336,7 +27336,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 				self.parts.wpn_fps_upg_m1919a6_mag_ext.custom_stats = {
 					ads_speed_mult = 1.1
 				}
-				
+
 				self.parts.wpn_fps_upg_m1919a6_barrel_m1917.supported = true
 				self.parts.wpn_fps_upg_m1919a6_barrel_m1917.stats = {
 					value = 2,
@@ -27354,7 +27354,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 				self.parts.wpn_fps_upg_m1919a6_stock_m1.supported = true
 				self.parts.wpn_fps_upg_m1919a6_stock_m1.stats = deep_clone(stocks.fixed_acc_stats)
 				self.parts.wpn_fps_upg_m1919a6_stock_m1.custom_stats = deep_clone(stocks.fixed_acc_stats)
-				
+
 				self.parts.wpn_fps_upg_m1919a6_irons.pcs = nil
 				table.insert(self.wpn_fps_lmg_m1919a6.default_blueprint, "wpn_fps_upg_m1919a6_irons")
 			end
@@ -27672,7 +27672,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 					reload = 5,
 					extra_ammo = -10
 				}
-				self.parts.wpn_fps_upg_sr3m_mag_20rnd.custom_stats = { 
+				self.parts.wpn_fps_upg_sr3m_mag_20rnd.custom_stats = {
 					ads_speed_mult = 0.95
 				}
 
@@ -28423,7 +28423,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 					reload = 5,
 					extra_ammo = -10
 				}
-				self.parts.wpn_fps_upg_ak12_2014_mag_steel20.custom_stats = { 
+				self.parts.wpn_fps_upg_ak12_2014_mag_steel20.custom_stats = {
 					ads_speed_mult = 0.95
 				}
 				self.parts.wpn_fps_upg_ak12_2014_mag_steel20dual.supported = true
@@ -28434,7 +28434,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 					reload = 8,
 					extra_ammo = -10
 				}
-				self.parts.wpn_fps_upg_ak12_2014_mag_steel20dual.custom_stats = { 
+				self.parts.wpn_fps_upg_ak12_2014_mag_steel20dual.custom_stats = {
 					ads_speed_mult = 0.95
 				}
 				self.parts.wpn_fps_upg_ak12_2014_mag_steel20magpul.supported = true
@@ -28445,7 +28445,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 					reload = 8,
 					extra_ammo = -10
 				}
-				self.parts.wpn_fps_upg_ak12_2014_mag_steel20magpul.custom_stats = { 
+				self.parts.wpn_fps_upg_ak12_2014_mag_steel20magpul.custom_stats = {
 					ads_speed_mult = 0.95
 				}
 				self.parts.wpn_fps_upg_ak12_2014_mag_waffle40.supported = true
@@ -28468,6 +28468,116 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 				self.wpn_fps_ass_ak12_2014.override.wpn_fps_upg_m4_s_standard = {
 					stats = {},
 					custom_stats = {}
+				}
+			end
+
+			if self.parts.wpn_fps_pis_hk45c_mag then
+				self.parts.wpn_fps_pis_hk45c_mag.supported = true
+				self.parts.wpn_fps_pis_hk45c_mag.stats = { value = 0 }
+				self.parts.wpn_fps_pis_hk45c_mag.custom_stats = nil
+
+				self.parts.wpn_fps_upg_hk45c_sight_tritium.supported = true
+				self.parts.wpn_fps_upg_hk45c_sight_tritium.stats = { value = 0 }
+				self.parts.wpn_fps_upg_hk45c_sight_tritium.custom_stats = nil
+				self.parts.wpn_fps_upg_hk45c_sight_ghostring.supported = true
+				self.parts.wpn_fps_upg_hk45c_sight_ghostring.stats = { value = 0 }
+				self.parts.wpn_fps_upg_hk45c_sight_ghostring.custom_stats = nil
+
+				self.parts.wpn_fps_upg_hk45c_mag_elephant.supported = true
+				self.parts.wpn_fps_upg_hk45c_mag_elephant.stats = {
+					extra_ammo = 2,
+					reload = -3,
+					concealment = -1,
+					value = 1
+				}
+
+				self.parts.wpn_fps_upg_hk45c_mag_ext.supported = true
+				self.parts.wpn_fps_upg_hk45c_mag_ext.stats = {
+					value = 8,
+					extra_ammo = 6,
+					concealment = -2,
+					reload = -4
+				}
+				self.parts.wpn_fps_upg_hk45c_mag_ext.custom_stats = { ads_speed_mult = 1.05 }
+
+				self.parts.wpn_fps_upg_hk45c_aac_tirant.supported = true
+				self.parts.wpn_fps_upg_hk45c_aac_tirant.stats = deep_clone(muzzle_device.supp_acc_r)
+				self.parts.wpn_fps_upg_hk45c_aac_tirant.custom_stats = deep_clone(muzzle_device.supp_acc_r)
+				self.parts.wpn_fps_upg_hk45c_aac_tirant.perks = {"silencer"}
+			end
+
+			if self.parts.wpn_fps_x_hk45c_mag then
+				self.parts.wpn_fps_x_hk45c_mag.supported = true
+				self.parts.wpn_fps_x_hk45c_mag.stats = { value = 0 }
+				self.parts.wpn_fps_x_hk45c_mag.custom_stats = nil
+
+				self.parts.wpn_fps_upg_x_hk45c_mag_elephant.supported = true
+				self.parts.wpn_fps_upg_x_hk45c_mag_elephant.stats = {
+					extra_ammo = 4,
+					reload = -3,
+					concealment = -1,
+					value = 1
+				}
+
+				self.parts.wpn_fps_upg_x_hk45c_mag_ext.supported = true
+				self.parts.wpn_fps_upg_x_hk45c_mag_ext.stats = {
+					value = 8,
+					extra_ammo = 12,
+					concealment = -2,
+					reload = -4
+				}
+				self.parts.wpn_fps_upg_x_hk45c_mag_ext.custom_stats = { ads_speed_mult = 1.05 }
+			end
+
+			if self.parts.wpn_fps_lmg_rpd_mag then
+				self.parts.wpn_fps_lmg_rpd_mag.supported = true
+				self.parts.wpn_fps_lmg_rpd_mag.stats = { value = 0 }
+				self.parts.wpn_fps_lmg_rpd_mag.custom_stats = nil
+
+				self.parts.wpn_fps_upg_rpd_bipod.supported = true
+				self.parts.wpn_fps_upg_rpd_bipod.has_description = true
+				self.parts.wpn_fps_upg_rpd_bipod.desc_id = "bm_sc_bipod_desc"
+				self.parts.wpn_fps_upg_rpd_bipod.stats = deep_clone(self.parts.wpn_fps_upg_bp_lmg_lionbipod.stats)
+				self.parts.wpn_fps_upg_rpd_bipod.stats.value = 0
+				self.parts.wpn_fps_upg_rpd_bipod.custom_stats = deep_clone(self.parts.wpn_fps_upg_bp_lmg_lionbipod.custom_stats)
+				self.parts.wpn_fps_upg_rpd_bipod.perks = {"bipod"}
+
+				self.parts.wpn_fps_upg_rpd_vanilia_ads.pcs = nil
+			end
+
+			if self.parts.wpn_fps_smg_cbjms_mag then
+				self.parts.wpn_fps_smg_cbjms_mag.supported = true
+				self.parts.wpn_fps_smg_cbjms_mag.stats = { value = 0 }
+				self.parts.wpn_fps_smg_cbjms_mag.custom_stats = nil
+
+				self.parts.wpn_fps_smg_cbjms_receiver.adds = {}
+
+				self.parts.wpn_fps_upg_cbjms_no_stock.supported = true
+				self.parts.wpn_fps_upg_cbjms_no_stock.stats = deep_clone(stocks.remove_folded_stats)
+				self.parts.wpn_fps_upg_cbjms_no_stock.custom_stats = deep_clone(stocks.remove_folded_stats)
+				self.parts.wpn_fps_upg_cbjms_stock_extended.supported = true
+				self.parts.wpn_fps_upg_cbjms_stock_extended.stats = deep_clone(stocks.unfold_nocheeks_stats)
+				self.parts.wpn_fps_upg_cbjms_stock_extended.custom_stats = deep_clone(stocks.unfold_nocheeks_stats)
+
+				self.parts.wpn_fps_upg_cbjms_drum_mag_half.supported = true
+				self.parts.wpn_fps_upg_cbjms_drum_mag_half.stats = {
+					value = 1,
+					extra_ammo = 20,
+					reload = -3,
+					concealment = -4
+				}
+				self.parts.wpn_fps_upg_cbjms_drum_mag_half.custom_stats = {
+					ads_speed_mult = 1.1
+				}
+				self.parts.wpn_fps_upg_cbjms_drum_mag.supported = true
+				self.parts.wpn_fps_upg_cbjms_drum_mag.stats = {
+					value = 9,
+					extra_ammo = 70,
+					reload = -9,
+					concealment = -7
+				}
+				self.parts.wpn_fps_upg_cbjms_drum_mag.custom_stats = {
+					ads_speed_mult = 1.175
 				}
 			end
 
@@ -28680,7 +28790,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 			self.parts.wpn_fps_ass_hk_g56_flash_hider.perks = nil
 			self.parts.wpn_fps_ass_hk_g56_handguard.adds = nil
 			self.parts.wpn_fps_ass_hk_g56_irons_rear.stance_mod = {
-				wpn_fps_ass_hk_g56 = { 
+				wpn_fps_ass_hk_g56 = {
 					translation = Vector3(-4.912, -8, -2.538),
 					rotation = Rotation(-0.15, 0.3, -10.5)
 				}
@@ -28693,14 +28803,14 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 			self.parts.wpn_fps_ass_hk_g56_bipod.supported = true
 			self.parts.wpn_fps_ass_hk_g56_bipod.custom_stats = nil
 			self.parts.wpn_fps_ass_hk_g56_bipod.stats = {
-				value = 5, 
+				value = 5,
 				concealment = -3,
 				recoil = 6
 			}
 			self.parts.wpn_fps_ass_hk_g56_bipod_folded.supported = true
 			self.parts.wpn_fps_ass_hk_g56_bipod_folded.custom_stats = nil
 			self.parts.wpn_fps_ass_hk_g56_bipod_folded.stats = {
-				value = 5, 
+				value = 5,
 				concealment = -1,
 				recoil = 2
 			}
@@ -28720,10 +28830,10 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 				recoil = -2
 			}
 			--STOCKS
-			self.parts.wpn_fps_ass_hk_g56_stock_long.supported = true 
+			self.parts.wpn_fps_ass_hk_g56_stock_long.supported = true
 			self.parts.wpn_fps_ass_hk_g56_stock_long.stats = deep_clone(stocks.unfold_folded_stats)
 			self.parts.wpn_fps_ass_hk_g56_stock_long.custom_stats = deep_clone(stocks.unfold_folded_stats)
-			self.parts.wpn_fps_ass_hk_g56_stock_short.supported = true 
+			self.parts.wpn_fps_ass_hk_g56_stock_short.supported = true
 			self.parts.wpn_fps_ass_hk_g56_stock_short.stats = deep_clone(stocks.fold_folder_stats)
 			self.parts.wpn_fps_ass_hk_g56_stock_short.custom_stats = deep_clone(stocks.fold_folder_stats)
 			--MAGS
@@ -28766,7 +28876,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 
 			self.parts.wpn_fps_smg_geasy9_ammo_grom.pcs = {}
 			self.parts.wpn_fps_smg_geasy9_ammo_grom.no_cull = true
-			self.parts.wpn_fps_smg_geasy9_ammo_grom.stats = { 
+			self.parts.wpn_fps_smg_geasy9_ammo_grom.stats = {
 				value = 10,
 				recoil = -6,
 				total_ammo_mod = -18
@@ -28873,7 +28983,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 					concealment = 1,
 					reload = 3
 				}
-				self.parts.wpn_fps_smg_geasy9_magazine_fast.custom_stats = { 
+				self.parts.wpn_fps_smg_geasy9_magazine_fast.custom_stats = {
 					ads_speed_mult = 0.975,
 					reload_non_empty_anim_mult = 0.97,
 					adj_timers = {
@@ -28889,7 +28999,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 					concealment = 2,
 					reload = 6
 				}
-				self.parts.wpn_fps_smg_geasy9_magazine_short.custom_stats = { 
+				self.parts.wpn_fps_smg_geasy9_magazine_short.custom_stats = {
 					ads_speed_mult = 0.95,
 					reload_non_empty_anim_mult = 0.92,
 					adj_timers = {
@@ -28904,7 +29014,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 					reload = -4,
 					extra_ammo = 10
 				}
-				self.parts.wpn_fps_smg_geasy9_xmag1.custom_stats = { 
+				self.parts.wpn_fps_smg_geasy9_xmag1.custom_stats = {
 					ads_speed_mult = 1.05,
 					reload_non_empty_anim_mult = 0.97,
 					adj_timers = {
@@ -28920,7 +29030,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 					reload = -6,
 					extra_ammo = 20
 				}
-				self.parts.wpn_fps_smg_geasy9_xmag2.custom_stats = { 
+				self.parts.wpn_fps_smg_geasy9_xmag2.custom_stats = {
 					ads_speed_mult = 1.1,
 					reload_non_empty_anim_mult = 0.91,
 					adj_timers = {
@@ -29028,7 +29138,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 					concealment = 1,
 					reload = 3
 				}
-				self.parts.wpn_fps_shot_uncle12_magazine_fast1.custom_stats = { 
+				self.parts.wpn_fps_shot_uncle12_magazine_fast1.custom_stats = {
 					ads_speed_mult = 0.975,
 					reload_non_empty_anim_mult = 1.16666
 				}
@@ -29040,7 +29150,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 					concealment = 2,
 					reload = 6
 				}
-				self.parts.wpn_fps_shot_uncle12_magazine_fast2.custom_stats = { 
+				self.parts.wpn_fps_shot_uncle12_magazine_fast2.custom_stats = {
 					ads_speed_mult = 0.95,
 					reload_non_empty_anim_mult = 1.2666
 				}
@@ -29052,7 +29162,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 					reload = -3,
 					extra_ammo = 3
 				}
-				self.parts.wpn_fps_shot_uncle12_xmag1.custom_stats = { 
+				self.parts.wpn_fps_shot_uncle12_xmag1.custom_stats = {
 					ads_speed_mult = 1.025,
 					reload_non_empty_anim_mult = 1.366,
 					adj_timers = {
@@ -29067,7 +29177,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 					reload = -5,
 					extra_ammo = 8
 				}
-				self.parts.wpn_fps_shot_uncle12_xmag2.custom_stats = { 
+				self.parts.wpn_fps_shot_uncle12_xmag2.custom_stats = {
 					ads_speed_mult = 1.075,
 					reload_non_empty_anim_mult = 1.4,
 					adj_timers = {
@@ -29237,7 +29347,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 					reload = 3,
 					extra_ammo = -5
 				}
-				self.parts.wpn_fps_ass_coslo723_magazine_flip.custom_stats = { 
+				self.parts.wpn_fps_ass_coslo723_magazine_flip.custom_stats = {
 					ads_speed_mult = 0.975
 				}
 				--FM 2
@@ -29248,7 +29358,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 					reload = 5,
 					extra_ammo = -10
 				}
-				self.parts.wpn_fps_ass_coslo723_magazine_fastreload2.custom_stats = { 
+				self.parts.wpn_fps_ass_coslo723_magazine_fastreload2.custom_stats = {
 					ads_speed_mult = 0.95
 				}
 				--EX 1
@@ -29258,7 +29368,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 					concealment = -2,
 					extra_ammo = 15
 				}
-				self.parts.wpn_fps_ass_coslo723_magazine_ext.custom_stats = { 
+				self.parts.wpn_fps_ass_coslo723_magazine_ext.custom_stats = {
 					ads_speed_mult = 1.05
 				}
 				--EX 2
@@ -29269,7 +29379,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 					reload = -6,
 					extra_ammo = 30
 				}
-				self.parts.wpn_fps_ass_coslo723_magazine_box.custom_stats = { 
+				self.parts.wpn_fps_ass_coslo723_magazine_box.custom_stats = {
 					ads_speed_mult = 1.1
 				}
 				--EX 3
@@ -29306,7 +29416,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 			for i, part_id in pairs(self.wpn_fps_ass_coslo723.uses_parts) do
 				if self.parts[part_id] and self.parts[part_id].type then
 					if self.parts[part_id].pcs then
-						if ((self.parts[part_id].global_value and self.parts[part_id].global_value ~= "coslo723_mod") or not self.parts[part_id].global_value) and 
+						if ((self.parts[part_id].global_value and self.parts[part_id].global_value ~= "coslo723_mod") or not self.parts[part_id].global_value) and
 							(self.parts[part_id].type == "grip" or self.parts[part_id].type == "stock" or self.parts[part_id].type == "magazine") then
 							self.wpn_fps_ass_coslo723.uses_parts[i] = "resmod_dummy"
 						end
@@ -29431,7 +29541,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 					reload = 3,
 					extra_ammo = -5
 				}
-				self.parts.wpn_fps_ass_rmary2_magazine_fast1.custom_stats = { 
+				self.parts.wpn_fps_ass_rmary2_magazine_fast1.custom_stats = {
 					ads_speed_mult = 0.975
 				}
 				--FM 2
@@ -29442,7 +29552,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 					reload = 5,
 					extra_ammo = -10
 				}
-				self.parts.wpn_fps_ass_rmary2_magazine_fast2.custom_stats = { 
+				self.parts.wpn_fps_ass_rmary2_magazine_fast2.custom_stats = {
 					ads_speed_mult = 0.95
 				}
 				--EX 1
@@ -29453,7 +29563,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 					reload = -4,
 					extra_ammo = 10
 				}
-				self.parts.wpn_fps_ass_rmary2_xmag1.custom_stats = { 
+				self.parts.wpn_fps_ass_rmary2_xmag1.custom_stats = {
 					ads_speed_mult = 1.05
 				}
 				--EX 2
@@ -29464,7 +29574,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 					reload = -6,
 					extra_ammo = 20
 				}
-				self.parts.wpn_fps_ass_rmary2_xmag2.custom_stats = { 
+				self.parts.wpn_fps_ass_rmary2_xmag2.custom_stats = {
 					ads_speed_mult = 1.1
 				}
 
@@ -29638,9 +29748,9 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 			}
 
 			self.wpn_fps_ass_l403a1_npc.default_blueprint = deep_clone(self.wpn_fps_ass_l403a1.default_blueprint)
-			self.wpn_fps_ass_l403a1_npc.uses_parts = deep_clone(self.wpn_fps_ass_l403a1.uses_parts)	
+			self.wpn_fps_ass_l403a1_npc.uses_parts = deep_clone(self.wpn_fps_ass_l403a1.uses_parts)
 			self.wpn_fps_ass_l403a1_npc.adds = deep_clone(self.wpn_fps_ass_l403a1.adds)
-			self.wpn_fps_ass_l403a1_npc.override = deep_clone(self.wpn_fps_ass_l403a1.override)	
+			self.wpn_fps_ass_l403a1_npc.override = deep_clone(self.wpn_fps_ass_l403a1.override)
 		end
 
 		if self.parts.wpn_fps_ass_l119a2_magazine_pmag then
@@ -29784,7 +29894,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 				self.parts.wpn_fps_snp_mptango41_stock_mk.stats = deep_clone(stocks.adj_to_fold_stats)
 				self.parts.wpn_fps_snp_mptango41_stock_mk.stats.value = 0
 				self.parts.wpn_fps_snp_mptango41_stock_mk.custom_stats = deep_clone(stocks.adj_to_fold_stats)
-				
+
 				self.parts.wpn_fps_snp_mptango41_stock_ri.supported = true
 				self.parts.wpn_fps_snp_mptango41_stock_ri.stats = deep_clone(stocks.adj_to_nocheeks_stats)
 				self.parts.wpn_fps_snp_mptango41_stock_ri.stats.value = 0
@@ -29846,8 +29956,8 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 				self.wpn_fps_snp_mptango41.override[part_id] = { a_obj = "a_o_meme"}
 			end
 
-			self.wpn_fps_snp_mptango41_npc.adds = deep_clone(self.wpn_fps_snp_mptango41.adds)	
-			self.wpn_fps_snp_mptango41_npc.uses_parts = deep_clone(self.wpn_fps_snp_mptango41.uses_parts)	
+			self.wpn_fps_snp_mptango41_npc.adds = deep_clone(self.wpn_fps_snp_mptango41.adds)
+			self.wpn_fps_snp_mptango41_npc.uses_parts = deep_clone(self.wpn_fps_snp_mptango41.uses_parts)
 		end
 
 		--TTI GEN-12
@@ -29860,8 +29970,8 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 			self.parts.wpn_fps_shot_tti_dracarys_grip.custom_stats = nil
 
 			self.parts.wpn_fps_shot_tti_dracarys_eotech.supported = true
-			self.parts.wpn_fps_shot_tti_dracarys_eotech.desc_id = "bm_wp_upg_o_1_5"			
-			self.parts.wpn_fps_shot_tti_dracarys_eotech.has_description = true			
+			self.parts.wpn_fps_shot_tti_dracarys_eotech.desc_id = "bm_wp_upg_o_1_5"
+			self.parts.wpn_fps_shot_tti_dracarys_eotech.has_description = true
 			self.parts.wpn_fps_shot_tti_dracarys_eotech.stats = {
 				value = 3,
 				zoom = 5
@@ -29955,7 +30065,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 				reload = 4,
 				extra_ammo = -10
 			}
-			self.parts.wpn_fps_ass_pd3_qbz191_smag.custom_stats = { 
+			self.parts.wpn_fps_ass_pd3_qbz191_smag.custom_stats = {
 				ads_speed_mult = 0.975
 			}
 			self.parts.wpn_fps_ass_pd3_qbz191_magazine_quick.supported = true
@@ -29986,7 +30096,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 				custom_stats = {}
 			}
 
-			self.wpn_fps_ass_pd3_qbz191_npc.uses_parts = deep_clone(self.wpn_fps_ass_pd3_qbz191.uses_parts)	
+			self.wpn_fps_ass_pd3_qbz191_npc.uses_parts = deep_clone(self.wpn_fps_ass_pd3_qbz191.uses_parts)
 		end
 
 		--RJC9000, PlayBONK, and Offyerocker's M7 SMG
@@ -30046,9 +30156,9 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 				steelsight_id = part_id .. "_steelsight"
 				self.parts[part_id].steelsight_visible = false
 				self.parts[part_id].adds = self.parts[part_id].adds or {}
-		
+
 				table.insert(self.parts[part_id].adds, steelsight_id)
-		
+
 				self.parts[steelsight_id] = steelsight_data
 				self.parts[steelsight_id].steelsight_visible = true
 				self.parts[steelsight_id].stats = {
@@ -30109,8 +30219,8 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 			table.insert(self.wpn_fps_snp_pd3_lynx.uses_parts, "wpn_fps_upg_o_t1micro")
 			table.insert(self.wpn_fps_snp_pd3_lynx.uses_parts, "wpn_fps_upg_o_cmore")
 			table.insert(self.wpn_fps_snp_pd3_lynx.uses_parts, "wpn_fps_upg_o_aimpoint_2")
-			table.insert(self.wpn_fps_snp_pd3_lynx.uses_parts, "wpn_fps_upg_o_cs")	
-			table.insert(self.wpn_fps_snp_pd3_lynx.uses_parts, "wpn_fps_upg_o_rx30")	
+			table.insert(self.wpn_fps_snp_pd3_lynx.uses_parts, "wpn_fps_upg_o_cs")
+			table.insert(self.wpn_fps_snp_pd3_lynx.uses_parts, "wpn_fps_upg_o_rx30")
 			table.insert(self.wpn_fps_snp_pd3_lynx.uses_parts, "wpn_fps_upg_o_rx01")
 			table.insert(self.wpn_fps_snp_pd3_lynx.uses_parts, "wpn_fps_upg_o_reflex")
 			table.insert(self.wpn_fps_snp_pd3_lynx.uses_parts, "wpn_fps_upg_o_eotech_xps")
@@ -30164,7 +30274,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 					translation = Vector3(-0.01, -4, 0.985)
 				}
 			}
-			
+
 			self.parts.wpn_fps_ass_br55_magazine.stats = { value = 0 }
 			self.parts.wpn_fps_ass_br55_barrel.stats = { value = 0 }
 			self.parts.wpn_fps_ass_br55_barrel.custom_stats = nil
@@ -30204,7 +30314,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 			self.parts.wpn_fps_ass_t9fastburst_receiver.perks = nil
 			self.parts.wpn_fps_ass_t9fastburst_receiver.stats = { value = 0 }
 			self.parts.wpn_fps_ass_t9fastburst_receiver.adds = { "g11_lock_burst" }
-	
+
 			--Magazines
 				--55 Rnd Drum
 				self.parts.wpn_fps_ass_t9fastburst_xmag_01.supported = true
@@ -30269,7 +30379,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 				self.parts.wpn_fps_ass_t9fastburst_magazine_mix_pro.custom_stats = {
 					ads_speed_mult = 1.1
 				}
-	
+
 			--Barrels
 				--Rapid Fire
 				self.parts.wpn_fps_ass_t9fastburst_barrel_short_01.supported = true
@@ -30316,7 +30426,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 				self.parts.wpn_fps_ass_t9fastburst_barrel_heavy_01.stats.concealment = 0
 				self.parts.wpn_fps_ass_t9fastburst_barrel_heavy_01.custom_stats = deep_clone(barrels.long_b3_stats)
 				self.parts.wpn_fps_ass_t9fastburst_barrel_heavy_01.custom_stats.ads_speed_mult = nil
-	
+
 			--Grips
 				--Speed Tape
 				self.parts.wpn_fps_ass_t9fastburst_quickdraw_01.supported = true
@@ -30370,7 +30480,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 				self.parts.wpn_fps_ass_t9fastburst_handle_mix_pro.custom_stats = {
 					ads_speed_mult = 0.95
 				}
-	
+
 			--Stocks
 				--Tactical Stock
 				self.parts.wpn_fps_ass_t9fastburst_stock_cheekrest_01.supported = true
@@ -30427,7 +30537,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 				self.parts.wpn_fps_ass_t9fastburst_stock_mix_pro.custom_stats = {
 					ads_speed_mult = 0.975
 				}
-	
+
 			self.parts.g11_lock_burst = { --dummy attachment to modify the available firemodes on the stat chart
 				type = "custom",
 				sub_type = "autofire",
@@ -30449,7 +30559,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 				},
 				internal_part = true
 			}
-	
+
 			self.parts.wpn_fps_ass_t9fastburst_i_g11athome = {
 				pcs = {},
 				type = "custom",
@@ -30486,11 +30596,11 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 				},
 				forbids = {
 					"g11_lock_burst",
-	
+
 					"wpn_fps_ass_t9fastburst_barrel_mix_01",
 					"wpn_fps_ass_t9fastburst_barrel_short_01",
 					"wpn_fps_ass_t9fastburst_barrel_short_pro",
-	
+
 					"wpn_fps_ass_t9fastburst_magazine_mix_01",
 					"wpn_fps_ass_t9fastburst_magazine_mix_pro",
 					"wpn_fps_ass_t9fastburst_xmag_01",
@@ -30499,7 +30609,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 				internal_part = true,
 				dlc = "sc"
 			}
-	
+
 			self.parts.wpn_fps_ass_t9fastburst_g11_sound_switch = {
 				third_unit = "units/payday2/weapons/wpn_upg_dummy/wpn_upg_dummy",
 				a_obj = "a_body",
@@ -30519,9 +30629,9 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 					}
 				}
 			}
-	
+
 			table.insert(self.wpn_fps_ass_t9fastburst.uses_parts, "wpn_fps_ass_t9fastburst_i_g11athome")
-	
+
 			self.wpn_fps_ass_t9fastburst_npc.uses_parts = deep_clone(self.wpn_fps_ass_t9fastburst.uses_parts)
 		end
 
@@ -30754,7 +30864,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 			}
 
 			table.insert(self.wpn_fps_ass_t9british.uses_parts, "wpn_fps_ass_t9british_handle_mix_01")
-	
+
 			self.wpn_fps_ass_t9british.override = self.wpn_fps_ass_t9british.override or {}
 
 			for i, part_id in pairs(self.wpn_fps_ass_t9british.uses_parts) do
@@ -30845,7 +30955,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 					reload = 1
 				}
 				self.parts.wpn_fps_smg_lc10_magazine_mix_01.custom_stats = { ads_speed_mult = 1.025 }
-				--STANAG 55 Rnd 
+				--STANAG 55 Rnd
 				self.parts.wpn_fps_smg_lc10_xmag_01_pro.supported = true
 				self.parts.wpn_fps_smg_lc10_xmag_01_pro.has_description = false
 				self.parts.wpn_fps_smg_lc10_xmag_01_pro.stats = {
@@ -31061,7 +31171,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 					reload = 1
 				}
 				self.parts.wpn_fps_smg_ksp45_magazine_mix_01.custom_stats = { ads_speed_mult = 1.025 }
-				--STANAG 48 Rnd 
+				--STANAG 48 Rnd
 				self.parts.wpn_fps_smg_ksp45_xmag_02.supported = true
 				self.parts.wpn_fps_smg_ksp45_xmag_02.has_description = false
 				self.parts.wpn_fps_smg_ksp45_xmag_02.stats = {
@@ -31212,7 +31322,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 
 			self.parts.wpn_fps_lmg_stoner63a_tank_v14.supported = true
 			self.parts.wpn_fps_lmg_stoner63a_tank_v14.stats = { value = 0 }
-	
+
 			--BARRELS
 				--Cut Down
 				self.parts.wpn_fps_lmg_stoner63a_barrel_01.supported = true
@@ -31394,7 +31504,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 					reload = 6
 				}
 				self.parts.wpn_fps_lmg_stoner63a_magazine_fast_02.custom_stats = { ads_speed_mult = 1.025 }
-			
+
 			self.parts.wpn_fps_lmg_stoner63a_bipod.supported = true
 			self.parts.wpn_fps_lmg_stoner63a_bipod.stats = deep_clone(self.parts.wpn_fps_upg_bp_lmg_lionbipod.stats)
 			self.parts.wpn_fps_lmg_stoner63a_bipod.stats.value = 0
@@ -31430,7 +31540,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 			self.parts.wpn_fps_ass_stoner63a_rifle_magazine.custom_stats = {}
 
 			self.parts.wpn_fps_ass_stoner63a_rifle_magazine_xmag.supported = true
-			self.parts.wpn_fps_ass_stoner63a_rifle_magazine_xmag.stats = { 
+			self.parts.wpn_fps_ass_stoner63a_rifle_magazine_xmag.stats = {
 				value = 3,
 				concealment = -4,
 				reload = -6,
@@ -31483,7 +31593,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 			self.parts.wpn_fps_ass_ngsierra_flash_hider.stats = { value = 0 }
 			self.parts.wpn_fps_ass_ngsierra_flash_hider.custom_stats = nil
 			self.parts.wpn_fps_ass_ngsierra_flash_hider.perks = nil
-	
+
 			self.parts.wpn_fps_ass_ngsierra_barrel_short.supported = true
 			self.parts.wpn_fps_ass_ngsierra_barrel_short.stats = deep_clone(barrels.short_b2_stats)
 			self.parts.wpn_fps_ass_ngsierra_barrel_short.custom_stats = deep_clone(barrels.short_b2_stats)
@@ -31601,7 +31711,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 				translation = Vector3(-0.0, -10, -1),
 				rotation = Rotation(-0.03, -0.03, 0)
 			}
-	
+
 			self.parts.wpn_fps_ass_ngsierra_irons_angled.stance_mod.wpn_fps_snp_tti = { --funni thing to make this play nice with >:3's Mare's Leg
 				translation = Vector3(-1.8, 4, -11.3),
 				rotation = Rotation(-0.02, 0.04, -45)
@@ -31694,7 +31804,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 				self.parts.wpn_fps_lmg_pkilo_stock_no.stats = deep_clone(stocks.remove_fixed_stats)
 				self.parts.wpn_fps_lmg_pkilo_stock_no.stats.value = 0
 				self.parts.wpn_fps_lmg_pkilo_stock_no.custom_stats = deep_clone(stocks.remove_fixed_stats)
-			
+
 			self.wpn_fps_lmg_pkilo.override = self.wpn_fps_lmg_pkilo.override or {}
 
 
@@ -31703,9 +31813,9 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 					if self.parts[part_id].type == "sight" then
 						self.wpn_fps_lmg_pkilo.override[part_id] = self.wpn_fps_lmg_pkilo.override[part_id] or {}
 						self.wpn_fps_lmg_pkilo.override[part_id].custom_stats = self.parts[part_id].custom_stats and deep_clone(self.parts[part_id].custom_stats) or {}
-						self.wpn_fps_lmg_pkilo.override[part_id].custom_stats.big_scope = true 
+						self.wpn_fps_lmg_pkilo.override[part_id].custom_stats.big_scope = true
 					end
-					if ((self.parts[part_id].global_value and self.parts[part_id].global_value ~= "pkilomod") or not self.parts[part_id].global_value) and 
+					if ((self.parts[part_id].global_value and self.parts[part_id].global_value ~= "pkilomod") or not self.parts[part_id].global_value) and
 						(self.parts[part_id].type == "grip" or self.parts[part_id].type == "stock") then
 						self.wpn_fps_lmg_pkilo.uses_parts[i] = "resmod_dummy"
 					end
@@ -31944,7 +32054,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 
 			for i, part_id in pairs(self.wpn_fps_shot_vecho.uses_parts) do
 				if self.parts[part_id] and self.parts[part_id].pcs and self.parts[part_id].type then
-					if ((self.parts[part_id].global_value and self.parts[part_id].global_value ~= "vecho_mod") or not self.parts[part_id].global_value) and 
+					if ((self.parts[part_id].global_value and self.parts[part_id].global_value ~= "vecho_mod") or not self.parts[part_id].global_value) and
 						(self.parts[part_id].type == "grip" or self.parts[part_id].type == "stock") then
 						self.wpn_fps_shot_vecho.uses_parts[i] = "resmod_dummy"
 					end
@@ -31986,7 +32096,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 					sounds = {
 						fire = "mw2_acr_fire",
 						fire_single = "mw2_acr_fire",
-						fire_auto = "mw2_acr_fire", 
+						fire_auto = "mw2_acr_fire",
 						stop_fire = "m16_stop"
 					}
 				}
@@ -32019,12 +32129,12 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 			self.parts.wpn_fps_ass_mcx_spear_am_762.pcs = nil
 			self.parts.wpn_fps_ass_mcx_spear_am_762.stats = { value = 0 }
 			self.parts.wpn_fps_ass_mcx_spear_am_762.custom_stats = nil
-	
+
 			--DBAL Gadget
 			self.parts.wpn_fps_ass_mcx_spear_gadget_dbal.supported = true
 			self.parts.wpn_fps_ass_mcx_spear_gadget_dbal.stats = { value = 0 }
 			self.parts.wpn_fps_ass_mcx_spear_gadget_dbal.custom_stats = nil
-	
+
 			--Default stock
 			self.parts.wpn_fps_ass_mcx_spear_stock.supported = true
 			self.parts.wpn_fps_ass_mcx_spear_stock.stats = { value = 0 }
@@ -32037,17 +32147,17 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 			self.parts.wpn_fps_ass_mcx_spear_stock_lt.supported = true
 			self.parts.wpn_fps_ass_mcx_spear_stock_lt.stats = deep_clone(stocks.adj_to_fold_stats)
 			self.parts.wpn_fps_ass_mcx_spear_stock_lt.custom_stats = deep_clone(stocks.adj_to_fold_stats)
-	
+
 			--Default Suppressor
 			self.parts.wpn_fps_ass_mcx_spear_suppressor.supported = true
 			self.parts.wpn_fps_ass_mcx_spear_suppressor.pcs = nil
-			self.parts.wpn_fps_ass_mcx_spear_suppressor.stats = { 
+			self.parts.wpn_fps_ass_mcx_spear_suppressor.stats = {
 				value = 2,
 				suppression = 12,
 				alert_size = -1
 			}
 			self.parts.wpn_fps_ass_mcx_spear_suppressor.custom_stats = nil
-	
+
 			self.parts.wpn_fps_ass_mcx_spear_optic_ngsw.supported = true
 			self.parts.wpn_fps_ass_mcx_spear_optic_ngsw.stats = {
 				value = 0,
@@ -32056,7 +32166,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 			self.parts.wpn_fps_ass_mcx_spear_optic_ngsw.stance_mod.wpn_fps_ass_mcx_spear = {
 				translation = Vector3(0.01, -5, 1.35)
 			}
-			
+
 			self.parts.wpn_fps_ass_mcx_spear_optic_ngsw_remote.supported = true
 			self.parts.wpn_fps_ass_mcx_spear_optic_ngsw_remote.stats = {
 				value = 0,
@@ -32065,7 +32175,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 			self.parts.wpn_fps_ass_mcx_spear_optic_ngsw_remote.stance_mod.wpn_fps_ass_mcx_spear = {
 				translation = Vector3(0.01, -5, 1.35)
 			}
-	
+
 			--BCM Grip
 			self.parts.wpn_fps_ass_mcx_spear_vg_bcm.supported = true
 			self.parts.wpn_fps_ass_mcx_spear_vg_bcm.stats = {
@@ -32078,7 +32188,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 				recoil = 2,
 				concealment = -1
 			}
-	
+
 			--Default Grip
 			self.parts.wpn_fps_ass_mcx_spear_grip.supported = true
 			self.parts.wpn_fps_ass_mcx_spear_grip.pcs = nil
@@ -32088,7 +32198,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 			self.parts.wpn_fps_ass_mcx_spear_grip_lt.supported = true
 			self.parts.wpn_fps_ass_mcx_spear_grip_lt.stats = { value = 0 }
 			self.parts.wpn_fps_ass_mcx_spear_grip_lt.custom_stats = nil
-	
+
 			--Default Mag
 			self.parts.wpn_fps_ass_mcx_spear_magazine.supported = true
 			self.parts.wpn_fps_ass_mcx_spear_magazine.pcs = nil
@@ -32102,14 +32212,14 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 			self.parts.wpn_fps_ass_mcx_spear_magazine_meme.supported = true
 			self.parts.wpn_fps_ass_mcx_spear_magazine_meme.stats = {}
 			self.parts.wpn_fps_ass_mcx_spear_magazine_meme.custom_stats = nil
-	
+
 			self.parts.wpn_fps_ass_mcx_spear_barrel_marksman.supported = true
 			self.parts.wpn_fps_ass_mcx_spear_barrel_marksman.stats = deep_clone(barrels.long_b3_stats)
 			self.parts.wpn_fps_ass_mcx_spear_barrel_marksman.custom_stats = deep_clone(barrels.long_b3_stats)
 			self.parts.wpn_fps_ass_mcx_spear_barrel_marksman.has_description = false
 			self.parts.wpn_fps_ass_mcx_spear_barrel_marksman.forbids = nil
 			self.parts.wpn_fps_ass_mcx_spear_barrel_marksman.perks = nil
-	
+
 			self.wpn_fps_ass_mcx_spear.override = self.wpn_fps_ass_mcx_spear.override or {}
 			self.wpn_fps_ass_mcx_spear.override.wpn_fps_smg_schakal_vg_surefire = {
 				stats = {
@@ -32122,7 +32232,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 				stats = {},
 				custom_stats = {},
 			}
-	
+
 			self.wpn_fps_ass_mcx_spear_npc.default_blueprint = deep_clone(self.wpn_fps_ass_mcx_spear.default_blueprint)
 			self.wpn_fps_ass_mcx_spear_npc.override = deep_clone(self.wpn_fps_ass_mcx_spear.override)
 			self.wpn_fps_ass_mcx_spear_npc.uses_parts = deep_clone(self.wpn_fps_ass_mcx_spear.uses_parts)
@@ -32133,7 +32243,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 			self.parts.wpn_fps_lmg_sig_xm250_magazine.custom_stats = {}
 			self.parts.wpn_fps_lmg_sig_xm250_stock.stats = { value = 0 }
 			self.parts.wpn_fps_lmg_sig_xm250_stock.custom_stats = {}
-	
+
 			self.parts.wpn_fps_lmg_sig_xm250_suppressor.supported = true
 			self.parts.wpn_fps_lmg_sig_xm250_suppressor.pcs = nil
 			self.parts.wpn_fps_lmg_sig_xm250_suppressor.stats = {
@@ -32142,7 +32252,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 				suppression = -12
 			}
 			self.parts.wpn_fps_lmg_sig_xm250_suppressor.custom_stats = nil
-	
+
 			self.parts.wpn_fps_lmg_sig_xm250_optic_ngsw.supported = true
 			self.parts.wpn_fps_lmg_sig_xm250_optic_ngsw.stats = {
 				value = 0,
@@ -32151,11 +32261,11 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 			self.parts.wpn_fps_lmg_sig_xm250_optic_ngsw.stance_mod = {
 				wpn_fps_lmg_sig_xm250 = {
 					translation = Vector3(0, -8, 1.95)
-				}		
+				}
 			}
 			self.parts.wpn_fps_lmg_sig_xm250_optic_ngsw_steelsight.stance_mod = {}
-	
-	
+
+
 			for i, part_id in pairs(self.wpn_fps_lmg_sig_xm250.default_blueprint) do
 				attachment_list = {
 					"wpn_fps_lmg_sig_xm250_irons_angled"
@@ -32166,7 +32276,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 					end
 				end
 			end
-	
+
 			for i, part_id in pairs(self.wpn_fps_lmg_sig_xm250.uses_parts) do
 				attachment_list = {
 					"wpn_fps_upg_o_box"
@@ -32177,7 +32287,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 					end
 				end
 			end
-	
+
 			self.wpn_fps_lmg_sig_xm250_npc.default_blueprint = deep_clone(self.wpn_fps_lmg_sig_xm250.default_blueprint)
 			self.wpn_fps_lmg_sig_xm250_npc.uses_parts = deep_clone(self.wpn_fps_lmg_sig_xm250.uses_parts)
 		end
@@ -32272,7 +32382,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 			self.parts.wpn_fps_ass_owd_m1a_stock_light.custom_stats = {
 				ads_speed_mult = 0.975
 			}
-			
+
 			self.parts.wpn_fps_ass_owd_m1a_stock_throwback.supported = true
 			self.parts.wpn_fps_ass_owd_m1a_stock_throwback.stats = {
 				value = 0
@@ -32293,7 +32403,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 			table.insert(self.wpn_fps_ass_owd_m1a.uses_parts, "wpn_fps_upg_o_schmidt_magnified")
 			table.insert(self.wpn_fps_ass_owd_m1a.uses_parts, "wpn_fps_upg_i_singlefire")
 			table.insert(self.wpn_fps_ass_owd_m1a.uses_parts, "wpn_fps_upg_i_autofire")
-		
+
 			self.wpn_fps_ass_owd_m1a_npc.adds = deep_clone(self.wpn_fps_ass_owd_m1a.adds)
 			self.wpn_fps_ass_owd_m1a_npc.uses_parts = deep_clone(self.wpn_fps_ass_owd_m1a.uses_parts)
 		end
@@ -32557,7 +32667,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 				rof_mult = 0.933006,
 				damage_min_mult = 2
 			}
-			
+
 			self.parts.wpn_fps_ass_nova4_receiver_upper_rare.supported = true
 			self.parts.wpn_fps_ass_nova4_receiver_upper_rare.has_description = true
 			self.parts.wpn_fps_ass_nova4_receiver_upper_rare.desc_id = "bm_wp_wpn_fps_ass_nova4_chaos_desc"
@@ -32570,7 +32680,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 				ads_rof_mult = 0.806722,
 				hip_mult = 0.8
 			}
-			
+
 			self.wpn_fps_ass_nova4.override = self.wpn_fps_ass_nova4.override or {}
 			self.wpn_fps_ass_nova4.override.wpn_fps_upg_m4_s_standard = {
 				stats = {},
@@ -32706,7 +32816,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 			for i, part_id in pairs(self.wpn_fps_ass_msecho.uses_parts) do
 				if self.parts[part_id] and self.parts[part_id].type then
 					if self.parts[part_id].pcs then
-						if ((self.parts[part_id].global_value and self.parts[part_id].global_value ~= "msecho_mod") or not self.parts[part_id].global_value) and 
+						if ((self.parts[part_id].global_value and self.parts[part_id].global_value ~= "msecho_mod") or not self.parts[part_id].global_value) and
 							(self.parts[part_id].type == "grip" or self.parts[part_id].type == "stock") then
 							self.wpn_fps_ass_msecho.uses_parts[i] = "resmod_dummy"
 						end
@@ -33227,7 +33337,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 				self.parts.wpn_fps_ass_akilo_2022_stock_rkilo.stats = { value = 0 }
 				self.parts.wpn_fps_ass_akilo_2022_stock_rkilo.custom_stats = nil
 				self.parts.wpn_fps_ass_akilo_2022_stock_rkilo.supported = true
-				self.parts.wpn_fps_ass_akilo_2022_stock_rkilo.stats = { 
+				self.parts.wpn_fps_ass_akilo_2022_stock_rkilo.stats = {
 					value = 0,
 					recoil = 4,
 					concealment = -2
@@ -33241,7 +33351,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 				self.parts.wpn_fps_ass_akilo_2022_stock_rkilo_heavy.stats = { value = 0 }
 				self.parts.wpn_fps_ass_akilo_2022_stock_rkilo_heavy.custom_stats = nil
 				self.parts.wpn_fps_ass_akilo_2022_stock_rkilo_heavy.supported = true
-				self.parts.wpn_fps_ass_akilo_2022_stock_rkilo_heavy.stats = { 
+				self.parts.wpn_fps_ass_akilo_2022_stock_rkilo_heavy.stats = {
 					value = 0,
 					spread = 1,
 					recoil = 6,
@@ -33445,17 +33555,17 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 				}
 
 				self.parts.wpn_fps_ass_akilo_2022_magazine_mw2.supported = true
-				self.parts.wpn_fps_ass_akilo_2022_magazine_mw2.stats = { 
+				self.parts.wpn_fps_ass_akilo_2022_magazine_mw2.stats = {
 					value = 0,
 					recoil = -2,
-					concealment = 1 
+					concealment = 1
 				}
 				self.parts.wpn_fps_ass_akilo_2022_magazine_mw2.custom_stats = nil
 				self.parts.wpn_fps_ass_akilo_2022_magazine_mw2_545.supported = true
-				self.parts.wpn_fps_ass_akilo_2022_magazine_mw2_545.stats = { 
+				self.parts.wpn_fps_ass_akilo_2022_magazine_mw2_545.stats = {
 					value = 0,
 					recoil = -2,
-					concealment = 1 
+					concealment = 1
 				}
 				self.parts.wpn_fps_ass_akilo_2022_magazine_mw2_545.custom_stats = nil
 
@@ -33603,7 +33713,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 						self.parts.wpn_fps_smg_alpha57_barrel_sil.forbids[i] = "dummy"
 					end
 				end
-			end	
+			end
 
 			self.parts.wpn_fps_smg_alpha57_grip_steady.supported = true
 			self.parts.wpn_fps_smg_alpha57_grip_steady.has_description = false
@@ -33676,7 +33786,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 			self.parts.wpn_fps_smg_alpha57_stock_no.stats = deep_clone(stocks.remove_folder_stats)
 			self.parts.wpn_fps_smg_alpha57_stock_no.stats.value = 0
 			self.parts.wpn_fps_smg_alpha57_stock_no.custom_stats = deep_clone(stocks.remove_folder_stats)
-			
+
 			self.parts.wpn_fps_smg_alpha57_stock_tac.supported = true
 			self.parts.wpn_fps_smg_alpha57_stock_tac.stats = {
 				value = 0,
@@ -33730,10 +33840,10 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 						self.wpn_fps_smg_alpha57_prim.uses_parts[i] = "resmod_dummy"
 					end
 				end
-			end	
+			end
 
 			self.wpn_fps_smg_alpha57_prim_npc.override = deep_clone(self.wpn_fps_smg_alpha57_prim.override)
-			self.wpn_fps_smg_alpha57_prim_npc.uses_parts = deep_clone(self.wpn_fps_smg_alpha57_prim.uses_parts)	
+			self.wpn_fps_smg_alpha57_prim_npc.uses_parts = deep_clone(self.wpn_fps_smg_alpha57_prim.uses_parts)
 		end
 
 		if self.parts.wpn_fps_snp_xmike2010_bolt_light then --MW2022 M2010
@@ -33772,7 +33882,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 
 				self.parts.wpn_fps_snp_xmike2010_barrel_mike24_barsil.supported = true
 				self.parts.wpn_fps_snp_xmike2010_barrel_mike24_barsil.stats = {
-					value = 0, 
+					value = 0,
 					alert_size = -1,
 					suppression = 12
 				}
@@ -33781,7 +33891,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 			--BOLTS
 				self.parts.wpn_fps_snp_xmike2010_bolt_heavy.supported = true
 				self.parts.wpn_fps_snp_xmike2010_bolt_heavy.stats = {
-					value = 0, 
+					value = 0,
 					spread = 3
 				}
 				self.parts.wpn_fps_snp_xmike2010_bolt_heavy.custom_stats = {
@@ -33864,11 +33974,11 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 			self.parts.wpn_fps_pis_swhiskey_trigger_heavy.supported = true
 			self.parts.wpn_fps_pis_swhiskey_trigger_heavy.stats = { spread = 1 }
 			self.parts.wpn_fps_pis_swhiskey_trigger_heavy.custom_stats = { ignore_rof_mult_anims = true, ads_speed_mult = 0.925 , rof_mult = 0.85 }
-			
+
 			self.parts.wpn_fps_pis_swhiskey_trigger_hair.supported = true
 			self.parts.wpn_fps_pis_swhiskey_trigger_hair.stats = { recoil = -6, spread = -3 }
 			self.parts.wpn_fps_pis_swhiskey_trigger_hair.custom_stats = { rof_mult = 1.15, ads_speed_mult = 1.1 }
-			
+
 			self.parts.wpn_fps_pis_swhiskey_trigger_light.supported = true
 			self.parts.wpn_fps_pis_swhiskey_trigger_light.stats = { recoil = -4, spread = 1 }
 			self.parts.wpn_fps_pis_swhiskey_trigger_light.custom_stats = { rof_mult = 1.05 }
@@ -33884,7 +33994,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 
 			self.parts.wpn_fps_pis_swhiskey_barrel_long.supported = true
 			self.parts.wpn_fps_pis_swhiskey_barrel_long.stats = { recoil = -2, concealment = -3, spread = 5}
-			self.parts.wpn_fps_pis_swhiskey_barrel_long.custom_stats = { 
+			self.parts.wpn_fps_pis_swhiskey_barrel_long.custom_stats = {
 				ads_speed_mult = 1.45,
 				falloff_start_mult = 1.3,
 				falloff_end_mult = 1.3,
@@ -33893,7 +34003,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 
 			self.parts.wpn_fps_pis_swhiskey_barrel_mini.supported = true
 			self.parts.wpn_fps_pis_swhiskey_barrel_mini.stats = { recoil = -4, concealment = 3, spread = -2}
-			self.parts.wpn_fps_pis_swhiskey_barrel_mini.custom_stats = { 
+			self.parts.wpn_fps_pis_swhiskey_barrel_mini.custom_stats = {
 				ads_speed_mult = 0.875,
 				falloff_start_mult = 0.85,
 				falloff_end_mult = 0.85
@@ -33901,7 +34011,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 
 			self.parts.wpn_fps_pis_swhiskey_barrel_short.supported = true
 			self.parts.wpn_fps_pis_swhiskey_barrel_short.stats = { concealment = 1, spread = -1}
-			self.parts.wpn_fps_pis_swhiskey_barrel_short.custom_stats = { 
+			self.parts.wpn_fps_pis_swhiskey_barrel_short.custom_stats = {
 				ads_speed_mult = 0.925,
 				falloff_start_mult = 0.9,
 				falloff_end_mult = 0.9
@@ -33911,14 +34021,14 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 			self.parts.wpn_fps_pis_swhiskey_scope.supported = true
 			self.parts.wpn_fps_pis_swhiskey_scope.desc_id = "bm_wp_upg_o_4"
 			self.parts.wpn_fps_pis_swhiskey_scope.stats = { zoom = 30 }
-			self.parts.wpn_fps_pis_swhiskey_scope.custom_stats = { 
+			self.parts.wpn_fps_pis_swhiskey_scope.custom_stats = {
 				ads_speed_mult = 1.625
 			}
 
 			--Lasers
 			self.parts.wpn_fps_pis_swhiskey_laser01.supported = true
 			self.parts.wpn_fps_pis_swhiskey_laser01.stats = { concealment = -1 }
-			self.parts.wpn_fps_pis_swhiskey_laser01.custom_stats = { 
+			self.parts.wpn_fps_pis_swhiskey_laser01.custom_stats = {
 				ads_speed_mult = 0.95
 			}
 
@@ -34007,41 +34117,41 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 			self.parts.wpn_fps_ass_m4_usasoc_handguard_colt.adds = {}
 
 			self.parts.wpn_fps_ass_m4_usasoc_grip_dd.supported = true
-			self.parts.wpn_fps_ass_m4_usasoc_grip_dd.stats = { 
+			self.parts.wpn_fps_ass_m4_usasoc_grip_dd.stats = {
 				value = 0,
 				recoil = 2,
 				spread = 1,
 				concealment = -2
 			}
 
-			self.parts.wpn_fps_ass_m4_usasoc_stock_dd.supported = true 
-			self.parts.wpn_fps_ass_m4_usasoc_stock_dd.stats = { 
+			self.parts.wpn_fps_ass_m4_usasoc_stock_dd.supported = true
+			self.parts.wpn_fps_ass_m4_usasoc_stock_dd.stats = {
 				value = 0,
 				recoil = -2,
 				concealment = 1
 			}
 			self.parts.wpn_fps_ass_m4_usasoc_stock_dd.custom_stats = { ads_speed_mult = 0.975 }
-			self.parts.wpn_fps_ass_m4_usasoc_stock_m4ss.supported = true 
-			self.parts.wpn_fps_ass_m4_usasoc_stock_m4ss.stats = { 
+			self.parts.wpn_fps_ass_m4_usasoc_stock_m4ss.supported = true
+			self.parts.wpn_fps_ass_m4_usasoc_stock_m4ss.stats = {
 				value = 0
 			}
 			self.parts.wpn_fps_ass_m4_usasoc_stock_m4ss.custom_stats = nil
-			self.parts.wpn_fps_ass_m4_usasoc_stock_moe.supported = true 
-			self.parts.wpn_fps_ass_m4_usasoc_stock_moe.stats = { 
+			self.parts.wpn_fps_ass_m4_usasoc_stock_moe.supported = true
+			self.parts.wpn_fps_ass_m4_usasoc_stock_moe.stats = {
 				value = 0,
 				recoil = -2,
 				spread = 1
 			}
 			self.parts.wpn_fps_ass_m4_usasoc_stock_moe.custom_stats = nil
 
-			self.parts.wpn_fps_ass_m4_usasoc_magazine_20.supported = true 
+			self.parts.wpn_fps_ass_m4_usasoc_magazine_20.supported = true
 			self.parts.wpn_fps_ass_m4_usasoc_magazine_20.stats = {
 				value = 0,
 				concealment = 1,
 				reload = 4,
 				extra_ammo = -10
 			}
-			self.parts.wpn_fps_ass_m4_usasoc_magazine_20.custom_stats = { 
+			self.parts.wpn_fps_ass_m4_usasoc_magazine_20.custom_stats = {
 				ads_speed_mult = 0.975
 			}
 			self.parts.wpn_fps_ass_m4_usasoc_magazine_xmag.supported = true
@@ -34081,15 +34191,15 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 
 
 
-			self.parts.wpn_fps_ass_m4_usasoc_angled_sight_rmr.supported = true 
+			self.parts.wpn_fps_ass_m4_usasoc_angled_sight_rmr.supported = true
 			self.parts.wpn_fps_ass_m4_usasoc_angled_sight_rmr.desc_id = "bm_wp_upg_o_angled_1_1_desc"
 			self.parts.wpn_fps_ass_m4_usasoc_angled_sight_rmr.has_description = true
 			self.parts.wpn_fps_ass_m4_usasoc_angled_sight_rmr.stats = {
 				value = 1,
 				gadget_zoom = 2
 			}
-			self.parts.wpn_fps_ass_m4_usasoc_gadget_mawl.supported = true 
-			self.parts.wpn_fps_ass_m4_usasoc_gadget_mawl.stats = { 
+			self.parts.wpn_fps_ass_m4_usasoc_gadget_mawl.supported = true
+			self.parts.wpn_fps_ass_m4_usasoc_gadget_mawl.stats = {
 				value = 0
 			}
 
@@ -34138,7 +34248,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 					rotation = Rotation(-0.017, 0, 0 )
 				}
 			}
-					
+
 			self.parts.wpn_fps_snp_sbeta_scope.supported = true
 			self.parts.wpn_fps_snp_sbeta_scope.desc_id = "bm_wp_upg_o_3_7"
 			self.parts.wpn_fps_snp_sbeta_scope.stats = {
@@ -34264,7 +34374,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 					recoil = -2,
 				}
 				self.parts.wpn_fps_snp_sbeta_comb_tac.custom_stats = { ads_speed_mult = 0.975 }
-				
+
 				self.parts.wpn_fps_snp_sbeta_comb_slv.supported = true
 				self.parts.wpn_fps_snp_sbeta_comb_slv.stats = {
 					value = 2,
@@ -34283,7 +34393,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 			self.parts.wpn_fps_ass_m416d_barrel_16.supported = true
 			self.parts.wpn_fps_ass_m416d_barrel_16.stats = deep_clone(barrels.long_b3_stats)
 			self.parts.wpn_fps_ass_m416d_barrel_16.custom_stats = deep_clone(barrels.long_b3_stats)
-			
+
 			self.parts.wpn_fps_ass_m416d_handguard_geissele_10.stats = {}
 			self.parts.wpn_fps_ass_m416d_handguard_geissele_10.custom_stats = {}
 			self.parts.wpn_fps_ass_m416d_handguard.supported = true
@@ -34317,7 +34427,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 				spread = 2,
 				concealment = -2
 			}
-			
+
 			self.parts.wpn_fps_ass_m416d_flash_hider.stats = {}
 			self.parts.wpn_fps_ass_m416d_flash_hider.custom_stats = {}
 
@@ -34327,7 +34437,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 			self.parts.wpn_fps_ass_m416d_gadget_mod3.supported = true
 			self.parts.wpn_fps_ass_m416d_gadget_mod3.stats = { value = 1 }
 			self.parts.wpn_fps_ass_m416d_gadget_mod3.custom_stats = nil
-			
+
 			self.parts.wpn_fps_ass_m416d_grip.stats = {}
 			self.parts.wpn_fps_ass_m416d_grip.custom_stats = {}
 			self.parts.wpn_fps_ass_m416d_grip_tangodown.supported = true
@@ -34401,13 +34511,13 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 			self.parts.wpn_fps_pis_korth_prs_barrel_weight.custom_stats = deep_clone(muzzle_device.muzz_dual_c)
 			self.parts.wpn_fps_pis_korth_prs_barrel_weight.perks = nil
 
-			
+
 			self.parts.wpn_fps_pis_korth_prs_gadget_weight.supported = true
 			self.parts.wpn_fps_pis_korth_prs_gadget_weight.has_description = false
 			self.parts.wpn_fps_pis_korth_prs_gadget_weight.stats = { value = 1 }
 			self.parts.wpn_fps_pis_korth_prs_gadget_weight.custom_stats = nil
 
-			
+
 			self.parts.wpn_fps_pis_korth_prs_grip_2.supported = true
 			self.parts.wpn_fps_pis_korth_prs_grip_2.has_description = false
 			self.parts.wpn_fps_pis_korth_prs_grip_2.stats = deep_clone(grips.recoil_1)
@@ -34462,13 +34572,13 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 			}
 
 			table.insert(self.wpn_fps_lmg_raid_ww2_bren.uses_parts, "wpn_fps_upg_o_specter")
-			table.insert(self.wpn_fps_lmg_raid_ww2_bren.uses_parts, "wpn_fps_upg_o_aimpoint")	
+			table.insert(self.wpn_fps_lmg_raid_ww2_bren.uses_parts, "wpn_fps_upg_o_aimpoint")
 			table.insert(self.wpn_fps_lmg_raid_ww2_bren.uses_parts, "wpn_fps_upg_o_docter")
 			table.insert(self.wpn_fps_lmg_raid_ww2_bren.uses_parts, "wpn_fps_upg_o_eotech")
 			table.insert(self.wpn_fps_lmg_raid_ww2_bren.uses_parts, "wpn_fps_upg_o_t1micro")
 			table.insert(self.wpn_fps_lmg_raid_ww2_bren.uses_parts, "wpn_fps_upg_o_rx30")
-			table.insert(self.wpn_fps_lmg_raid_ww2_bren.uses_parts, "wpn_fps_upg_o_rx01")	
-			table.insert(self.wpn_fps_lmg_raid_ww2_bren.uses_parts, "wpn_fps_upg_o_reflex")	
+			table.insert(self.wpn_fps_lmg_raid_ww2_bren.uses_parts, "wpn_fps_upg_o_rx01")
+			table.insert(self.wpn_fps_lmg_raid_ww2_bren.uses_parts, "wpn_fps_upg_o_reflex")
 			table.insert(self.wpn_fps_lmg_raid_ww2_bren.uses_parts, "wpn_fps_upg_o_eotech_xps")
 			table.insert(self.wpn_fps_lmg_raid_ww2_bren.uses_parts, "wpn_fps_upg_o_cmore")
 			table.insert(self.wpn_fps_lmg_raid_ww2_bren.uses_parts, "wpn_fps_upg_o_aimpoint_2")
@@ -34482,7 +34592,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 			table.insert(self.wpn_fps_lmg_raid_ww2_bren.uses_parts, "wpn_fps_upg_o_poe")
 			table.insert(self.wpn_fps_lmg_raid_ww2_bren.uses_parts, "wpn_fps_upg_o_health")
 			table.insert(self.wpn_fps_lmg_raid_ww2_bren.uses_parts, "wpn_fps_upg_o_hamr")
-			table.insert(self.wpn_fps_lmg_raid_ww2_bren.uses_parts, "wpn_fps_upg_o_atibal")	
+			table.insert(self.wpn_fps_lmg_raid_ww2_bren.uses_parts, "wpn_fps_upg_o_atibal")
 			table.insert(self.wpn_fps_lmg_raid_ww2_bren.uses_parts, "wpn_fps_upg_o_xpsg33_magnifier")
 			table.insert(self.wpn_fps_lmg_raid_ww2_bren.uses_parts, "wpn_fps_upg_o_sig")
 
@@ -34501,7 +34611,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 				if self.parts[used_part_id] and self.parts[used_part_id].type then
 					if self.parts[used_part_id].type == "sight" then
 						self.wpn_fps_lmg_raid_ww2_bren.adds[used_part_id] = {"wpn_fps_lmg_raid_ww2_bren_o_unit", "wpn_fps_bow_elastic_rail"}
-						self.wpn_fps_lmg_raid_ww2_bren.override[used_part_id] = { 
+						self.wpn_fps_lmg_raid_ww2_bren.override[used_part_id] = {
 							parent = "shitass_o"
 						}
 					end
@@ -34554,7 +34664,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 				reload = -7,
 				concealment = -5
 			}
-			self.parts.wpn_fps_pis_zip22_magazine_drum.custom_stats = { 
+			self.parts.wpn_fps_pis_zip22_magazine_drum.custom_stats = {
 				ads_speed_mult = 1.125,
 				reload_empty_anim_mult = 1.25,
 				reload_non_empty_anim_mult = 1.3,
@@ -34570,7 +34680,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 				reload = -10,
 				concealment = -8
 			}
-			self.parts.wpn_fps_pis_zip22_magazine_drum_110.custom_stats = { 
+			self.parts.wpn_fps_pis_zip22_magazine_drum_110.custom_stats = {
 				ads_speed_mult = 1.2,
 				reload_empty_anim_mult = 1.25,
 				reload_non_empty_anim_mult = 1.3,
@@ -34612,7 +34722,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 					translation = Vector3(0, 5, -1.1)
 				}
 			}
-			
+
 			--BARRELS
 				self.parts.wpn_fps_ass_stango44_barrel_short.supported =  true
 				self.parts.wpn_fps_ass_stango44_barrel_short.stats = deep_clone(barrels.short_b2_stats)
@@ -34637,7 +34747,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 				self.parts.wpn_fps_ass_stango44_barrel_long.stats = deep_clone(barrels.long_b3_stats)
 				self.parts.wpn_fps_ass_stango44_barrel_long.stats.value = 0
 				self.parts.wpn_fps_ass_stango44_barrel_long.custom_stats = deep_clone(barrels.long_b3_stats)
-				
+
 				self.parts.wpn_fps_ass_stango44_barrel_sil.supported =  true
 				self.parts.wpn_fps_ass_stango44_barrel_sil.stats = {
 					value = 0,
@@ -34710,12 +34820,12 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 				}
 
 		end
-		
+
 	--[[ GAMBYT'S MODS ]]
 
 		--Gambyt's Vanilla Mod Pack
 			if self.parts.wpn_fps_ass_flint_b_long then
-	
+
 				--Stuff that has been disabled
 					self.parts.wpn_fps_ass_s552_m_ak.supported = true
 					self.parts.wpn_fps_ass_s552_m_ak.pcs = nil
@@ -34726,7 +34836,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 					self.parts.wpn_fps_ass_m4_m_stick_heavy.supported = true
 					self.parts.wpn_fps_ass_m4_m_stick_heavy.pcs = nil
 					self.parts.wpn_fps_ass_m4_m_stick.supported = true
-					self.parts.wpn_fps_ass_m4_m_stick.pcs = nil	--caliber conversions STINK	
+					self.parts.wpn_fps_ass_m4_m_stick.pcs = nil	--caliber conversions STINK
 					--Karbin Stock
 					self.parts.wpn_fps_ass_ak5_s_pts.pcs = nil
 					self.parts.wpn_fps_ass_ak5_s_pts.supported = true
@@ -34753,7 +34863,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 					for i, part_id in ipairs(foregrips) do
 						self.parts[ part_id ].supported = true
 						self.parts[ part_id ].pcs = {}
-						self.parts[ part_id ].stats = { 
+						self.parts[ part_id ].stats = {
 							value = 4,
 							recoil = 2,
 							concealment = -1
@@ -34769,7 +34879,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 					for i, part_id in ipairs(foregrips) do
 						self.parts[ part_id ].supported = true
 						self.parts[ part_id ].pcs = {}
-						self.parts[ part_id ].stats = { 
+						self.parts[ part_id ].stats = {
 							value = 1,
 							recoil = 4,
 							concealment = -2
@@ -34779,10 +34889,10 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 					self.parts.wpn_fps_vg_vmp_cheems.alt_icon = "guis/dlcs/bbq/textures/pd2/blackmarket/icons/weapons/m32"
 					self.parts.wpn_fps_vg_vmp_pod.alt_icon = "guis/dlcs/character_pack_clover/textures/pd2/blackmarket/icons/weapons/l85a2"
 
-		
+
 					self.parts.wpn_fps_smg_mac10_fg_m4.supported = true
 					self.parts.wpn_fps_pis_lebman_b_chrome_akimbo.supported = true
-			
+
 				--Sights
 					--Theia Micro Sight
 					self.parts.wpn_fps_upg_o_cqb.supported = true
@@ -34791,28 +34901,28 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 						value = 5,
 						zoom = 1
 					}
-					table.insert(self.wpn_fps_lmg_m60.uses_parts, "wpn_fps_upg_o_cqb")	
+					table.insert(self.wpn_fps_lmg_m60.uses_parts, "wpn_fps_upg_o_cqb")
 					self.wpn_fps_lmg_m60.override.wpn_fps_upg_o_cqb = {
 						parent = "upper_reciever"
-					}						
-					table.insert(self.wpn_fps_lmg_par.uses_parts, "wpn_fps_upg_o_cqb")		
+					}
+					table.insert(self.wpn_fps_lmg_par.uses_parts, "wpn_fps_upg_o_cqb")
 					self.wpn_fps_lmg_par.override.wpn_fps_upg_o_cqb = {
 						parent = "upper_reciever"
-					}						
+					}
 					self.wpn_fps_lmg_mg42.adds.wpn_fps_upg_o_cqb = {"wpn_fps_snp_mosin_rail"}
-					table.insert(self.wpn_fps_lmg_mg42.uses_parts, "wpn_fps_upg_o_cqb")		
+					table.insert(self.wpn_fps_lmg_mg42.uses_parts, "wpn_fps_upg_o_cqb")
 					self.wpn_fps_lmg_mg42.override.wpn_fps_upg_o_cqb = {
 						parent = "magazine_extra"
-					}				
+					}
 					self.wpn_fps_lmg_rpk.adds.wpn_fps_upg_o_cqb = {"wpn_fps_ak_extra_ris"} --hk21 only meme is over
-					table.insert(self.wpn_fps_lmg_rpk.uses_parts, "wpn_fps_upg_o_cqb")			
-					table.insert(self.wpn_fps_lmg_m249.uses_parts, "wpn_fps_upg_o_cqb")		
+					table.insert(self.wpn_fps_lmg_rpk.uses_parts, "wpn_fps_upg_o_cqb")
+					table.insert(self.wpn_fps_lmg_m249.uses_parts, "wpn_fps_upg_o_cqb")
 					self.wpn_fps_lmg_m249.override.wpn_fps_upg_o_cqb = {
 						parent = "upper_reciever"
-					}		
+					}
 					self.wpn_fps_lmg_hk21.adds.wpn_fps_upg_o_cqb = {"wpn_fps_ass_g3_body_rail"}
-					table.insert(self.wpn_fps_lmg_hk21.uses_parts, "wpn_fps_upg_o_cqb")				
-		
+					table.insert(self.wpn_fps_lmg_hk21.uses_parts, "wpn_fps_upg_o_cqb")
+
 				--PISTOLS
 					--Bernetti 9
 						--Desert Slide
@@ -34821,8 +34931,8 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 						--Desert Grip
 						self.parts.wpn_fps_pis_beretta_g_tan.supported = true
 						self.parts.wpn_fps_pis_beretta_g_tan.stats = deep_clone(grips.quickdraw_1)
-						self.parts.wpn_fps_pis_beretta_g_tan.custom_stats = deep_clone(grips.quickdraw_1)	
-		
+						self.parts.wpn_fps_pis_beretta_g_tan.custom_stats = deep_clone(grips.quickdraw_1)
+
 					--White Streak (PL14)
 						--Reaper Custom Frame
 						self.parts.wpn_fps_pis_pl14_body_custom.supported = true
@@ -34831,22 +34941,22 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 							recoil = 2,
 							concealment = -1
 						}
-		
+
 					--Chimano 88
 						--Bling Slide
 						self.parts.wpn_fps_pis_g17_b_bling.supported = true
 						self.parts.wpn_fps_pis_g17_b_bling.stats = { value = 1 }
-		
-					--Crosskill Guard) 
+
+					--Crosskill Guard)
 						--Aftermarket Slide
 						self.parts.wpn_fps_pis_shrew_sl_tt.supported = true
 						self.parts.wpn_fps_pis_shrew_sl_tt.stats = { value = 1 }
-		
+
 					--Czech 92
 						--Argent Slide
 						self.parts.wpn_fps_pis_czech_sl_chrome.supported = true
 						self.parts.wpn_fps_pis_czech_sl_chrome.stats = { value = 3 }
-		
+
 					--Crosskill Classic
 						--Wooden Grip
 						self.parts.wpn_fps_pis_cold_g_wood.supported = true
@@ -34880,10 +34990,10 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 						self.parts.wpn_fps_pis_cold_m_extended.stats = {
 							value = 2,
 							concealment = -1,
-							extra_ammo = 4,		
+							extra_ammo = 4,
 							reload = -3
 					}
-		
+
 					--Vendetta .38
 						--Extended Magazine
 						self.parts.wpn_fps_pis_lebman_m_extended.supported = true
@@ -34903,26 +35013,26 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 						--Chrome Slide
 						self.parts.wpn_fps_pis_lebman_b_chrome.supported = true
 						self.parts.wpn_fps_pis_lebman_b_chrome.stats = { value = 3 }
-		
+
 				--SHOTGUNS
 					--Shotguns Parts
 						--Trench Sweeper Nozzle
 						self.parts.wpn_fps_upg_ns_shot_grinder.supported = true
 						self.parts.wpn_fps_upg_ns_shot_grinder.stats = deep_clone(muzzle_device.muzz_dual_c)
 						self.parts.wpn_fps_upg_ns_shot_grinder.custom_stats = deep_clone(muzzle_device.muzz_dual_c)
-		
-					--IZHMA 12G 
+
+					--IZHMA 12G
 						--Smooth Receiver
 						--Smooth dust cover is on by default
 						self.parts.wpn_fps_sho_saiga_upper_receiver_smooth.supported = true
 						self.parts.wpn_fps_sho_saiga_upper_receiver_smooth.stats = { value = 1 }
-				
+
 					--Predator 12G
 						--Short Barrel
 						self.parts.wpn_fps_sho_b_spas12_small.supported = true
 						self.parts.wpn_fps_sho_b_spas12_small.stats = deep_clone(barrels.short_b1_stats)
 						self.parts.wpn_fps_sho_b_spas12_small.custom_stats = deep_clone(barrels.short_b1_stats)
-		
+
 					--GSPS 12G
 						--Hunting Barrel
 						self.parts.wpn_fps_shot_m37_b_ridge.supported = true
@@ -34944,8 +35054,8 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 							value = 1,
 							recoil = 2
 						}
-						--Riot Sight 
-						self.parts.wpn_fps_shot_m37_o_expert.supported = true 
+						--Riot Sight
+						self.parts.wpn_fps_shot_m37_o_expert.supported = true
 						self.parts.wpn_fps_shot_m37_o_expert.stats = {
 							value = 1
 						}
@@ -34963,14 +35073,14 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 							recoil = -2,
 							concealment = 1
 						}
-		
+
 					--AMR-12G
 						--Big Brother Magazine
 						self.parts.wpn_fps_shot_amr12_m_extended.supported = true
 						self.parts.wpn_fps_shot_amr12_m_extended.stats = {
-							value = 1, 
-							extra_ammo = 5, 
-							reload = -4, 
+							value = 1,
+							extra_ammo = 5,
+							reload = -4,
 							concealment = -2
 						}
 						self.parts.wpn_fps_shot_amr12_m_extended.custom_stats = {
@@ -34994,28 +35104,28 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 						self.parts.wpn_fps_shot_amr12_fg_short.stats = deep_clone(barrels.short_b2_stats)
 						self.parts.wpn_fps_shot_amr12_fg_short.custom_stats = deep_clone(barrels.short_b2_stats)
 						self.parts.wpn_fps_shot_amr12_fg_short.adds = nil
-				
+
 						self.parts.wpn_fps_shot_amr12_o_front.adds = nil
 						self.parts.wpn_fps_shot_amr12_rail.adds = nil
-				
+
 						self.parts.wpn_fps_shot_amr12_b_standard.supported = true
-				
+
 						self.parts.wpn_fps_shot_amr12_b_standard.stats = {
 							value = 1,
 						}
 						self.parts.wpn_fps_shot_amr12_b_standard.custom_stats = nil
-						
+
 						self.parts.wpn_fps_shot_amr12_o_front.stance_mod = {
 							wpn_fps_shot_amr12 = {
 								translation = Vector3(-0.1, -15, 0),
 								rotation = Rotation(-0.1, 0.1, 0)
 							}
 						}
-			
+
 						self.wpn_fps_shot_amr12.override = {
 							wpn_fps_upg_a_slug = deep_clone(shot_ammo.a_slug_semi_override),
 							wpn_fps_upg_a_custom = deep_clone(shot_ammo.a_custom_semi_override),
-							wpn_fps_upg_a_custom_free = deep_clone(shot_ammo.a_custom_semi_override),			
+							wpn_fps_upg_a_custom_free = deep_clone(shot_ammo.a_custom_semi_override),
 							wpn_fps_upg_a_explosive = deep_clone(shot_ammo.a_explosive_semi_override),
 							wpn_fps_upg_a_rip = deep_clone(shot_ammo.a_rip_semi_override),
 							wpn_fps_upg_a_piercing = deep_clone(shot_ammo.a_piercing_semi_override),
@@ -35069,7 +35179,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 							stats = deep_clone(stocks.fixed_acc_stats),
 							custom_stats = deep_clone(stocks.fixed_acc_stats)
 						}
-			
+
 						self.wpn_fps_shot_amr12.override.wpn_fps_ass_tecci_s_wire = {
 							stats = deep_clone(stocks.fixed_to_nocheeks_stats),
 							custom_stats = deep_clone(stocks.fixed_to_nocheeks_stats)
@@ -35078,14 +35188,14 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 							stats = deep_clone(stocks.fixed_to_thumbhole_stats),
 							custom_stats = deep_clone(stocks.fixed_to_thumbhole_stats)
 						}
-			
+
 						self.wpn_fps_shot_amr12.override.wpn_fps_m16_fg_standard = {
 							adds = {}
 						}
-					
-						self.wpn_fps_shot_amr12_npc.override = deep_clone(self.wpn_fps_shot_amr12.override)	
-						self.wpn_fps_shot_amr12_npc.uses_parts = deep_clone(self.wpn_fps_shot_amr12.uses_parts)	
-			
+
+						self.wpn_fps_shot_amr12_npc.override = deep_clone(self.wpn_fps_shot_amr12.override)
+						self.wpn_fps_shot_amr12_npc.uses_parts = deep_clone(self.wpn_fps_shot_amr12.uses_parts)
+
 				--RIFLES
 					--Commando 553
 						--Sniper Grip
@@ -35099,12 +35209,12 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 							spread = 1,
 							concealment = -1
 						}
-						--Sniper Stock		
-						self.parts.wpn_fps_ass_s552_s_sniper.supported = true		
+						--Sniper Stock
+						self.parts.wpn_fps_ass_s552_s_sniper.supported = true
 						self.parts.wpn_fps_ass_s552_s_sniper.stats = deep_clone(stocks.folder_to_fixed_acc1_rec2_stats)
 						self.parts.wpn_fps_ass_s552_s_sniper.custom_stats = deep_clone(stocks.folder_to_fixed_acc1_rec2_stats)
-		
-					--UAR 
+
+					--UAR
 						--Heavy Barrel
 						self.parts.wpn_fps_aug_b_big.supported = true
 						self.parts.wpn_fps_aug_b_big.pcs = nil
@@ -35114,7 +35224,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 						self.parts.wpn_fps_aug_b_big.stats.concealment = -6
 						self.parts.wpn_fps_aug_b_big.custom_stats = deep_clone(barrels.long_b2_stats)
 						self.parts.wpn_fps_aug_b_big.custom_stats.ads_speed_mult = 1.15
-		
+
 					--M308
 						--Classic Body
 						self.parts.wpn_fps_ass_m14_body_old.supported = true
@@ -35123,14 +35233,14 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 							recoil = 2,
 							spread = -1
 						}
-		
+
 					--Grom
 						--Short Barrel
 						self.parts.wpn_fps_snp_siltstone_b_short.supported = true
 						self.parts.wpn_fps_snp_siltstone_b_short.stats = deep_clone(barrels.short_b2_stats)
 						self.parts.wpn_fps_snp_siltstone_b_short.custom_stats = deep_clone(barrels.short_b2_stats)
-		
-					--AK17 
+
+					--AK17
 						--Smooth Grip
 						self.parts.wpn_fps_ass_flint_g_custom.supported = true
 						self.parts.wpn_fps_ass_flint_g_custom.stats = deep_clone(grips.acc_recoil)
@@ -35155,7 +35265,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 						self.parts.wpn_fps_ass_flint_s_solid.supported = true
 						self.parts.wpn_fps_ass_flint_s_solid.stats = deep_clone(stocks.adj_to_fixed_rec_stats)
 						self.parts.wpn_fps_ass_flint_s_solid.custom_stats = deep_clone(stocks.adj_to_fixed_rec_stats)
-		
+
 					--Little Friend
 						--Short Barrel
 						self.parts.wpn_fps_ass_contraband_b_short.supported = true
@@ -35170,7 +35280,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 						self.parts.wpn_fps_ass_contraband_s_tecci.stats = deep_clone(stocks.adj_to_nocheeks_stats)
 						self.parts.wpn_fps_ass_contraband_s_tecci.custom_stats = deep_clone(stocks.adj_to_nocheeks_stats)
 						self.parts.wpn_fps_ass_contraband_s_tecci.forbids = {"wpn_fps_upg_m4_s_adapter"}
-				
+
 						table.insert(self.wpn_fps_ass_sg416.uses_parts, "wpn_fps_ass_contraband_s_tecci")
 						table.insert(self.wpn_fps_ass_sg416_npc.uses_parts, "wpn_fps_ass_contraband_s_tecci")
 						table.insert(self.wpn_fps_ass_m4.uses_parts, "wpn_fps_ass_contraband_s_tecci")
@@ -35185,43 +35295,43 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 						table.insert(self.wpn_fps_ass_tecci_npc.uses_parts, "wpn_fps_ass_contraband_s_tecci")
 						table.insert(self.wpn_fps_smg_car9.uses_parts, "wpn_fps_ass_contraband_s_tecci")
 						table.insert(self.wpn_fps_smg_car9_npc.uses_parts, "wpn_fps_ass_contraband_s_tecci")
-		
+
 					--Mamba AK
 						self.parts.wpn_fps_ass_aknato_b_long.supported = true
 						self.parts.wpn_fps_ass_aknato_b_long.stats = deep_clone(barrels.long_b2_stats)
 						self.parts.wpn_fps_ass_aknato_b_long.custom_stats = deep_clone(barrels.long_b2_stats)
-				
+
 				--SMGS
-	
-	
+
+
 				--Aftermarket Stock
 					self.parts.wpn_fps_pis_lebman_stock.supported = true
 					self.parts.wpn_fps_pis_lebman_stock.stats = deep_clone(stocks.add_fixed_stats)
 					self.parts.wpn_fps_pis_lebman_stock.custom_stats = deep_clone(stocks.add_fixed_stats)
-		
+
 				--(Reinfeld) Swat Pump
 				self.parts.wpn_fps_shot_r870_fg_swat.supported = true
 				self.parts.wpn_fps_shot_r870_fg_swat.stats = {
 					value = 1,
 					spread = 1,
 					concealment = -1
-				}		
-		
+				}
+
 				--(Goliath 12G) Long Barrel
 				self.parts.wpn_fps_sho_rota_b_longer.supported = true
 				self.parts.wpn_fps_sho_rota_b_longer.stats = deep_clone(barrels.long_b1_stats)
 				self.parts.wpn_fps_sho_rota_b_longer.custom_stats = deep_clone(barrels.long_b1_stats)
-		
-		
-		
-				
-		
+
+
+
+
+
 				--(Microgun) Red Body
 				self.parts.wpn_fps_lmg_shuno_body_red.supported = true
 				self.parts.wpn_fps_lmg_shuno_body_red.stats = {
 					value = 0
 				}
-		
+
 				--Cylinder Foregrip
 				self.parts.wpn_fps_ass_amcar_fg_cylinder.supported = true
 				self.parts.wpn_fps_ass_amcar_fg_cylinder.stats = {
@@ -35229,71 +35339,71 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 					spread = 1,
 					recoil = -2
 				}
-		
+
 				--(Matever) Spiked Grip
 				self.parts.wpn_fps_pis_2006m_g_pearl.supported = true
 				self.parts.wpn_fps_pis_2006m_g_pearl.stats = {
 					value = 2
 				}
-		
+
 				--(Specops) Long Barrel
 				self.parts.wpn_fps_smg_mp7_b_long.supported = true
 				self.parts.wpn_fps_smg_mp7_b_long.stats = deep_clone(barrels.long_b2_stats)
 				self.parts.wpn_fps_smg_mp7_b_long.custom_stats = deep_clone(barrels.long_b2_stats)
-		
+
 				--(Uzi) Carbine Barrel
 				self.parts.wpn_fps_smg_uzi_b_carbine.supported = true
 				self.parts.wpn_fps_smg_uzi_b_carbine.stats = deep_clone(barrels.long_b1_stats)
 				self.parts.wpn_fps_smg_uzi_b_carbine.custom_stats = deep_clone(barrels.long_b1_stats)
-		
+
 				--(Jacket's Piece) Clean Hit Kit
 				self.parts.wpn_fps_smg_cobray_body_upper_long.supported = true
 				self.parts.wpn_fps_smg_cobray_body_upper_long.stats = deep_clone(barrels.long_b2_stats)
 				self.parts.wpn_fps_smg_cobray_body_upper_long.custom_stats = deep_clone(barrels.long_b2_stats)
-		
+
 				--(Leo Pistol) HS Convert Frame
 				self.parts.wpn_fps_pis_hs2000_body_stealth.supported = true
 				self.parts.wpn_fps_pis_hs2000_body_stealth.stats = {
 					value = 1
 				}
-		
+
 				--(Signature .40) Signature Chrome Frame
 				self.parts.wpn_fps_pis_p226_body_silver.supported = true
 				self.parts.wpn_fps_pis_p226_body_silver.stats = {
 					value = 1
 				}
-		
+
 				--(Jackal) Medium Barrel
 				self.parts.wpn_fps_smg_schakal_b_uncivil.supported = true
 				self.parts.wpn_fps_smg_schakal_b_uncivil.stats = deep_clone(barrels.long_b1_stats)
 				self.parts.wpn_fps_smg_schakal_b_uncivil.custom_stats = deep_clone(barrels.long_b1_stats)
-		
+
 				--(Kross Vertex) Long Barrel
 				self.parts.wpn_fps_smg_polymer_barrel_long.supported = true
 				self.parts.wpn_fps_smg_polymer_barrel_long.stats = deep_clone(barrels.long_b1_stats)
 				self.parts.wpn_fps_smg_polymer_barrel_long.custom_stats = deep_clone(barrels.long_b1_stats)
-		
+
 				--(Micro Uzi) Long Barrel
 				self.parts.wpn_fps_smg_baka_b_long.supported = true
 				self.parts.wpn_fps_smg_baka_b_long.stats = deep_clone(barrels.long_b1_stats)
 				self.parts.wpn_fps_smg_baka_b_long.custom_stats = deep_clone(barrels.long_b1_stats)
-		
+
 				--Heavy Compensator
 				self.parts.wpn_fps_upg_ns_ass_smg_heavy.supported = true
 				self.parts.wpn_fps_upg_ns_ass_smg_heavy.stats = deep_clone(muzzle_device.muzz_acc2_r)
 				self.parts.wpn_fps_upg_ns_ass_smg_heavy.custom_stats = deep_clone(muzzle_device.muzz_acc2_r)
-		
+
 				--(Claire 12G) Huntsman Barrel
 				self.parts.wpn_fps_sho_coach_b_long.supported = true
 				self.parts.wpn_fps_sho_coach_b_long.stats = deep_clone(barrels.long_b3_stats)
 				self.parts.wpn_fps_sho_coach_b_long.custom_stats = deep_clone(barrels.long_b3_stats)
-		
+
 				--(Lion's Roar) Urban Heat Kit
 				self.parts.wpn_fps_ass_vhs_body_camo.supported = true
 				self.parts.wpn_fps_ass_vhs_body_camo.stats = {
 					value = 0
 				}
-		
+
 				--HeistEye Target Marker
 				self.parts.wpn_fps_upg_fl_ass_smg_sho_marker.supported = true
 				self.parts.wpn_fps_upg_fl_ass_smg_sho_marker.desc_id = "bm_wp_upg_fl_vmp_marker"
@@ -35301,47 +35411,47 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 					value = 3,
 					concealment = -2
 				}
-		
+
 				--(Castigo) Smooth Cylinder
 				self.parts.wpn_fps_pis_chinchilla_cylinder_smooth.supported = true
 				self.parts.wpn_fps_pis_chinchilla_cylinder_smooth.stats = {
-					value = 1				
+					value = 1
 				}
-		
+
 				--(M13) Chrome Slide
 				self.parts.wpn_fps_pis_legacy_sl_chrome.supported = true
 				self.parts.wpn_fps_pis_legacy_sl_chrome.stats = {
 					value = 1
 				}
-		
+
 				--(White Streak) Chrome Slide
 				self.parts.wpn_fps_pis_pl14_sl_chrome.supported = true
 				self.parts.wpn_fps_pis_pl14_sl_chrome.stats = {
 					value = 1
 				}
-		
+
 				--(Castigo) Largo Barrel
 				self.parts.wpn_fps_pis_chinchilla_b_longboy.supported = true
 				self.parts.wpn_fps_pis_chinchilla_b_longboy.stats = deep_clone(barrels.long_b3_stats)
 				self.parts.wpn_fps_pis_chinchilla_b_longboy.custom_stats = deep_clone(barrels.long_b3_stats)
-		
-		
+
+
 				--(Deagle) Steady Wooden Grip
 				self.parts.wpn_fps_pis_deagle_g_wooden.supported = true
 				self.parts.wpn_fps_pis_deagle_g_wooden.stats = deep_clone(stocks.add_fixed_stats)
 				self.parts.wpn_fps_pis_deagle_g_wooden.custom_stats = deep_clone(stocks.add_fixed_stats)
-				
+
 				--(Peacemaker) Polymer Grip
 				self.parts.wpn_fps_pis_peacemaker_g_black.supported = true
 				self.parts.wpn_fps_pis_peacemaker_g_black.stats = deep_clone(grips.quickdraw_acc)
 				self.parts.wpn_fps_pis_peacemaker_g_black.custom_stats = deep_clone(grips.quickdraw_acc)
-		
+
 				--Rutted Receiver
 				self.parts.wpn_fps_ass_74_upper_receiver_bump.supported = true
 				self.parts.wpn_fps_ass_74_upper_receiver_bump.stats = {
 					value = 1
 				}
-		
+
 				--Plastic Handguard.
 				self.parts.wpn_fps_ass_ak_fg_waffle.supported = true
 				self.parts.wpn_fps_ass_ak_fg_waffle.stats = {
@@ -35349,12 +35459,12 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 					recoil = -2,
 					concealment = 1
 				}
-		
+
 				--(Stryk) Striking Slide
 				self.parts.wpn_fps_pis_g18c_b_long.supported = true
 				self.parts.wpn_fps_pis_g18c_b_long.stats = deep_clone(barrels.long_b1_stats)
 				self.parts.wpn_fps_pis_g18c_b_long.custom_stats = deep_clone(barrels.long_b1_stats)
-		
+
 				--(Bootleg) Anarchist Grip
 				self.parts.wpn_fps_ass_tecci_vg_ergo.supported = true
 				self.parts.wpn_fps_ass_tecci_vg_ergo.stats = {
@@ -35363,16 +35473,16 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 					concealment = 1
 				}
 				table.insert(self.wpn_fps_smg_mp7.uses_parts, "wpn_fps_ass_tecci_vg_ergo")
-				table.insert(self.wpn_fps_smg_mp7_npc.uses_parts, "wpn_fps_ass_tecci_vg_ergo")	
-	
+				table.insert(self.wpn_fps_smg_mp7_npc.uses_parts, "wpn_fps_ass_tecci_vg_ergo")
+
 				--(Loco) Railed Pump
 				self.parts.wpn_fps_shot_shorty_fg_rail.supported = true
 				self.parts.wpn_fps_shot_shorty_fg_rail.stats = {
 					value = 1,
 					recoil = -1,
-					concealment = 1				
-				}					
-		
+					concealment = 1
+				}
+
 				--(Bootleg) SG Compact Stock
 				--Repurposed to a fixed stock
 				self.parts.wpn_fps_ass_tecci_s_minicontra.unit = "units/pd2_dlc_chico/weapons/wpn_fps_ass_contraband_pts/wpn_fps_ass_contraband_s_standard"
@@ -35381,19 +35491,19 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 				self.parts.wpn_fps_ass_tecci_s_minicontra.supported = true
 				self.parts.wpn_fps_ass_tecci_s_minicontra.stats = deep_clone(stocks.adj_to_fixed_rec_stats)
 				self.parts.wpn_fps_ass_tecci_s_minicontra.custom_stats = deep_clone(stocks.adj_to_fixed_rec_stats)
-		
+
 				table.insert(self.wpn_fps_ass_m4.uses_parts, "wpn_fps_ass_tecci_s_minicontra")
-				table.insert(self.wpn_fps_ass_m4_npc.uses_parts, "wpn_fps_ass_tecci_s_minicontra")	
+				table.insert(self.wpn_fps_ass_m4_npc.uses_parts, "wpn_fps_ass_tecci_s_minicontra")
 				table.insert(self.wpn_fps_ass_amcar.uses_parts, "wpn_fps_ass_tecci_s_minicontra")
 				table.insert(self.wpn_fps_ass_amcar_npc.uses_parts, "wpn_fps_ass_tecci_s_minicontra")
 				table.insert(self.wpn_fps_ass_sg416.uses_parts, "wpn_fps_ass_tecci_s_minicontra")
-				table.insert(self.wpn_fps_ass_sg416_npc.uses_parts, "wpn_fps_ass_tecci_s_minicontra")	
+				table.insert(self.wpn_fps_ass_sg416_npc.uses_parts, "wpn_fps_ass_tecci_s_minicontra")
 				table.insert(self.wpn_fps_smg_car9.uses_parts, "wpn_fps_ass_tecci_s_minicontra")
 				table.insert(self.wpn_fps_smg_car9_npc.uses_parts, "wpn_fps_ass_tecci_s_minicontra")
 				table.insert(self.wpn_fps_smg_olympic.uses_parts, "wpn_fps_ass_tecci_s_minicontra")
-				table.insert(self.wpn_fps_smg_olympic_npc.uses_parts, "wpn_fps_ass_tecci_s_minicontra")	
-		
-				--Castigo .44 
+				table.insert(self.wpn_fps_smg_olympic_npc.uses_parts, "wpn_fps_ass_tecci_s_minicontra")
+
+				--Castigo .44
 					--Corto Barrel
 					self.parts.wpn_fps_pis_chinchilla_b_short.supported = true
 					self.parts.wpn_fps_pis_chinchilla_b_short.stats = deep_clone(barrels.short_b3_stats)
@@ -35403,7 +35513,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 					self.parts.wpn_fps_pis_chinchilla_g_pearl.stats = {
 						value = 1
 					}
-		
+
 				--Platypus 70
 					--Discrete Stock
 					self.parts.wpn_fps_snp_model70_s_discrete.supported = true
@@ -35419,12 +35529,12 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 						spread = -2,
 						concealment = 2
 					}
-		
+
 				--(Union 5.56) Medium Barrel
 				self.parts.wpn_fps_ass_corgi_b_medium.supported = true
 				self.parts.wpn_fps_ass_corgi_b_medium.stats = deep_clone(barrels.short_b1_stats)
 				self.parts.wpn_fps_ass_corgi_b_medium.custom_stats = deep_clone(barrels.short_b1_stats)
-		
+
 				--Contractor 308
 					--Long Barrel
 					self.parts.wpn_fps_snp_tti_b_long.supported = true
@@ -35436,23 +35546,23 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 						recoil = 2,
 						concealment = -1
 					}
-		
+
 				--(Jacket's Piece) Overdose Magazine
 				self.parts.wpn_fps_smg_cobray_m_extended.supported = true
 				self.parts.wpn_fps_smg_cobray_m_extended.stats = {
 					value = 2,
 					extra_ammo = 12,
-					concealment = -2,				
+					concealment = -2,
 					reload = -4
 				}
 				self.parts.wpn_fps_smg_cobray_m_extended_akimbo.supported = true
 				self.parts.wpn_fps_smg_cobray_m_extended_akimbo.stats = {
 					value = 2,
 					extra_ammo = 24,
-					concealment = -2,				
+					concealment = -2,
 					reload = -4
 				}
-		
+
 				--(Eagle Heavy) Extended Magazine
 				self.parts.wpn_fps_ass_scar_m_extended.supported = true
 				self.parts.wpn_fps_ass_scar_m_extended.stats = {
@@ -35475,7 +35585,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 					concealment = 2
 				}
 				--self.parts.wpn_fps_pis_c96_b_short.custom_stats = nil -- just making sure these are removed.
-		
+
 				--(Chicago Typewriter) Refurbished Foregrip
 				self.parts.wpn_fps_smg_thompson_fg_custom.supported = true
 				self.parts.wpn_fps_smg_thompson_fg_custom.stats = {
@@ -35483,21 +35593,21 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 					recoil = 2,
 					concealment = -1
 				}
-		
+
 				--(Chicago Typewriter) Folding Stock
 				self.parts.wpn_fps_smg_thompson_stock_fold.supported = true
 				self.parts.wpn_fps_smg_thompson_stock_fold.stats = deep_clone(stocks.fixed_to_nocheeks_stats)
 				self.parts.wpn_fps_smg_thompson_stock_fold.custom_stats = deep_clone(stocks.fixed_to_nocheeks_stats)
-		
-		
+
+
 				--Schäfer Grip
 				self.parts.wpn_fps_ass_m4_g_sg.supported = true
 				self.parts.wpn_fps_ass_m4_g_sg.stats = deep_clone(grips.acc_2_recoil)
-		
+
 				--(Nagant) Comfort Stock
 				self.parts.wpn_fps_snp_mosin_body_grip.supported = true
 				self.parts.wpn_fps_snp_mosin_body_grip.stats = deep_clone(grips.recoil_1)
-		
+
 				--(Broomstick) Finned Barrel
 				self.parts.wpn_fps_pis_c96_b_finned.supported = true
 				self.parts.wpn_fps_pis_c96_b_finned.stats = {
@@ -35506,13 +35616,13 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 					recoil = -1,
 					concealment = -1
 				}
-		
+
 				--(Peacemaker) Smooth Cylinder
 				self.parts.wpn_fps_pis_peacemaker_m_smooth.supported = true
 				self.parts.wpn_fps_pis_peacemaker_m_smooth.stats = {
 					value = 2
 				}
-		
+
 				--(Compact 5) Match Magazine
 				self.parts.wpn_fps_smg_mp5_m_custom.supported = true
 				self.parts.wpn_fps_smg_mp5_m_custom.stats = {
@@ -35521,12 +35631,12 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 					concealment = 1
 				}
 				self.parts.wpn_fps_smg_mp5_m_custom.custom_stats = nil
-		
+
 				--Grievky Nozzle
 				self.parts.wpn_fps_upg_ns_ass_smg_russian.supported = true
 				self.parts.wpn_fps_upg_ns_ass_smg_russian.stats = deep_clone(muzzle_device.muzz_rec2_a)
 				self.parts.wpn_fps_upg_ns_ass_smg_russian.custom_stats = deep_clone(muzzle_device.muzz_rec2_a)
-		
+
 				--Assassin Suppressor
 				self.parts.wpn_fps_upg_ns_pis_cloth.supported = true
 				self.parts.wpn_fps_upg_ns_pis_cloth.stats = {
@@ -35534,18 +35644,18 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 					suppression = 12,
 					alert_size = -1
 				}
-		
+
 				--(Galant) Prototype Carbine Stock
 				self.parts.wpn_fps_ass_ching_s_why.supported = true
 				self.parts.wpn_fps_ass_ching_s_why.stats = deep_clone(stocks.fixed_to_nocheeks_stats)
 				self.parts.wpn_fps_ass_ching_s_why.custom_stats = deep_clone(stocks.fixed_to_nocheeks_stats)
-		
-		
+
+
 				--(Parabellum) Discrete Grip
 				self.parts.wpn_fps_pis_breech_g_stealth.supported = true
 				self.parts.wpn_fps_pis_breech_g_stealth.stats = deep_clone(grips.quickdraw_1)
 				self.parts.wpn_fps_pis_breech_g_stealth.custom_stats = deep_clone(grips.quickdraw_1)
-		
+
 				--(Repeater 1874) Mare's Leg Barrel
 				self.parts.wpn_fps_snp_winchester_b_short.supported = true
 				self.parts.wpn_fps_snp_winchester_b_short.stats = deep_clone(barrels.short_b1_stats)
@@ -35553,14 +35663,14 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 				self.parts.wpn_fps_snp_winchester_b_short.stats.concealment = 2
 				self.parts.wpn_fps_snp_winchester_b_short.custom_stats = deep_clone(barrels.short_b1_stats)
 				self.parts.wpn_fps_snp_winchester_b_short.custom_stats.ads_speed_mult = 0.95
-		
+
 				--(Contractor Pistol) Bling Slide
 				self.parts.wpn_fps_pis_packrat_sl_silver.supported = true
 				self.parts.wpn_fps_pis_packrat_sl_silver.stats = {
 					value = 6
 				}
-		
-		
+
+
 				--5/7 AP
 					--Sport Barrel
 					self.parts.wpn_fps_pis_lemming_b_long.supported = true
@@ -35571,27 +35681,27 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 					self.parts.wpn_fps_pis_lemming_body_silver.stats = {
 						value = 4
 					}
-					
-		
+
+
 				--(Microgun) XL Barrel
 				self.parts.wpn_fps_lmg_shuno_b_long.supported = true
 				self.parts.wpn_fps_lmg_shuno_b_long.stats = deep_clone(barrels.long_b3_stats)
 				self.parts.wpn_fps_lmg_shuno_b_long.custom_stats = deep_clone(barrels.long_b3_stats)
-		
+
 				--(Signature) Long Foregrip
 				self.parts.wpn_fps_smg_shepheard_body_long.supported = true
 				self.parts.wpn_fps_smg_shepheard_body_long.stats = deep_clone(barrels.long_b2_stats)
 				self.parts.wpn_fps_smg_shepheard_body_long.custom_stats = deep_clone(barrels.long_b2_stats)
-		
+
 				--(Tempest 21) Long Barrel
 				self.parts.wpn_fps_ass_komodo_b_long.supported = true
 				self.parts.wpn_fps_ass_komodo_b_long.stats = deep_clone(barrels.long_b2_stats)
 				self.parts.wpn_fps_ass_komodo_b_long.custom_stats = deep_clone(barrels.long_b2_stats)
-		
+
 				--(Crosskill) Classic Grip
 				self.parts.wpn_fps_pis_1911_g_classic.supported = true
 				self.parts.wpn_fps_pis_1911_g_classic.stats = deep_clone(grips.recoil_acc)
-	
+
 				--AR Parts
 					--Ratnik Stock
 					--Disabled as I don't know how to make it not work on the 870s
@@ -35620,7 +35730,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 					self.parts.wpn_fps_ass_m4_m_wick.supported = true
 					self.parts.wpn_fps_ass_m4_m_wick.stats = deep_clone(self.parts.wpn_fps_upg_m4_m_straight.stats)
 					self.parts.wpn_fps_ass_m4_m_wick.custom_stats = deep_clone(self.parts.wpn_fps_upg_m4_m_straight.custom_stats)
-		
+
 				--AK Parts
 					--Kalashnikov Ninja Stock
 					self.parts.wpn_fps_upg_ak_s_polymerstock.pcs = {}
@@ -35638,9 +35748,9 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 					self.parts.wpn_fps_upg_ak_s_empty.supported = true
 					self.parts.wpn_fps_upg_ak_s_empty.stats = deep_clone(stocks.remove_nocheeks_stats)
 					self.parts.wpn_fps_upg_ak_s_empty.custom_stats = deep_clone(stocks.remove_nocheeks_stats)
-			
+
 					table.insert(self.wpn_fps_smg_coal.uses_parts, "wpn_fps_upg_ak_s_empty")
-					table.insert(self.wpn_fps_smg_coal_npc.uses_parts, "wpn_fps_upg_ak_s_empty")		
+					table.insert(self.wpn_fps_smg_coal_npc.uses_parts, "wpn_fps_upg_ak_s_empty")
 					--Modern Magazine
 					self.parts.wpn_fps_ass_ak_m_proto.supported = true
 					self.parts.wpn_fps_ass_ak_m_proto.stats = {
@@ -35652,7 +35762,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 					self.parts.wpn_upg_ak_g_titanium.supported = true
 					self.parts.wpn_upg_ak_g_titanium.stats = deep_clone(grips.quickdraw_dual)
 					self.parts.wpn_upg_ak_g_titanium.custom_stats = deep_clone(grips.quickdraw_dual)
-		
+
 				--Spiker 7.62
 					--Long Foregrip
 					self.parts.wpn_fps_ass_spike_fg_long.supported = true
@@ -35661,18 +35771,18 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 						recoil = 2,
 						spread = -1
 					}
-			
-					--Long Barrel 
-					self.parts.wpn_fps_ass_spike_b_long.supported = true 
+
+					--Long Barrel
+					self.parts.wpn_fps_ass_spike_b_long.supported = true
 					self.parts.wpn_fps_ass_spike_b_long.stats = deep_clone(barrels.long_b1_stats)
 					self.parts.wpn_fps_ass_spike_b_long.custom_stats = deep_clone(barrels.long_b1_stats)
-			
+
 					if SystemFS:exists("assets/mod_overrides/AK Correct Magpul Assist Mags") then
 						self.wpn_fps_ass_spike.override = self.wpn_fps_ass_spike.override or {}
 						self.wpn_fps_ass_spike.override.wpn_fps_upg_ak_m_quick = self.wpn_fps_ass_spike.override.wpn_fps_upg_ak_m_quick or {}
 						self.wpn_fps_ass_spike.override.wpn_fps_upg_ak_m_quick.unit = "units/mods/weapons/wpn_fps_ass_akm_m_magpul/wpn_fps_ass_akm_m_magpul"
 					end
-		
+
 				--SG-416
 					--Long Barrel
 					self.parts.wpn_fps_ass_sg416_b_long.supported = true
@@ -35680,7 +35790,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 					self.parts.wpn_fps_ass_sg416_b_long.custom_stats = deep_clone(barrels.long_b1_stats)
 					self.parts.wpn_fps_ass_sg416_b_long.unit = "units/mods/weapons/wpn_fps_ass_contraband_pts/wpn_fps_ass_contraband_b_long"
 					self.parts.wpn_fps_ass_sg416_b_long.a_obj = "a_fg"
-		
+
 					--Schäfer Prototype Foregrip
 					self.parts.wpn_fps_ass_sg416_fg_custom.supported = true
 					self.parts.wpn_fps_ass_sg416_fg_custom.stats = {
@@ -35688,7 +35798,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 						recoil = 2,
 						concealment = -1
 					}
-		
+
 					--SG416 default parts...
 					self.parts.wpn_fps_ass_sg416_s_standard.supported = true
 					self.parts.wpn_fps_ass_sg416_s_standard.stats = { value = 1 }
@@ -35699,7 +35809,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 					self.parts.wpn_fps_ass_sg416_m_standard.custom_stats = nil
 					self.parts.wpn_fps_ass_sg416_m_standard.unit = "units/payday2/weapons/wpn_fps_ass_m4_pts/wpn_fps_m4_uupg_m_std"
 					self.parts.wpn_fps_ass_sg416_m_standard.third_unit = "units/payday2/weapons/wpn_third_ass_m4_pts/wpn_third_m4_uupg_m_std"
-					self.parts.wpn_fps_ass_sg416_dh_custom.supported = true	
+					self.parts.wpn_fps_ass_sg416_dh_custom.supported = true
 					self.parts.wpn_fps_ass_sg416_dh_custom.stats = { value = 0 }
 					self.parts.wpn_fps_ass_sg416_o_standard.unit = "units/mods/weapons/wpn_fps_smg_shepheard_pts/wpn_fps_smg_shepheard_o_long"
 					self.parts.wpn_fps_ass_sg416_o_standard.stance_mod = {
@@ -35708,7 +35818,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 							rotation = Rotation(0.05, 0, 0)
 						}
 					}
-			
+
 					self.wpn_fps_ass_sg416.override.wpn_fps_upg_m4_g_standard_vanilla = {
 						unit = "units/pd2_dlc_opera/weapons/wpn_fps_ass_tecci_pts/wpn_fps_ass_tecci_g_standard",
 						third_unit = "units/pd2_dlc_opera/weapons/wpn_fps_ass_tecci_pts/wpn_third_ass_tecci_g_standard"
@@ -35753,25 +35863,25 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 							}
 						}
 					}
-			
+
 					self.wpn_fps_ass_sg416.default_blueprint[9] = "wpn_fps_ass_contraband_ns_standard"
 					self.wpn_fps_ass_sg416.uses_parts[18] = "wpn_fps_ass_contraband_ns_standard"
-			
+
 					table.insert(self.wpn_fps_ass_sg416.uses_parts, "wpn_fps_m4_uupg_s_fold")
 					table.insert(self.wpn_fps_ass_sg416.uses_parts, "wpn_fps_ass_m16_s_fixed")
 					table.insert(self.wpn_fps_ass_sg416.uses_parts, "wpn_fps_upg_m4_m_drum")
-					table.insert(self.wpn_fps_ass_sg416.uses_parts, "wpn_fps_ass_tecci_b_long")		
-					table.insert(self.wpn_fps_ass_sg416.uses_parts, "wpn_fps_ass_contraband_b_short")		
-			
-					self.wpn_fps_ass_sg416_npc.override = deep_clone(self.wpn_fps_ass_sg416.override)	
+					table.insert(self.wpn_fps_ass_sg416.uses_parts, "wpn_fps_ass_tecci_b_long")
+					table.insert(self.wpn_fps_ass_sg416.uses_parts, "wpn_fps_ass_contraband_b_short")
+
+					self.wpn_fps_ass_sg416_npc.override = deep_clone(self.wpn_fps_ass_sg416.override)
 					self.wpn_fps_ass_sg416_npc.uses_parts = deep_clone(self.wpn_fps_ass_sg416.uses_parts)
-		
+
 				--Automat-5
 					--Long Barrel
 					self.parts.wpn_fps_smg_ak5s_b_long.supported = true
 					self.parts.wpn_fps_smg_ak5s_b_long.stats = deep_clone(barrels.long_b1_stats)
 					self.parts.wpn_fps_smg_ak5s_b_long.custom_stats = deep_clone(barrels.long_b1_stats)
-		
+
 					--Aftermarket Magazine
 					self.parts.wpn_fps_smg_ak5s_m_new.supported = true
 					self.parts.wpn_fps_smg_ak5s_m_new.stats = {
@@ -35792,23 +35902,23 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 					self.parts.wpn_fps_smg_ak5s_m_smol.stats = {
 						value = 1
 					}
-				
+
 					--Wrist Breaker Stock
 					self.parts.wpn_fps_smg_ak5s_nostock.supported = true
 					self.parts.wpn_fps_smg_ak5s_nostock.stats = deep_clone(stocks.remove_adj_stats)
 					self.parts.wpn_fps_smg_ak5s_nostock.custom_stats = deep_clone(stocks.remove_adj_stats)
-			
+
 				--ACAR-9
 					--Steel Barrel
 					self.parts.wpn_fps_smg_car9_b_long.supported = true
 					self.parts.wpn_fps_smg_car9_b_long.stats = deep_clone(barrels.long_b1_stats)
 					self.parts.wpn_fps_smg_car9_b_long.custom_stats = deep_clone(barrels.long_b1_stats)
-			
+
 					self.parts.wpn_fps_smg_car9_b_standard.supported = true
 					self.parts.wpn_fps_smg_car9_b_standard.stats = { value = 1 }
 					self.parts.wpn_fps_smg_car9_fg_rail.supported = true
 					self.parts.wpn_fps_smg_car9_fg_rail.stats = { value = 1 }
-			
+
 					--Extended Magazine
 					self.parts.wpn_fps_smg_car9_m_extended.supported = true
 					self.parts.wpn_fps_smg_car9_m_extended.stats = {
@@ -35817,7 +35927,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 						reload = -3,
 						concealment = -1
 					}
-		
+
 				--Reinbeck
 					--Classic Heat Barrel
 					self.parts.wpn_fps_shot_beck_b_heat_dummy.supported = true
@@ -35863,7 +35973,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 						recoil = 2,
 						concealment = -1
 					}
-		
+
 					self.wpn_fps_shot_beck.override = self.wpn_fps_shot_beck.override or {}
 					self.wpn_fps_shot_beck.override.wpn_fps_upg_a_slug = deep_clone(shot_ammo.a_slug_pump_override)
 					self.wpn_fps_shot_beck.override.wpn_fps_upg_a_custom = deep_clone(shot_ammo.a_custom_pump_override)
@@ -35872,22 +35982,22 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 					self.wpn_fps_shot_beck.override.wpn_fps_upg_a_rip = deep_clone(shot_ammo.a_rip_pump_override)
 					self.wpn_fps_shot_beck.override.wpn_fps_upg_a_piercing = deep_clone(shot_ammo.a_piercing_pump_override)
 					self.wpn_fps_shot_beck.override.wpn_fps_upg_a_dragons_breath = deep_clone(shot_ammo.a_dragons_breath_pump_override)
-		
+
 				--(Breaker 12G) Tactical Stock
 				self.parts.wpn_fps_sho_boot_s_black.supported = true
 				self.parts.wpn_fps_sho_boot_s_black.stats = deep_clone(stocks.add_nocheeks_stats)
 				self.parts.wpn_fps_sho_boot_s_black.custom_stats = deep_clone(stocks.add_nocheeks_stats)
-		
+
 				--(JP36) Sniper Grip
 				self.parts.wpn_fps_ass_g36_g_sniper.supported = true
 				self.parts.wpn_fps_ass_g36_g_sniper.stats = deep_clone(grips.acc_1)
-		
-		
+
+
 				self.parts.wpn_fps_ass_s552_o_custom.supported = true
 				self.parts.wpn_fps_ass_s552_o_custom.stats = {
 					value = 0
 				}
-		
+
 				self.parts.wpn_fps_ass_s552_o_custom.stance_mod = {
 					wpn_fps_ass_s552 = {
 						translation = Vector3(0.015, 2, -0.7),
@@ -35898,7 +36008,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 						rotation = Rotation(0.04, 0.5, 0)
 					}
 				}
-		
+
 				--(HRL-7) Very Subtle Grip
 				self.parts.wpn_fps_rpg7_body_subtle.supported = true
 				self.parts.wpn_fps_rpg7_body_subtle.stats = {
@@ -35907,13 +36017,13 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 					concealment = 1
 				}
 				self.parts.wpn_fps_rpg7_body_subtle.custom_stats = nil
-		
+
 				--(Eagle Heavy) Eagle Aftermarket Grip
 				--Disabled
 				self.parts.wpn_fps_ass_scar_g_tan.pcs = nil
 				self.parts.wpn_fps_ass_scar_g_tan.supported = true
-				self.parts.wpn_fps_ass_scar_g_tan.stats = {}			
-				
+				self.parts.wpn_fps_ass_scar_g_tan.stats = {}
+
 				--Low Profile Compensator
 				self.parts.wpn_fps_upg_pis_ns_edge.supported = true
 				self.parts.wpn_fps_upg_pis_ns_edge.perks = nil
@@ -35921,7 +36031,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 				self.parts.wpn_fps_upg_pis_ns_edge.has_description = nil
 				self.parts.wpn_fps_upg_pis_ns_edge.stats = deep_clone(muzzle_device.muzz_rec_c)
 				self.parts.wpn_fps_upg_pis_ns_edge.custom_stats = nil
-		
+
 				--Guerilla .308
 					--Sniper Stock
 					self.parts.wpn_fps_snp_sgs_s_sniper.supported = true
@@ -35936,14 +36046,14 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 					self.parts.wpn_fps_snp_sgs_b_long.custom_stats = deep_clone(barrels.long_b2_stats)
 					--Suppressed Barrel
 					self.parts.wpn_fps_snp_sgs_b_sil.supported = true
-					self.parts.wpn_fps_snp_sgs_b_sil.stats = { 
+					self.parts.wpn_fps_snp_sgs_b_sil.stats = {
 						value = 5,
 						suppression = 12,
 						alert_size = -1
 					}
 					--Scout foregrip
 					self.parts.wpn_fps_snp_sgs_fg_rail.supported = true
-					self.parts.wpn_fps_snp_sgs_fg_rail.stats = { 
+					self.parts.wpn_fps_snp_sgs_fg_rail.stats = {
 						value = 4,
 						concealment = 1,
 						recoil = -2
@@ -35994,7 +36104,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 					table.insert(self.wpn_fps_snp_sgs.uses_parts, "wpn_fps_snp_victor_s_mod0")
 					table.insert(self.wpn_fps_snp_sgs.uses_parts, "wpn_fps_upg_m4_s_ubr")
 					table.insert(self.wpn_fps_snp_sgs.uses_parts, "wpn_fps_snp_tti_s_vltor")
-			
+
 					self.wpn_fps_snp_sgs_npc.override = deep_clone(self.wpn_fps_snp_sgs.override)
 					self.wpn_fps_snp_sgs_npc.uses_parts = deep_clone(self.wpn_fps_snp_sgs.uses_parts)
 
@@ -36014,14 +36124,14 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 						concealment = -1,
 						reload = 3
 					}
-		
+
 				--(KSP 58) Aftermarket Rail
 				self.parts.wpn_fps_lmg_par_rail.supported = true
 				self.parts.wpn_fps_lmg_par_rail.stats = {
 					value = 3,
 					recoil = 2,
 					concealment = -1
-				}		
+				}
 			end
 
 			--Vanilla Mod Pack Volume 2 Support
@@ -36030,7 +36140,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 				self.parts.wpn_fps_smg_uzi_b_longue.supported = true
 				self.parts.wpn_fps_smg_uzi_b_longue.stats = deep_clone(barrels.long_b2_stats)
 				self.parts.wpn_fps_smg_uzi_b_longue.custom_stats = deep_clone(barrels.long_b2_stats)
-		
+
 				--(RPK) Lightweight combo Magazine
 				self.parts.wpn_lmg_rpk_m_jungle.supported = true
 				self.parts.wpn_lmg_rpk_m_jungle.stats = {
@@ -36044,11 +36154,11 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 				self.parts.wpn_lmg_rpk_m_jungle.custom_stats = {
 					ads_speed_mult = 0.925
 				}
-		
+
 				--(Holt 9mm) Luxury Grip
 				self.parts.wpn_fps_pis_holt_g_wrap.supported = true
 				self.parts.wpn_fps_pis_holt_g_wrap.stats = deep_clone(grips.recoil_2)
-		
+
 				--(R700) Hunting Stock
 				self.parts.wpn_fps_snp_r700_s_redwood.supported = true
 				self.parts.wpn_fps_snp_r700_s_redwood.stats = {
@@ -36056,13 +36166,13 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 					concealment = 1,
 					spread = -1
 				}
-		
+
 				--(R700) Low Profile Iron Sight
 				self.parts.wpn_fps_snp_r700_o_is.supported = true
 				self.parts.wpn_fps_snp_r700_o_is.stats = {
 					value = 1
 				}
-				
+
 				--(Bernetti Rangehitter) Mare's Leg Barrel
 				self.parts.wpn_fps_snp_sbl_b_stub.supported = true
 				self.parts.wpn_fps_snp_sbl_b_stub.stats = {
@@ -36070,22 +36180,22 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 					spread = -1,
 					concealment = 2,
 					extra_ammo = -1
-				}		
+				}
 				self.parts.wpn_fps_snp_sbl_b_stub.custom_stats = deep_clone(barrels.short_b1_stats)
 				self.parts.wpn_fps_snp_sbl_b_stub.custom_stats.ads_speed_mult = 0.95
-		
+
 				--(Czech 92) Angled Grip
 				self.parts.wpn_fps_pis_czech_body_afg.pcs = nil
 				self.parts.wpn_fps_pis_czech_body_afg.supported = true
 				self.parts.wpn_fps_pis_czech_body_afg.stats = {
 					value = 1
 				}
-				
+
 				--(Cobra) Solid Wooden Stock
 				self.parts.wpn_fps_smg_scorpion_s_wood.supported = true
-				self.parts.wpn_fps_smg_scorpion_s_wood.stats = deep_clone(stocks.folded_to_fixed_stats)		
-				self.parts.wpn_fps_smg_scorpion_s_wood.custom_stats = deep_clone(stocks.folded_to_fixed_stats)		
-		
+				self.parts.wpn_fps_smg_scorpion_s_wood.stats = deep_clone(stocks.folded_to_fixed_stats)
+				self.parts.wpn_fps_smg_scorpion_s_wood.custom_stats = deep_clone(stocks.folded_to_fixed_stats)
+
 				--(Heather) Aftermarket Vertical Grip
 				self.parts.wpn_fps_smg_sr2_vg_custom.supported = true
 				self.parts.wpn_fps_smg_sr2_vg_custom.stats = {
@@ -36093,14 +36203,14 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 					spread = 1,
 					recoil = -2
 				}
-		
+
 				--(Compact 5) Combat Stock
 				self.parts.wpn_fps_smg_mp5_s_m4.supported = true
 				self.parts.wpn_fps_smg_mp5_s_m4.stats = deep_clone(stocks.fixed_to_adj_rec_stats)
 				self.parts.wpn_fps_smg_mp5_s_m4.custom_stats = deep_clone(stocks.fixed_to_adj_rec_stats)
-		
+
 				self.parts.wpn_fps_smg_mp5_s_m4_dummy = deep_clone(self.parts.wpn_fps_smg_mp5_s_m4)
-				self.parts.wpn_fps_smg_mp5_s_m4_dummy.pcs = nil		
+				self.parts.wpn_fps_smg_mp5_s_m4_dummy.pcs = nil
 				self.parts.wpn_fps_smg_mp5_s_m4_dummy.stats = { value = 1 }
 				self.parts.wpn_fps_smg_mp5_s_m4_dummy.custom_stats = nil
 				self.parts.wpn_fps_smg_mp5_s_m4_dummy.adds = nil
@@ -36113,9 +36223,9 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 					adds = {"wpn_fps_smg_mp5_s_m4_dummy"}
 				}
 				self.wpn_fps_smg_mp5_npc.override = deep_clone(self.wpn_fps_smg_mp5.override)
-				
+
 				self.parts.wpn_fps_bdgr_covers.adds = {}
-		
+
 				--(Hornet .300) Bumblebee Foregrip
 				self.parts.wpn_fps_bdgr_uupg_fg_railed.supported = true
 				self.parts.wpn_fps_bdgr_uupg_fg_railed.adds = {"wpn_fps_bdgr_covers"}
@@ -36140,7 +36250,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 					third_unit = "units/mods/weapons/wpn_third_ass_bdgr_pts/wpn_third_bdgr_b_sd_small",
 					a_obj = "a_fg"
 				}
-		
+
 				self.parts.wpn_fps_bdgr_uupg_fg_std.unit = "units/payday2/weapons/wpn_fps_ass_m4_pts/wpn_fps_m4_uupg_fg_rail"
 				self.parts.wpn_fps_bdgr_uupg_fg_std.third_unit = "units/payday2/weapons/wpn_third_ass_m4_pts/wpn_third_m4_uupg_fg_rail"
 				self.parts.wpn_fps_bdgr_uupg_fg_std.override = {
@@ -36148,7 +36258,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 						a_obj = "a_fg"
 					}
 				}
-		
+
 				self.wpn_fps_ass_bdgr.override = {
 					wpn_fps_smg_olympic_s_adjust = {
 						unit = "units/mods/weapons/wpn_fps_ass_contraband_pts/wpn_fps_ass_contraband_s_tecci"
@@ -36206,42 +36316,42 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 					stats = deep_clone(stocks.nocheeks_to_fixed_rec3_stats),
 					custom_stats = deep_clone(stocks.nocheeks_to_fixed_rec3_stats)
 				}
-		
+
 				table.insert(self.wpn_fps_ass_bdgr.uses_parts, "wpn_fps_smg_olympic_s_short")
 				table.insert(self.wpn_fps_ass_bdgr.uses_parts, "wpn_fps_ass_m16_s_fixed")
-		
+
 				table.insert(self.wpn_fps_ass_amcar.uses_parts, "wpn_fps_m4_uupg_s_fold")
 				table.insert(self.wpn_fps_ass_amcar_npc.uses_parts, "wpn_fps_m4_uupg_s_fold")
-		
+
 				self.wpn_fps_ass_bdgr_npc.override = deep_clone(self.wpn_fps_ass_bdgr.override)
 				self.wpn_fps_ass_bdgr_npc.uses_parts = deep_clone(self.wpn_fps_ass_bdgr.uses_parts)
-		
-		
+
+
 				--(M60) Long Barrel
 				self.parts.wpn_fps_lmg_m60_b_longer.supported = true
 				self.parts.wpn_fps_lmg_m60_b_longer.stats = deep_clone(barrels.long_b3_stats)
 				self.parts.wpn_fps_lmg_m60_b_longer.custom_stats = deep_clone(barrels.long_b3_stats)
-				
+
 				--Wrapped Grip
 				self.parts.wpn_fps_m4_g_wrap.supported = true
 				self.parts.wpn_fps_m4_g_wrap.stats = deep_clone(grips.recoil_1)
-		
+
 				--Polygonal Suppressor
 				self.parts.wpn_fps_upg_ns_shot_flat.supported = true
 				self.parts.wpn_fps_upg_ns_shot_flat.stats = deep_clone(muzzle_device.supp_acc_c)
 				self.parts.wpn_fps_upg_ns_shot_flat.custom_stats = deep_clone(muzzle_device.supp_acc_c)
-		
+
 				--Professional Suppressor
 				self.parts.wpn_fps_upg_ns_ass_smg_pro.supported = true
 				self.parts.wpn_fps_upg_ns_ass_smg_pro.stats = deep_clone(muzzle_device.supp_dual_c)
 				self.parts.wpn_fps_upg_ns_ass_smg_pro.custom_stats = deep_clone(muzzle_device.supp_dual_c)
-		
+
 				--(Jacket's Piece) Foldable Stock
 				self.parts.wpn_fps_smg_cobray_s_custom.supported = true
 				self.parts.wpn_fps_smg_cobray_s_custom.stats = {
 					value = 0
 				}
-		
+
 				--Modern Bolt
 				self.parts.wpn_fps_ak_bolt_chrome.supported = true
 				self.parts.wpn_fps_ak_bolt_chrome.stats = {
@@ -36249,22 +36359,22 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 					recoil = 1,
 					concealment = -2
 				}
-		
+
 				--(Patchett L2A1) Extended Barrel
 				self.parts.wpn_fps_smg_sterling_b_poke.supported = true
 				self.parts.wpn_fps_smg_sterling_b_poke.stats = deep_clone(barrels.long_b2_stats)
 				self.parts.wpn_fps_smg_sterling_b_poke.custom_stats = deep_clone(barrels.long_b2_stats)
-		
+
 				--(Parabellum) Langer Barrel
 				self.parts.wpn_fps_pis_breech_b_length.supported = true
 				self.parts.wpn_fps_pis_breech_b_length.stats = deep_clone(barrels.long_b2_stats)
 				self.parts.wpn_fps_pis_breech_b_length.custom_stats = deep_clone(barrels.long_b2_stats)
-		
+
 				--Constrictor Nozzle
 				self.parts.wpn_fps_upg_ns_shot_close.supported = true
 				self.parts.wpn_fps_upg_ns_shot_close.stats = deep_clone(muzzle_device.muzz_acc2_r)
 				self.parts.wpn_fps_upg_ns_shot_close.custom_stats = deep_clone(muzzle_device.muzz_acc2_r)
-		
+
 				--(OVE9000 Saw) Ripper Blade
 				self.parts.wpn_fps_saw_m_blade_scream.supported = true
 				self.parts.wpn_fps_saw_m_blade_scream.keep_damage = true
@@ -36274,7 +36384,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 					damage = 30,
 					total_ammo_mod = -104
 				}
-		
+
 				--(Compact-5) Package Deal Magazines
 				self.parts.wpn_fps_smg_mp5_m_dos.supported = true
 				self.parts.wpn_fps_smg_mp5_m_dos.stats = {
@@ -36287,7 +36397,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 				self.parts.wpn_fps_smg_mp5_m_dos_clip.custom_stats = {}
 				self.parts.wpn_fps_smg_mp5_m_dos_bullet.custom_stats = {}
 				self.parts.wpn_fps_smg_mp5_m_dos_bullet_2.custom_stats = {}
-		
+
 				self.wpn_fps_smg_x_mp5.override.wpn_fps_smg_mp5_m_dos = {
 					stats = {
 						value = 6,
@@ -36297,7 +36407,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 					},
 					custom_stats = {}
 				}
-		
+
 				--(GSPS 12G) High Capacity Barrel
 				self.parts.wpn_fps_shot_m37_b_extend.supported = true
 				self.parts.wpn_fps_shot_m37_b_extend.stats = {
@@ -36308,18 +36418,18 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 				self.parts.wpn_fps_shot_m37_b_extend.custom_stats = {
 					ads_speed_mult = 1.025
 				}
-		
+
 				--(MP40) Langer Barrel
 				self.parts.wpn_fps_smg_erma_b_langer.supported = true
 				self.parts.wpn_fps_smg_erma_b_langer.stats = deep_clone(barrels.long_b1_stats)
 				self.parts.wpn_fps_smg_erma_b_langer.custom_stats = deep_clone(barrels.long_b1_stats)
-		
-		
+
+
 				--(MP40) Kurz Barrel
 				self.parts.wpn_fps_smg_erma_b_kurz.supported = true
 				self.parts.wpn_fps_smg_erma_b_kurz.stats = deep_clone(barrels.short_b1_stats)
 				self.parts.wpn_fps_smg_erma_b_kurz.custom_stats = deep_clone(barrels.short_b1_stats)
-		
+
 				--(Pistol Crossbow) Ergo Handle
 				self.parts.wpn_fps_bow_hunter_body_swift.supported = true
 				self.parts.wpn_fps_bow_hunter_body_swift.stats = {
@@ -36327,24 +36437,24 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 					reload = 1,
 					concealment = -2
 				}
-		
+
 				--(Repeater 1874) Outlaw Frame
 				self.parts.wpn_fps_snp_winchester_body_bling.supported = true
 				self.parts.wpn_fps_snp_winchester_body_bling.stats = {
 					value = 2
 				}
-		
+
 				--(Bernetti Auto) Expert Slide
 				self.parts.wpn_fps_pis_beer_sl_expert.supported = true
 				self.parts.wpn_fps_pis_beer_sl_expert.stats = {
 					value = 2
 				}
-		
+
 				--(Locomotive 12G) Trench Boom Barrel
 				self.parts.wpn_fps_shot_r870_b_ithaca.supported = true
 				self.parts.wpn_fps_shot_r870_b_ithaca.stats = deep_clone(barrels.long_b3_stats)
 				self.parts.wpn_fps_shot_r870_b_ithaca.custom_stats = deep_clone(barrels.long_b3_stats)
-		
+
 				--(Reinbeck Auto) Shell Rack
 				self.parts.wpn_fps_shot_minibeck_shells.supported = true
 				self.parts.wpn_fps_shot_minibeck_shells.stats = {
@@ -36353,7 +36463,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 					concealment = -1,
 					reload = 2
 				}
-		
+
 				--(Reinbeck Auto) Extended Tube
 				self.parts.wpn_fps_shot_minibeck_ext.supported = true
 				self.parts.wpn_fps_shot_minibeck_ext.stats = {
@@ -36361,7 +36471,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 					extra_ammo = 1,
 					concealment = -1,
 				}
-		
+
 				--(Reinbeck Auto) Solid Stock
 				self.parts.wpn_fps_shot_minibeck_s_solid.supported = true
 				self.parts.wpn_fps_shot_minibeck_s_solid.stats = deep_clone(stocks.add_fixed_stats)
@@ -36374,16 +36484,16 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 				self.parts.wpn_fps_pis_holt_b_silver.stats = {
 					value = 7
 				}
-		
+
 				--(Signature SMG) Ergo Grip
 				self.parts.wpn_fps_smg_shepheard_g_ergo.supported = true
 				self.parts.wpn_fps_smg_shepheard_g_ergo.stats = deep_clone(grips.acc_recoil)
-		
+
 				--(Gruber Kurz) Expert Barrel
 				self.parts.wpn_fps_pis_ppk_b_standard_expert.supported = true
 				self.parts.wpn_fps_pis_ppk_b_standard_expert.stats = deep_clone(barrels.long_b2_stats)
 				self.parts.wpn_fps_pis_ppk_b_standard_expert.custom_stats = deep_clone(barrels.long_b2_stats)
-		
+
 				--(Bronco .44) Arbitrator Grip
 				self.parts.wpn_fps_pis_rage_g_fancy.supported = true
 				self.parts.wpn_fps_pis_rage_g_fancy.stats = {
@@ -36391,7 +36501,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 					spread = 1,
 					concealment = -1
 				}
-		
+
 				--(Castigo .44) Feroz Barrel
 				self.parts.wpn_fps_pis_chinchilla_b_rage.supported = true
 				self.parts.wpn_fps_pis_chinchilla_b_rage.stats = {
@@ -36399,12 +36509,12 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 					recoil = 2,
 					spread = -1
 				}
-		
+
 				--(Piglet) Overcompensating Barrel
 				self.parts.wpn_fps_gre_m32_barrel_extreme.supported = true
 				self.parts.wpn_fps_gre_m32_barrel_extreme.stats = deep_clone(barrels.long_b3_stats)
 				self.parts.wpn_fps_gre_m32_barrel_extreme.custom_stats = deep_clone(barrels.long_b3_stats)
-		
+
 				--(Valkyria Rifle) Heatsinked Barrel
 				self.parts.wpn_fps_ass_asval_b_heat.supported = true
 				self.parts.wpn_fps_ass_asval_b_heat.stats = {
@@ -36413,7 +36523,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 					recoil = 2
 				}
 				self.parts.wpn_fps_ass_asval_b_heat.forbids = deep_clone(self.parts.wpn_fps_ass_asval_b_standard.forbids)
-		
+
 				--(M1014) Wrist Remover Grip
 				self.parts.wpn_fps_sho_ben_s_fracture.supported = true
 				self.parts.wpn_fps_sho_ben_s_fracture.stats = deep_clone(stocks.remove_adj_stats)
@@ -36428,19 +36538,19 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 				self.parts.wpn_fps_m4_uupg_m_extend.custom_stats = {
 					ads_speed_mult = 1.025
 				}
-		
+
 				self.parts.wpn_fps_m4_uupg_m_extend_akimbo.supported = true
 				self.parts.wpn_fps_m4_uupg_m_extend_akimbo.stats = {
 					extra_ammo = 20,
 					concealment = -1,
 					reload = -3
 				}
-		
+
 				self.parts.wpn_fps_ass_asval_o_oldrail.supported = true
 				self.parts.wpn_fps_ass_asval_o_oldrail.stats = {
 					value = 2
 				}
-		
+
 				--Point Shoot Module
 				self.parts.wpn_fps_upg_fl_ass_smg_sho_pointshoot.desc_id = "bm_wp_upg_o_angled_laser_desc"
 				self.parts.wpn_fps_upg_fl_ass_smg_sho_pointshoot.has_description = true
@@ -36454,29 +36564,29 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 					pointshoot_spread = 10,
 					pointshoot_strafe = 0.5,
 				}
-		
+
 				--(M308) Mini 308 Magazine
 				self.parts.wpn_fps_ass_m14_m_curve.supported = true
 				self.parts.wpn_fps_ass_m14_m_curve.stats = {
 					value = 1
 				}
-		
+
 				--(GSPS 12) Hunting Sight
 				self.parts.wpn_fps_shot_m37_o_classic.supported = true
 				self.parts.wpn_fps_shot_m37_o_classic.stats = {
 					value = 1
 				}
-		
+
 				--(GSPS 12) Long Range Sight
 				self.parts.wpn_fps_shot_m37_o_circle.supported = true
 				self.parts.wpn_fps_shot_m37_o_circle.stats = {
 					value = 1,
 					zoom = 1
 				}
-		
+
 				--(Frenchman) Smooth Cylinder
 				self.parts.wpn_fps_pis_model3_cylinder_smooth.supported = true
-		
+
 				--(Compact 5)
 				self.parts.wpn_fps_smg_mp5_m_small.supported = true
 				self.parts.wpn_fps_smg_mp5_m_small.stats = {
@@ -36488,7 +36598,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 				self.parts.wpn_fps_smg_mp5_m_small.custom_stats = {
 					ads_speed_mult = 0.95
 				}
-		
+
 				self.wpn_fps_smg_x_mp5.override.wpn_fps_smg_mp5_m_small = {
 					stats = {
 						value = 2,
@@ -36497,62 +36607,62 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 						extra_ammo = -20
 					}
 				}
-		
+
 				--(Compact 5) Adjusted Stock
 				self.parts.wpn_fps_smg_mp5_s_adjusted.supported = true
 				self.parts.wpn_fps_smg_mp5_s_adjusted.stats = deep_clone(stocks.fixed_to_folded_stats)
 				self.parts.wpn_fps_smg_mp5_s_adjusted.custom_stats = deep_clone(stocks.fixed_to_folded_stats)
-		
+
 				table.insert(self.wpn_fps_ass_g3.uses_parts, "wpn_fps_smg_mp5_s_adjusted")
 				table.insert(self.wpn_fps_ass_g3_npc.uses_parts, "wpn_fps_smg_mp5_s_adjusted")
 				table.insert(self.wpn_fps_lmg_hk21.uses_parts, "wpn_fps_smg_mp5_s_adjusted")
 				table.insert(self.wpn_fps_lmg_hk21_npc.uses_parts, "wpn_fps_smg_mp5_s_adjusted")
-		
+
 				--(Compact 5) Marksman Foregrip
 				self.parts.wpn_fps_smg_mp5_fg_long.supported = true
 				self.parts.wpn_fps_smg_mp5_fg_long.stats = deep_clone(barrels.long_b2_stats)
 				self.parts.wpn_fps_smg_mp5_fg_long.custom_stats = deep_clone(barrels.long_b2_stats)
-		
+
 				--(Jackal) Solid Stock
 				self.parts.wpn_fps_smg_schakal_s_solid.supported = true
 				self.parts.wpn_fps_smg_schakal_s_solid.stats = deep_clone(stocks.folder_to_fixed_rec3_stats)
 				self.parts.wpn_fps_smg_schakal_s_solid.custom_stats = deep_clone(stocks.folder_to_fixed_rec3_stats)
-		
+
 				--(Jackal) Lightweight Stock
 				self.parts.wpn_fps_smg_schakal_s_hollow.supported = true
 				self.parts.wpn_fps_smg_schakal_s_hollow.stats = deep_clone(stocks.folder_acc_stats)
 				self.parts.wpn_fps_smg_schakal_s_hollow.custom_stats = deep_clone(stocks.folder_acc_stats)
-		
+
 				--(Jackal) Tactical Stock
 				self.parts.wpn_fps_smg_schakal_s_recon.supported = true
 				self.parts.wpn_fps_smg_schakal_s_recon.stats = deep_clone(stocks.folder_rec_stats)
 				self.parts.wpn_fps_smg_schakal_s_recon.custom_stats = deep_clone(stocks.folder_rec_stats)
-		
+
 				self.wpn_fps_shot_minibeck.override = {
 					wpn_fps_upg_a_slug = deep_clone(shot_ammo.a_slug_semi_override),
 					wpn_fps_upg_a_custom = deep_clone(shot_ammo.a_custom_semi_override),
-					wpn_fps_upg_a_custom_free = deep_clone(shot_ammo.a_custom_semi_override),			
+					wpn_fps_upg_a_custom_free = deep_clone(shot_ammo.a_custom_semi_override),
 					wpn_fps_upg_a_explosive = deep_clone(shot_ammo.a_explosive_semi_override),
 					wpn_fps_upg_a_rip = deep_clone(shot_ammo.a_rip_semi_override),
 					wpn_fps_upg_a_piercing = deep_clone(shot_ammo.a_piercing_semi_override),
 					wpn_fps_upg_a_dragons_breath = deep_clone(shot_ammo.a_dragons_breath_semi_override)
 				}
-				
+
 				--Hammer 23 short barrel
 				self.parts.wpn_fps_shot_bs23_barrel_short.supported = true
 				self.parts.wpn_fps_shot_bs23_barrel_short.stats = deep_clone(barrels.short_b2_stats)
 				self.parts.wpn_fps_shot_bs23_barrel_short.custom_stats = deep_clone(barrels.short_b2_stats)
-		
+
 				--Hammer 23 Sturdy Wooden Stock
 				self.parts.wpn_fps_shot_bs23_stock_full.supported = true
 				self.parts.wpn_fps_shot_bs23_stock_full.stats = deep_clone(stocks.nocheeks_to_fixed_rec3_stats)
 				self.parts.wpn_fps_shot_bs23_stock_full.custom_stats = deep_clone(stocks.nocheeks_to_fixed_rec3_stats)
-				
+
 				--Hammer 23 Hazardous stock
 				self.parts.wpn_fps_shot_bs23_stock_none.supported = true
 				self.parts.wpn_fps_shot_bs23_stock_none.stats = deep_clone(stocks.remove_nocheeks_stats)
 				self.parts.wpn_fps_shot_bs23_stock_none.custom_stats = deep_clone(stocks.remove_nocheeks_stats)
-				
+
 				self.parts.wpn_fps_shot_bs23_rec_sight_rear.stance_mod = {
 					wpn_fps_shot_bs23 = {
 						translation = Vector3(-0.05, -8, 0.5),
@@ -36561,12 +36671,12 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 				}
 				self.parts.wpn_fps_shot_bs23_rec_sight_rear.stats = {
 					value = 1
-				}		
-				
+				}
+
 				--Hammer 23 ammo stuff
-				self.wpn_fps_shot_bs23.override = {}		
+				self.wpn_fps_shot_bs23.override = {}
 			end
-		
+
 			--That one VMP update that added a tiny hat
 			if self.parts.wpn_fps_pis_peacemaker_hat then
 				--Lil' Yee-Haw
@@ -36576,37 +36686,37 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 					}
 				}
 			end
-		
+
 			--Vanilla Mod Pack 23.3 v6
 			if self.parts.wpn_fps_pis_triggermod_fast then
 				--Pistol Triggers, Disabled for now
 					self.parts.wpn_fps_pis_triggermod_fast.supported = true
-					self.parts.wpn_fps_pis_triggermod_fast.pcs = {} 
-					self.parts.wpn_fps_pis_triggermod_fast.stats = { 
+					self.parts.wpn_fps_pis_triggermod_fast.pcs = {}
+					self.parts.wpn_fps_pis_triggermod_fast.stats = {
 						value = 5,
 						spread = -3,
 						recoil = -4
 					}
-					self.parts.wpn_fps_pis_triggermod_fast.custom_stats = { 
+					self.parts.wpn_fps_pis_triggermod_fast.custom_stats = {
 						rof_mult = 1.08,
 						hip_mult = 1.5
 					}
 					self.parts.wpn_fps_pis_triggermod_slow.supported = true
-					self.parts.wpn_fps_pis_triggermod_slow.pcs = {} 
-					self.parts.wpn_fps_pis_triggermod_slow.stats = { 
+					self.parts.wpn_fps_pis_triggermod_slow.pcs = {}
+					self.parts.wpn_fps_pis_triggermod_slow.stats = {
 						value = 5,
 						spread = 3,
 						recoil = 2
 					}
-					self.parts.wpn_fps_pis_triggermod_slow.custom_stats = { 
+					self.parts.wpn_fps_pis_triggermod_slow.custom_stats = {
 						rof_mult = 0.9,
 						hip_mult = 0.9,
 					}
-		
+
 				--Argos III
 					self.parts.wpn_fps_sho_ultima_o_expert.supported = true
 					self.parts.wpn_fps_sho_ultima_o_expert.stats = { value = 0 }
-		
+
 				--Signature SMG
 					self.parts.wpn_fps_smg_shepheard_fg_suppressed.supported = true
 					self.parts.wpn_fps_smg_shepheard_fg_suppressed.has_description = true
@@ -36617,7 +36727,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 						alert_size = -1
 					}
 					self.parts.wpn_fps_smg_shepheard_fg_suppressed.perks = {"silencer"}
-		
+
 				--R700
 					self.parts.wpn_fps_snp_r700_b_supp.supported = true
 					self.parts.wpn_fps_snp_r700_b_supp.has_description = true
@@ -36629,7 +36739,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 						alert_size = -1
 					}
 					self.parts.wpn_fps_snp_r700_b_supp.perks = {"silencer"}
-		
+
 				--AK Family Parts
 					--Expanded Mag
 					self.parts.wpn_upg_ak_m_slick.supported = true
@@ -36649,10 +36759,10 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 						reload = 5,
 						extra_ammo = -10
 					}
-					self.parts.wpn_upg_ak_m_tiny.custom_stats = { 
+					self.parts.wpn_upg_ak_m_tiny.custom_stats = {
 						ads_speed_mult = 0.95
 					}
-		
+
 				--CAR Family Parts
 					--Modern Foregrip
 					self.parts.wpn_fps_uupg_m4_fg_victorcar.supported = true
@@ -36670,7 +36780,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 					self.parts.wpn_fps_ass_m4_m_star.supported = true
 					self.parts.wpn_fps_ass_m4_m_star.stats = deep_clone(self.parts.wpn_fps_upg_m4_m_straight.stats)
 					self.parts.wpn_fps_ass_m4_m_star.custom_stats = deep_clone(self.parts.wpn_fps_upg_m4_m_straight.custom_stats)
-		
+
 				--Glock 22 Kit
 					self.parts.wpn_fps_pis_g22c_body_wick_dummy.supported = true
 					self.parts.wpn_fps_pis_g22c_body_wick_dummy.stats = { value = 0 }
@@ -36686,18 +36796,18 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 					self.parts.wpn_fps_pis_g22c_body_wick_dummy.override.wpn_fps_pis_g22c_b_long = {
 						unit = "units/mods/weapons/wpn_fps_pis_g22c_pts/wpn_fps_pis_g22c_b_wick",
 					}
-		
+
 				--Deagle Steady Wooden Grip Updated
 					self.parts.wpn_fps_pis_deagle_g_wooden.supported = true
 					self.parts.wpn_fps_pis_deagle_g_wooden.stats = deep_clone(grips.recoil_acc)
 					self.parts.wpn_fps_pis_deagle_g_wooden.custom_stats = nil
-		
+
 				--Lion's Roar Urban Heat Kit Updated
 					self.parts.wpn_fps_ass_vhs_body_camo.supported = true
 					self.parts.wpn_fps_ass_vhs_body_camo.stats = {
 						value = 0
 					}
-		
+
 				--Repeater Papa Yeehaw
 					self.parts.wpn_fps_snp_winchester_yeehaw.type = "sight"
 					self.parts.wpn_fps_snp_winchester_yeehaw.supported = true
@@ -36711,7 +36821,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 						}
 					}
 			end
-			
+
 			--Vanilla Mod Pack 23.3 v7
 			if self.parts.wpn_fps_lmg_hcar_body_ww2 then
 				--BAR kit
@@ -36952,7 +37062,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 						parent = "exclusive_set",
 						a_obj = "a_s"
 					},
-		
+
 					wpn_fps_ass_contraband_o_standard = {
 						unit = "units/payday2/weapons/wpn_fps_smg_mp9_pts/wpn_fps_smg_mp9_b_dummy"
 					},
@@ -36966,7 +37076,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 						unit = "units/payday2/weapons/wpn_fps_smg_mp9_pts/wpn_fps_smg_mp9_b_dummy"
 					}
 				}
-		
+
 				for part_id, i in pairs(self.parts) do
 					if self.parts[part_id] and self.parts[part_id].type and self.parts[part_id].type == "charm" then
 						self.parts.wpn_fps_ass_contraband_body_sayhello.override[part_id] = {
@@ -36975,7 +37085,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 						}
 					end
 				end
-		
+
 				for i, part_id in pairs(self.wpn_fps_ass_contraband.uses_parts) do
 					if self.parts[part_id] and self.parts[part_id].type then
 						if self.parts[part_id].type == "grip" then
@@ -37053,7 +37163,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 				}
 
 				self.parts.wpn_fps_ass_contraband_body_sayhello.override.wpn_fps_ass_contraband_o_standard.stance_mod = {}
-		
+
 				--G2 Kit
 				self.parts.wpn_fps_snp_contender_receiver_hunt.supported = true
 				self.parts.wpn_fps_snp_contender_receiver_hunt.stats = {value = 0}
@@ -37064,11 +37174,11 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 					wpn_fps_snp_contender_receiver = {
 						unit = "units/mods/weapons/wpn_fps_snp_contender_pts/wpn_fps_snp_contender_receiver_hunt"
 					},
-		
+
 					wpn_fps_snp_contender_triggerguard = {
 						unit = "units/mods/weapons/wpn_fps_snp_contender_pts/wpn_fps_snp_contender_trigger_hunt"
 					},
-		
+
 					wpn_fps_snp_contender_barrel_standard = {
 						unit = "units/mods/weapons/wpn_fps_snp_contender_pts/wpn_fps_snp_contender_barrel_hunt"
 					},
@@ -37078,21 +37188,21 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 					wpn_fps_snp_contender_barrel_long = {
 						unit = "units/mods/weapons/wpn_fps_snp_contender_pts/wpn_fps_snp_contender_barrel_hunt"
 					},
-		
+
 					wpn_fps_snp_contender_frontgrip_short = {
 						unit = "units/mods/weapons/wpn_fps_snp_contender_pts/wpn_fps_snp_contender_frontgrip_hunt"
 					},
 					wpn_fps_snp_contender_frontgrip_long = {
 						unit = "units/mods/weapons/wpn_fps_snp_contender_pts/wpn_fps_snp_contender_frontgrip_hunt"
 					},
-		
+
 					wpn_fps_snp_contender_grip_standard = {
 						unit = "units/mods/weapons/wpn_fps_snp_contender_pts/wpn_fps_snp_contender_grip_hunt"
 					},
 					wpn_fps_smg_sr2_o_rail = {
 						parent = "barrel"
 					},
-		
+
 					wpn_fps_upg_contender_o_ironsight = {
 						unit = "units/payday2/weapons/wpn_upg_dummy/wpn_upg_dummy"
 					}
@@ -37109,7 +37219,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 						end
 					end
 				end
-		
+
 				--BS9
 				self.parts.wpn_fps_pis_beretta_body_stonecold.supported = true
 				self.parts.wpn_fps_pis_beretta_body_stonecold.has_description = nil
@@ -37125,7 +37235,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 				}
 				for i, part_id in pairs(self.wpn_fps_pis_beretta.uses_parts) do
 					if self.parts[part_id] and self.parts[part_id].type then
-		
+
 						if self.parts[part_id].type == "lower_reciever" then
 							self.parts.wpn_fps_pis_beretta_body_stonecold.override[part_id] = {
 								unit = "units/mods/weapons/wpn_fps_pis_beretta_pts/wpn_fps_pis_beretta_body_stonecold"
@@ -37155,7 +37265,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 								}
 							end
 						end
-		
+
 					end
 				end
 				self.parts.wpn_fps_upg_ns_gemberettadummy.supported = true
@@ -37166,7 +37276,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 				self.parts.wpn_fps_pis_beretta_co_coclassic.stats = {value = 0}
 				self.parts.wpn_fps_pis_beretta_co_coclassic.custom_stats = nil
 				self.parts.wpn_fps_pis_beretta_co_coclassic.override = {}
-		
+
 				--1911
 				self.parts.wpn_fps_pis_1911_body_sidewinder.supported = true
 				self.parts.wpn_fps_pis_1911_body_sidewinder.stats = deep_clone(barrels.short_b2_stats)
@@ -37198,7 +37308,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 						end
 					end
 				end
-		
+
 				--TANNED TITTY
 				self.parts.wpn_fps_snp_tti_body_camelspider.supported = true
 				self.parts.wpn_fps_snp_tti_body_camelspider.stats = {value = 0}
@@ -37273,7 +37383,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 
 			--Vanilla Mod Pack 23.3 v8
 			if self.parts.wpn_fps_ass_m4_body_dust then
-	
+
 				self.parts.wpn_fps_ass_m4_body_dust.supported = true
 				self.parts.wpn_fps_ass_m4_body_dust.stats = {
 					value = 8,
@@ -37292,10 +37402,10 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 						rotation = Rotation(0, -0.2, 0)
 					}
 				}
-				self.parts.wpn_fps_ass_m4_body_dust.forbids = { 
+				self.parts.wpn_fps_ass_m4_body_dust.forbids = {
 					"wpn_fps_m4_uupg_b_sd"
 				}
-	
+
 				--A RIGHTEOUS MAN NEVER HAS WEALTH
 				self.parts.wpn_fps_pis_shrew_body_light.supported = true
 				self.parts.wpn_fps_pis_shrew_body_light.stats = { value = 0 }
@@ -37339,7 +37449,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 						end
 					end
 				end
-	
+
 				--Korth Exclusive Set 2
 				self.parts.wpn_fps_pis_korth_body_skill.supported = true
 				self.parts.wpn_fps_pis_korth_body_skill.has_description = true
@@ -37369,7 +37479,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 					end
 				end
 				self.parts.wpn_fps_pis_korth_body_skill.override.wpn_fps_pis_korth_m_8.adds = {}
-	
+
 				self.parts.wpn_fps_pis_m1911_body_killer.supported = true
 				self.parts.wpn_fps_pis_m1911_body_killer.stats = { value = 0, zoom = 20, spread = 3, concealment = -5, recoil = 4 }
 				self.parts.wpn_fps_pis_m1911_body_killer.custom_stats = {
@@ -37393,10 +37503,10 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 						}
 					}
 				}
-	
+
 				self.parts.wpn_fps_pis_type54_body_wood.supported = true
 				self.parts.wpn_fps_pis_type54_body_wood.stats = { value = 0 }
-	
+
 				self.parts.wpn_fps_pis_chinchilla_body_cascade.supported = true
 				self.parts.wpn_fps_pis_chinchilla_body_cascade.stats = { value = 0 }
 				self.parts.wpn_fps_pis_chinchilla_body_cascade.custom_stats = nil
@@ -37414,7 +37524,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 						end
 					end
 				end
-	
+
 				self.parts.wpn_fps_pis_packrat_body_sport.supported = true
 				self.parts.wpn_fps_pis_packrat_body_sport.stats = { value = 0 }
 				self.parts.wpn_fps_pis_packrat_body_sport.custom_stats = nil
@@ -37453,14 +37563,14 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 					end
 				end
 				self.parts.wpn_fps_pis_packrat_body_sport_x.override.wpn_fps_pis_packrat_m_standard = nil
-	
+
 				self.parts.wpn_fps_pis_g17_body_sport.supported = true
 				self.parts.wpn_fps_pis_g17_body_sport.stats = deep_clone(barrels.long_b2_stats)
 				self.parts.wpn_fps_pis_g17_body_sport.custom_stats = deep_clone(barrels.long_b2_stats)
 				self.parts.wpn_fps_pis_g17_body_sport.forbids = {}
 				for k, used_part_id in ipairs(self.wpn_fps_pis_g17.uses_parts) do
 					if self.parts[used_part_id] and self.parts[used_part_id].type then
-						if not table.contains(self.wpn_fps_pis_g17.default_blueprint, used_part_id) and 
+						if not table.contains(self.wpn_fps_pis_g17.default_blueprint, used_part_id) and
 						not table.contains(self.parts.wpn_fps_pis_g17_body_sport.forbids, used_part_id) then
 							if self.parts[used_part_id].type == "slide" then
 								table.insert(self.parts.wpn_fps_pis_g17_body_sport.forbids, used_part_id)
@@ -37472,12 +37582,12 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 				self.parts.wpn_fps_pis_g17_body_sport_x.stats = deep_clone(self.parts.wpn_fps_pis_g17_body_sport.stats)
 				self.parts.wpn_fps_pis_g17_body_sport_x.custom_stats = deep_clone(self.parts.wpn_fps_pis_g17_body_sport.custom_stats)
 				self.parts.wpn_fps_pis_g17_body_sport_x.forbids = deep_clone(self.parts.wpn_fps_pis_g17_body_sport.forbids)
-	
+
 				self.parts.wpn_fps_ass_amcar_body_mark.supported = true
 				self.parts.wpn_fps_ass_amcar_body_mark.stats = { value = 0 }
 				self.parts.wpn_fps_ass_amcar_body_mark.custom_stats = nil
 				self.parts.wpn_fps_ass_amcar_body_mark.forbids = {}
-				self.parts.wpn_fps_ass_amcar_body_mark.adds = { 
+				self.parts.wpn_fps_ass_amcar_body_mark.adds = {
 					"wpn_fps_m4_uupg_draghandle"
 				}
 				for k, used_part_id in ipairs(self.wpn_fps_ass_amcar.uses_parts) do
@@ -37512,7 +37622,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 					unit = "units/mods/weapons/wpn_fps_ass_amcar_pts/wpn_fps_ass_amcar_fg_mark",
 					adds = { "wpn_fps_m4_uupg_fg_rail_ext_dummy" }
 				}
-	
+
 				self.parts.wpn_fps_ass_tecci_body_infinity.supported = true
 				self.parts.wpn_fps_ass_tecci_body_infinity.stats = { value = 0 }
 				self.parts.wpn_fps_ass_tecci_body_infinity.custom_stats = nil
@@ -37573,7 +37683,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 				self.parts.wpn_fps_ass_tecci_body_infinity.override.wpn_fps_upg_m4_s_adapter = {
 					unit = "units/payday2/weapons/wpn_fps_smg_mp9_pts/wpn_fps_smg_mp9_b_dummy"
 				}
-	
+
 				self.parts.wpn_fps_ass_contraband_body_mpx.supported = true
 				self.parts.wpn_fps_ass_contraband_body_mpx.keep_damage = true
 				self.parts.wpn_fps_ass_contraband_body_mpx.stats = {
@@ -37651,7 +37761,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 					parent = "exclusive_set",
 					a_obj = "a_s"
 				}
-	
+
 				self.parts.wpn_fps_ass_scar_body_light.supported = true
 				self.parts.wpn_fps_ass_scar_body_light.keep_damage = true
 				self.parts.wpn_fps_ass_scar_body_light.stats = {
@@ -37702,7 +37812,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 					adds = {},
 					desc_id = ""
 				}
-	
+
 				self.parts.wpn_fps_ass_ak_body_mamba.supported = true
 				self.parts.wpn_fps_ass_ak_body_mamba.keep_damage = true
 				self.parts.wpn_fps_ass_ak_body_mamba.stats = {
@@ -37752,13 +37862,13 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 						end
 					end
 				end
-	
+
 				self.parts.wpn_fps_upg_fl_ass_smg_sho_nano.desc_id = "bm_wp_upg_fl_laser"
 				self.parts.wpn_fps_upg_fl_ass_smg_sho_nano.supported = true
 				self.parts.wpn_fps_upg_fl_ass_smg_sho_nano.stats = {
 					value = 4
 				}
-	
+
 				self.parts.wpn_fps_ass_contraband_body_mpx_sound_dummy.supported = true
 				self.parts.wpn_fps_ass_contraband_body_mpx_sound_dummy.no_cull = true
 				self.parts.wpn_fps_ass_contraband_body_mpx_sound_dummy.custom_stats.sounds.fire_single3 = " "
@@ -37769,7 +37879,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 				self.parts.wpn_fps_ass_contraband_body_sayhello_sound_dummy.supported = true
 				self.parts.wpn_fps_ass_contraband_body_sayhello_sound_dummy.no_cull = true
 				self.parts.wpn_fps_ass_contraband_body_sayhello_sound_dummy.custom_stats.sounds.fire_single3 = " "
-	
+
 			end
 
 		if self.parts.wpn_fps_pis_1911_g_laser then -- Crosskill Laser Grip
@@ -37780,38 +37890,38 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 		if self.wpn_fps_pis_hpb then --Gambyt's Browning HP
 			self.parts.wpn_fps_pis_hpb_g_white.supported = true
 			self.parts.wpn_fps_pis_hpb_g_white.stats = deep_clone(grips.acc_1)
-	
+
 			self.parts.wpn_fps_pis_hpb_thread.supported = true
 			self.parts.wpn_fps_pis_hpb_thread.stats = deep_clone(barrels.long_b1_stats)
 			self.parts.wpn_fps_pis_hpb_thread.custom_stats = deep_clone(barrels.long_b1_stats)
-	
+
 			self.parts.wpn_fps_pis_hpb_comp.supported = true
 			self.parts.wpn_fps_pis_hpb_comp.stats = deep_clone(muzzle_device.muzz_rec_c)
 			self.parts.wpn_fps_pis_hpb_comp.custom_stats = {}
-	
+
 			self.parts.wpn_fps_pis_hpb_comp2.supported = true
 			self.parts.wpn_fps_pis_hpb_comp2.stats = deep_clone(muzzle_device.muzz_acc_c)
 			self.parts.wpn_fps_pis_hpb_comp2.custom_stats = deep_clone(muzzle_device.muzz_acc_c)
-										
-			self.parts.wpn_fps_pis_hpb_m_extended.supported = true								
-			self.parts.wpn_fps_pis_hpb_m_extended.stats = { 
+
+			self.parts.wpn_fps_pis_hpb_m_extended.supported = true
+			self.parts.wpn_fps_pis_hpb_m_extended.stats = {
 				value = 3,
 				concealment = -2,
 				extra_ammo = 16,
 				reload = -4
-			}		
+			}
 			self.parts.wpn_fps_pis_hpb_m_extended.custom_stats = {
 				ads_speed_mult = 1.05
 			}
-			
-			self.parts.wpn_fps_pis_hpb_g_cherry.supported = true				
+
+			self.parts.wpn_fps_pis_hpb_g_cherry.supported = true
 			self.parts.wpn_fps_pis_hpb_g_cherry.stats = deep_clone(grips.recoil_acc)
-	
-			self.parts.wpn_fps_pis_hpb_g_black.supported = true				
+
+			self.parts.wpn_fps_pis_hpb_g_black.supported = true
 			self.parts.wpn_fps_pis_hpb_g_black.stats = deep_clone(grips.quickdraw_1)
-			self.parts.wpn_fps_pis_hpb_g_black.custom_stats = deep_clone(grips.quickdraw_1)			
+			self.parts.wpn_fps_pis_hpb_g_black.custom_stats = deep_clone(grips.quickdraw_1)
 			self.parts.wpn_fps_pis_hpb_a_c45.pcs = nil
-		end		
+		end
 
 		if self.parts.wpn_fps_ass_toym16_b_standard then --Gambyt's Toy M16
 			self.parts.wpn_fps_ass_toym16_b_standard.pcs = nil
@@ -37821,49 +37931,49 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 
 		if self.wpn_fps_smg_czevo then --Gambyt's Scorpion EVO
 			self.parts.wpn_fps_smg_czevo_a_strong.pcs = nil
-			self.parts.wpn_fps_smg_czevo_a_classic.pcs = nil	
+			self.parts.wpn_fps_smg_czevo_a_classic.pcs = nil
 			table.list_append(self.wpn_fps_smg_czevo.uses_parts, {
 				"wpn_fps_upg_i_slower_rof"
 			})
 			table.list_append(self.wpn_fps_smg_czevo.uses_parts, {
 				"wpn_fps_upg_i_faster_rof"
-			})		
-			self.parts.wpn_fps_smg_czevo_barrel_long.supported = true		
+			})
+			self.parts.wpn_fps_smg_czevo_barrel_long.supported = true
 			self.parts.wpn_fps_smg_czevo_barrel_long.stats = deep_clone(barrels.long_b2_stats)
 			self.parts.wpn_fps_smg_czevo_barrel_long.custom_stats = deep_clone(barrels.long_b2_stats)
-	
-			self.parts.wpn_fps_smg_czevo_vg_tti.supported = true	
+
+			self.parts.wpn_fps_smg_czevo_vg_tti.supported = true
 			self.parts.wpn_fps_smg_czevo_vg_tti.stats = {
 				value = 1,
 				concealment = -2,
 				recoil = 4,
-			}					
-			self.parts.wpn_fps_smg_czevo_vg_handstop.supported = true					
+			}
+			self.parts.wpn_fps_smg_czevo_vg_handstop.supported = true
 			self.parts.wpn_fps_smg_czevo_vg_handstop.stats = {
 				value = 1,
 				concealment = -1,
 				recoil = 2,
-			}		
-			self.parts.wpn_fps_smg_czevo_vg_ptk.supported = true		
+			}
+			self.parts.wpn_fps_smg_czevo_vg_ptk.supported = true
 			self.parts.wpn_fps_smg_czevo_vg_ptk.stats = {
 				value = 1,
 				spread = 1,
 				concealment = -1
-			}		
-			self.parts.wpn_fps_smg_czevo_vg_angled.supported = true		
+			}
+			self.parts.wpn_fps_smg_czevo_vg_angled.supported = true
 			self.parts.wpn_fps_smg_czevo_vg_angled.stats = {
 				value = 1,
 				spread = 1,
 				concealment = -1
-			}																	
-			self.parts.wpn_fps_smg_czevo_sight_troy.supported = true																	
+			}
+			self.parts.wpn_fps_smg_czevo_sight_troy.supported = true
 			self.parts.wpn_fps_smg_czevo_sight_troy.stats = {
 				value = 1
-			}			
-			self.parts.wpn_fps_smg_czevo_vg_cover.supported = true			
+			}
+			self.parts.wpn_fps_smg_czevo_vg_cover.supported = true
 			self.parts.wpn_fps_smg_czevo_vg_cover.stats = {
 				value = 1
-			}					
+			}
 			self.parts.wpn_fps_smg_czevo_mag_speed.pcs = nil
 			self.parts.wpn_fps_smg_czevo_barrel_silenced.supported = true
 			self.parts.wpn_fps_smg_czevo_barrel_silenced.stats = {
@@ -37871,7 +37981,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 				suppression = 12,
 				alert_size = -1
 			}
-		end			
+		end
 
 	--[[ MIRA'S MODS ]]
 
@@ -37937,22 +38047,22 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 			self.parts.wpn_fps_pis_vp70_lc_stormtrooper.stats = { value = 0 }
 
 			self.parts.wpn_fps_pis_vp70_s_scifi.supported = true
-			self.parts.wpn_fps_pis_vp70_s_scifi.stats = { 
+			self.parts.wpn_fps_pis_vp70_s_scifi.stats = {
 				value = 2,
 				spread = -1,
 				concealment = 1
 			 }
 
 			self.parts.wpn_fps_pis_vp70_m_speed_std.supported = true
-			self.parts.wpn_fps_pis_vp70_m_speed_std.stats = { 
-				value = 4, 
+			self.parts.wpn_fps_pis_vp70_m_speed_std.stats = {
+				value = 4,
 				spread = -1,
 				concealment = -1,
 				reload = 2
 			}
 			self.parts.wpn_fps_pis_vp70_m_ext.supported = true
-			self.parts.wpn_fps_pis_vp70_m_ext.stats = { 
-				value = 6, 
+			self.parts.wpn_fps_pis_vp70_m_ext.stats = {
+				value = 6,
 				extra_ammo = 12,
 				concealment = -2,
 				reload = -4
@@ -37961,7 +38071,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 
 			self.wpn_fps_pis_x_vp70.override.wpn_fps_pis_vp70_m_ext = {
 				stats = {
-					value = 6, 
+					value = 6,
 					extra_ammo = 24,
 					concealment = -2,
 					reload = -4
@@ -37985,7 +38095,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 						self.wpn_fps_pis_x_vp70.uses_parts[i] = "resmod_dummy"
 					end
 				end
-			end	
+			end
 		end
 
 		if self.parts.wpn_fps_snp_bigbust_b_short then
@@ -38023,7 +38133,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 			self.parts.wpn_fps_snp_heartpiercer_o_rear.custom_stats = nil
 
 			self.parts.wpn_fps_snp_heartpiercer_b_dtk.supported = true
-			self.parts.wpn_fps_snp_heartpiercer_b_dtk.stats = { 
+			self.parts.wpn_fps_snp_heartpiercer_b_dtk.stats = {
 				value = 2,
 				recoil = 4,
 				concealment = -2
@@ -38068,15 +38178,15 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 				value = 3,
 				zoom = 5
 			}
-			
+
 			self.parts.wpn_fps_ass_fakedefy_m_alfa_magpul.supported = true
 			self.parts.wpn_fps_ass_fakedefy_m_alfa_magpul.stats = deep_clone(self.parts.wpn_fps_m4_upg_m_quick.stats)
 			self.parts.wpn_fps_ass_fakedefy_m_alfa_magpul.custom_stats = nil
-			
+
 			self.parts.wpn_fps_ass_fakedefy_s_nostock.supported = true
 			self.parts.wpn_fps_ass_fakedefy_s_nostock.stats = deep_clone(stocks.remove_adj_stats)
 			self.parts.wpn_fps_ass_fakedefy_s_nostock.custom_stats = deep_clone(stocks.remove_adj_stats)
-			
+
 			self.parts.wpn_fps_ass_fakedefy_b_long.supported = true
 			self.parts.wpn_fps_ass_fakedefy_b_long.stats = deep_clone(barrels.long_b2_stats)
 			self.parts.wpn_fps_ass_fakedefy_b_long.custom_stats = deep_clone(barrels.long_b2_stats)
@@ -38094,7 +38204,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 			table.insert(self.parts.wpn_fps_ass_grayhound_ex_jb.forbids, "wpn_fps_upg_ns_ass_tbrake")
 			table.insert(self.parts.wpn_fps_ass_grayhound_ex_jb.forbids, "wpn_fps_upg_ns_ass_smg_v6")
 			self.parts.wpn_fps_ass_grayhound_ex_jb.supported = true
-			self.parts.wpn_fps_ass_grayhound_ex_jb.stats = { 
+			self.parts.wpn_fps_ass_grayhound_ex_jb.stats = {
 				value = 2,
 				recoil = 4,
 				concealment = -2
@@ -38103,7 +38213,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 			self.parts.wpn_fps_ass_grayhound_ba_mk18.supported = true
 			self.parts.wpn_fps_ass_grayhound_ba_mk18.stats = deep_clone(barrels.short_b2_stats)
 			self.parts.wpn_fps_ass_grayhound_ba_mk18.custom_stats = deep_clone(barrels.short_b2_stats)
-			
+
 			self.parts.wpn_fps_ass_grayhound_hg_sai_short.supported = true
 			self.parts.wpn_fps_ass_grayhound_hg_sai_short.stats = {
 				value = 2,
@@ -38129,7 +38239,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 			self.parts.wpn_fps_ass_fsbcustom_b_std.custom_stats = nil
 			self.parts.wpn_fps_ass_fsbcustom_vg_afg.stats = { value = 0 }
 			self.parts.wpn_fps_ass_fsbcustom_vg_afg.custom_stats = nil
-			
+
 			self.parts.wpn_fps_ass_fsbcustom_b_ak74m.supported = true
 			self.parts.wpn_fps_ass_fsbcustom_b_ak74m.stats = deep_clone(barrels.long_b2_stats)
 			self.parts.wpn_fps_ass_fsbcustom_b_ak74m.custom_stats = deep_clone(barrels.long_b2_stats)
@@ -38170,11 +38280,11 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 			self.parts.wpn_fps_shot_fpsix_magext.custom_stats = {
 				ads_speed_mult = 1.025
 			}
-	
+
 			self.parts.wpn_fps_shot_fpsix_stock_folded.supported = true
 			self.parts.wpn_fps_shot_fpsix_stock_folded.stats = deep_clone(stocks.fixed_to_folded_stats)
 			self.parts.wpn_fps_shot_fpsix_stock_folded.custom_stats = deep_clone(stocks.fixed_to_folded_stats)
-			
+
 			self.parts.wpn_fps_shot_fpsix_stock_nought.supported = true
 			self.parts.wpn_fps_shot_fpsix_stock_nought.stats = deep_clone(stocks.remove_fixed_stats)
 			self.parts.wpn_fps_shot_fpsix_stock_nought.custom_stats = deep_clone(stocks.remove_fixed_stats)
@@ -38207,11 +38317,11 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 			self.parts.wpn_fps_shot_stf12_choke.supported = true
 			self.parts.wpn_fps_shot_stf12_choke.stats = deep_clone(barrels.long_b1_stats)
 			self.parts.wpn_fps_shot_stf12_choke.custom_stats = deep_clone(barrels.long_b1_stats)
-	
+
 			self.parts.wpn_fps_shot_stf12_stock_folded.supported = true
 			self.parts.wpn_fps_shot_stf12_stock_folded.stats = deep_clone(stocks.fixed_to_folded_stats)
 			self.parts.wpn_fps_shot_stf12_stock_folded.custom_stats = deep_clone(stocks.fixed_to_folded_stats)
-			
+
 			self.parts.wpn_fps_shot_stf12_stock_none.supported = true
 			self.parts.wpn_fps_shot_stf12_stock_none.stats = deep_clone(stocks.remove_fixed_stats)
 			self.parts.wpn_fps_shot_stf12_stock_none.custom_stats = deep_clone(stocks.remove_fixed_stats)
@@ -38293,18 +38403,33 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 			self.parts.wpn_fps_snp_troglodyte_s_full.custom_stats = deep_clone(stocks.add_fixed_stats)
 		end
 
+		if self.parts.wpn_fps_snp_dvl10_s_folded then
+			self.parts.wpn_fps_snp_dvl10_s_folded.supported = true
+			self.parts.wpn_fps_snp_dvl10_s_folded.stats = deep_clone(stocks.fold_folder_stats)
+			self.parts.wpn_fps_snp_dvl10_s_folded.custom_stats = deep_clone(stocks.fold_folder_stats)
+
+			self.parts.wpn_fps_snp_dvl10_b_supp.supported = true
+			self.parts.wpn_fps_snp_dvl10_b_supp.stats = {
+				value = 2,
+				suppression = 12,
+				alert_size = -1
+			}
+			self.parts.wpn_fps_snp_dvl10_b_supp.custom_stats = {}
+			self.parts.wpn_fps_snp_dvl10_b_supp.perks = {"silencer"}
+		end
+
 		if self.parts.wpn_fps_shot_dokkasho_b_long then
 			self.parts.wpn_fps_shot_dokkasho_b_long.supported = true
 			self.parts.wpn_fps_shot_dokkasho_b_long.stats = deep_clone(barrels.long_b3_stats)
 			self.parts.wpn_fps_shot_dokkasho_b_long.custom_stats = deep_clone(barrels.long_b3_stats)
 			self.parts.wpn_fps_shot_dokkasho_b_tfang.supported = true
 			self.parts.wpn_fps_shot_dokkasho_b_tfang.stats = deep_clone(muzzle_device.muzz_rec_c)
-			self.parts.wpn_fps_shot_dokkasho_b_tfang.custom_stats = {}			
+			self.parts.wpn_fps_shot_dokkasho_b_tfang.custom_stats = {}
 
 			self.parts.wpn_fps_shot_dokkasho_s_short.supported = true
 			self.parts.wpn_fps_shot_dokkasho_s_short.stats = deep_clone(stocks.remove_fixed_stats)
 			self.parts.wpn_fps_shot_dokkasho_s_short.custom_stats = deep_clone(stocks.remove_fixed_stats)
-			
+
 			self.parts.wpn_fps_shot_dokkasho_s_ammopouch.stats = {
 				value = 2,
 				spread = -1,
@@ -38352,27 +38477,27 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 			self.parts.wpn_fps_smg_tommy_or_simple.custom_stats = nil
 
 			self.parts.wpn_fps_smg_tommy_m_30rnd.supported = true
-			self.parts.wpn_fps_smg_tommy_m_30rnd.stats = { 
-				value = 4, 
+			self.parts.wpn_fps_smg_tommy_m_30rnd.stats = {
+				value = 4,
 				extra_ammo = 10,
 				concealment = -1,
 				reload = -3
 			}
-			self.parts.wpn_fps_smg_tommy_m_30rnd.custom_stats = { 
+			self.parts.wpn_fps_smg_tommy_m_30rnd.custom_stats = {
 				ads_speed_mult = 1.025
 			}
 
 			self.parts.wpn_fps_smg_tommy_m_quick.supported = true
-			self.parts.wpn_fps_smg_tommy_m_quick.stats = { 
-				value = 1, 
+			self.parts.wpn_fps_smg_tommy_m_quick.stats = {
+				value = 1,
 				spread = -1,
 				concealment = -1,
 				reload = 2
 			}
 
 			self.parts.wpn_fps_smg_tommy_m_30cal.supported = true
-			self.parts.wpn_fps_smg_tommy_m_30cal.stats = { 
-				value = 10, 
+			self.parts.wpn_fps_smg_tommy_m_30cal.stats = {
+				value = 10,
 				recoil = -6,
 				concealment = -1,
 				reload = -1
@@ -38442,7 +38567,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 
 		if self.parts.wpn_fps_smg_fang45_s_folded then --Mira's MW:R Fang-45
 			self.parts.wpn_fps_smg_fang45_o_std.stance_mod = {
-				wpn_fps_smg_fang45 = { 
+				wpn_fps_smg_fang45 = {
 					translation = Vector3(0.04, 0, 0.3),
 					rotation = Rotation(0, 0, 0)
 				}
@@ -38463,7 +38588,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 			}
 			self.parts.wpn_fps_pis_pinkie_b_sp.custom_stats = {}
 			self.parts.wpn_fps_pis_pinkie_b_sp.perks = {"silencer"}
-			
+
 			self.parts.wpn_fps_pis_pinkie_b_fh.supported = true
 			self.parts.wpn_fps_pis_pinkie_b_fh.stats = deep_clone(muzzle_device.muzz_rec_c)
 			self.parts.wpn_fps_pis_pinkie_b_fh.custom_stats = deep_clone(muzzle_device.muzz_rec_c)
@@ -38474,8 +38599,8 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 			self.parts.wpn_fps_pdw_fckmyfingers_b_medium.supported = true
 			self.parts.wpn_fps_pdw_fckmyfingers_b_medium.stats = deep_clone(barrels.long_b2_stats)
 			self.parts.wpn_fps_pdw_fckmyfingers_b_medium.custom_stats = deep_clone(barrels.long_b2_stats)
-			
-			self.parts.wpn_fps_pdw_fckmyfingers_o_susat.pcs = nil	-- just use the standalone 
+
+			self.parts.wpn_fps_pdw_fckmyfingers_o_susat.pcs = nil	-- just use the standalone
 
 			self.parts.wpn_fps_pdw_fckmyfingers_m_short.supported = true
 			self.parts.wpn_fps_pdw_fckmyfingers_m_short.stats = {
@@ -38484,10 +38609,10 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 				extra_ammo = -5,
 				reload = 3
 			}
-			self.parts.wpn_fps_pdw_fckmyfingers_m_short.custom_stats = { 
+			self.parts.wpn_fps_pdw_fckmyfingers_m_short.custom_stats = {
 				ads_speed_mult = 0.975
 			}
-			
+
 			self.wpn_fps_crb_enfieldl22.override = self.wpn_fps_crb_enfieldl22.overrides or {}
 			self.wpn_fps_crb_enfieldl22.override.wpn_fps_upg_vg_ass_smg_verticalgrip = {
 				stats = {
@@ -38528,7 +38653,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 					value = 0
 				}
 			}
-			
+
 			table.insert(self.wpn_fps_crb_enfieldl22.uses_parts, "wpn_fps_upg_vg_ass_smg_verticalgrip")
 			table.insert(self.wpn_fps_crb_enfieldl22.uses_parts, "wpn_fps_upg_vg_ass_smg_stubby")
 			table.insert(self.wpn_fps_crb_enfieldl22.uses_parts, "wpn_fps_smg_schakal_vg_surefire")
@@ -38556,7 +38681,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 			self.parts.wpn_fps_ass_kurisumasu_gb_windham.supported = true
 			self.parts.wpn_fps_ass_kurisumasu_gb_windham.stats = { value = 0 }
 			self.parts.wpn_fps_ass_kurisumasu_gb_windham.custom_stats = nil
-			
+
 			self.parts.wpn_fps_ass_kurisumasu_ro_buis.supported = true
 			self.parts.wpn_fps_ass_kurisumasu_ro_buis.stats = { value = 0 }
 			self.parts.wpn_fps_ass_kurisumasu_ro_buis.custom_stats = nil
@@ -38688,7 +38813,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 					reload = 5,
 					extra_ammo = -10
 				}
-				self.parts.wpn_fps_ass_kurisumasu_m_stanag20.custom_stats = { 
+				self.parts.wpn_fps_ass_kurisumasu_m_stanag20.custom_stats = {
 					ads_speed_mult = 0.95
 				}
 
@@ -38734,17 +38859,17 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 						end
 					end
 				end
-			end	
-		
+			end
+
 			if self.parts.wpn_fps_smg_polymer_stock_prototype then
 				self.parts.wpn_fps_smg_polymer_stock_prototype.supported = true
 				self.parts.wpn_fps_smg_polymer_stock_prototype.stats = deep_clone(stocks.folder_acc_stats)
 			end
-			
+
 			if self.parts.wpn_fps_ass_m16_fg_lsw then
 				self.parts.wpn_fps_ass_m16_fg_lsw.supported = true
 				self.parts.wpn_fps_ass_m16_fg_lsw.stats = { spread = -2, recoil = 6, concealment = -1 }
-			end		
+			end
 
 	--[[ CARL'S MODS ]]
 
@@ -38791,10 +38916,10 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 				reload = 5,
 				extra_ammo = -10
 			}
-			self.parts.wpn_fps_ass_l1a1_mag_short.custom_stats = { 
+			self.parts.wpn_fps_ass_l1a1_mag_short.custom_stats = {
 				ads_speed_mult = 0.95
 			}
-			
+
 			self.parts.wpn_fps_ass_l1a1_ns_fal.supported = true
 			self.parts.wpn_fps_ass_l1a1_ns_fal.stats = deep_clone(muzzle_device.muzz_rec2_c)
 		end
@@ -38821,43 +38946,43 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 		end
 
 		if self.wpn_fps_ass_tilt then -- Grocery's AN 92
-			self.parts.wpn_fps_ass_tilt_a_fuerte.pcs = nil		
-			self.parts.wpn_fps_ass_tilt_mag_big.supported = true		
+			self.parts.wpn_fps_ass_tilt_a_fuerte.pcs = nil
+			self.parts.wpn_fps_ass_tilt_mag_big.supported = true
 			self.parts.wpn_fps_ass_tilt_mag_big.stats = {
 					value = 3,
 					concealment = -3,
 					extra_ammo = 30,
 					reload = -5,
 					spread = -1
-				}	
-			self.parts.wpn_fps_ass_tilt_mag_swift.supported = true	
+				}
+			self.parts.wpn_fps_ass_tilt_mag_swift.supported = true
 			self.parts.wpn_fps_ass_tilt_mag_swift.stats = {
 					value = 2,
 					spread = -1,
 					concealment = -1,
 					reload = 3
-				}						
-			self.parts.wpn_fps_ass_tilt_mag_tactical.supported = true						
+				}
+			self.parts.wpn_fps_ass_tilt_mag_tactical.supported = true
 			self.parts.wpn_fps_ass_tilt_mag_tactical.stats = {
 					value = 1,
 					recoil = -2,
 					concealment = 1
-				}	
-			self.parts.wpn_fps_ass_tilt_g_wood.supported = true	
+				}
+			self.parts.wpn_fps_ass_tilt_g_wood.supported = true
 			self.parts.wpn_fps_ass_tilt_g_wood.stats = deep_clone(grips.recoil_acc)
 			self.parts.wpn_fps_ass_tilt_g_wood.custom_stats = nil
 			self.parts.wpn_fps_ass_tilt_stock_wood.supported = true
 			self.parts.wpn_fps_ass_tilt_stock_wood.stats = deep_clone(stocks.folder_to_fixed_rec3_stats)
 			self.parts.wpn_fps_ass_tilt_stock_wood.custom_stats = deep_clone(stocks.folder_to_fixed_rec3_stats)
-	
+
 			self.parts.wpn_fps_ass_tilt_stock_fold.supported = true
 			self.parts.wpn_fps_ass_tilt_stock_fold.stats = deep_clone(stocks.fold_folder_stats)
 			self.parts.wpn_fps_ass_tilt_stock_fold.custom_stats = deep_clone(stocks.fold_folder_stats)
-	
+
 			self.parts.wpn_fps_ass_tilt_stock_tactical.supported = true
 			self.parts.wpn_fps_ass_tilt_stock_tactical.stats = deep_clone(stocks.folder_to_adj_acc2_stats)
 			self.parts.wpn_fps_ass_tilt_stock_tactical.custom_stats = deep_clone(stocks.folder_to_adj_acc2_stats)
-	
+
 			self.parts.wpn_fps_ass_tilt_stock_none.supported = true
 			self.parts.wpn_fps_ass_tilt_stock_none.stats = deep_clone(stocks.remove_folder_stats)
 			self.parts.wpn_fps_ass_tilt_stock_none.custom_stats = deep_clone(stocks.remove_folder_stats)
@@ -38878,34 +39003,34 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 			self.parts.wpn_fps_pis_sr1_grip.supported = true
 			self.parts.wpn_fps_pis_sr1_grip.stats = deep_clone(grips.quickdraw_1)
 			self.parts.wpn_fps_pis_sr1_grip.custom_stats = deep_clone(grips.quickdraw_1)
-			
-			self.parts.wpn_fps_pis_sr1_slide_silver.supported = true						
+
+			self.parts.wpn_fps_pis_sr1_slide_silver.supported = true
 			self.parts.wpn_fps_pis_sr1_slide_silver.stats = {
 				value = 2
 			}
-			
-			self.parts.wpn_fps_pis_sr1_slide_silver.supported = true						
+
+			self.parts.wpn_fps_pis_sr1_slide_silver.supported = true
 			self.parts.wpn_fps_pis_sr1_slide_silver.stats = {
 				value = 2
 			}
 			self.parts.wpn_fps_pis_sr1_slide_long.supported = true
 			self.parts.wpn_fps_pis_sr1_slide_long.stats = deep_clone(barrels.long_b2_stats)
 			self.parts.wpn_fps_pis_sr1_slide_long.custom_stats = deep_clone(barrels.long_b2_stats)
-			
+
 			self.parts.wpn_fps_pis_sr1_comp2.supported = true
 			self.parts.wpn_fps_pis_sr1_comp2.stats = deep_clone(muzzle_device.muzz_acc_c)
 			self.parts.wpn_fps_pis_sr1_comp2.custom_stats = deep_clone(muzzle_device.muzz_acc_c)
 
 			self.parts.wpn_fps_pis_sr1_extmag.supported = true
 			self.parts.wpn_fps_pis_sr1_extmag.stats = {
-				value = 1, 
+				value = 1,
 				extra_ammo = 6,
 				concealment = -1,
 				reload = -3
 			}
 			self.parts.wpn_fps_pis_sr1_extmag_akimbo.supported = true
 			self.parts.wpn_fps_pis_sr1_extmag_akimbo.stats = {
-				value = 1, 
+				value = 1,
 				extra_ammo = 12,
 				concealment = -1,
 				reload = -3
@@ -38921,23 +39046,23 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 			}
 			self.parts.wpn_fps_smg_kedr_sil.custom_stats = nil
 
-			self.parts.wpn_fps_smg_kedr_g_wood.supported = true	
+			self.parts.wpn_fps_smg_kedr_g_wood.supported = true
 			self.parts.wpn_fps_smg_kedr_g_wood.stats = deep_clone(grips.recoil_acc)
 			self.parts.wpn_fps_smg_kedr_g_wood.custom_stats = nil
 
 			self.parts.wpn_fps_smg_kedr_m_ext.supported = true
-			self.parts.wpn_fps_smg_kedr_m_ext.stats = { 
-				value = 4, 
+			self.parts.wpn_fps_smg_kedr_m_ext.stats = {
+				value = 4,
 				extra_ammo = 10,
 				concealment = -1,
 				reload = -3
 			}
-			self.parts.wpn_fps_smg_kedr_m_ext.custom_stats = { 
+			self.parts.wpn_fps_smg_kedr_m_ext.custom_stats = {
 				ads_speed_mult = 1.025
 			}
 			self.wpn_fps_smg_x_kedr.override.wpn_fps_smg_kedr_m_ext = {
 				stats = {
-					value = 4, 
+					value = 4,
 					extra_ammo = 20,
 					concealment = -1,
 					reload = -3
@@ -38949,14 +39074,14 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 			self.parts.wpn_fps_ass_acwr_gl.type = "underbarrel"	-- doesn't work without this, good job
 			self.parts.wpn_fps_ass_acwr_gl.sub_type = "grenade_launcher"
 			self.parts.wpn_fps_ass_acwr_gl.perks = { "underbarrel" }
-			
+
 			self.parts.wpn_fps_ass_acwr_expert.supported = true
 			self.parts.wpn_fps_ass_acwr_expert.stats = { value = 0 }
-			
+
 			self.parts.wpn_fps_ass_acwr_b_short.supported = true
 			self.parts.wpn_fps_ass_acwr_b_short.stats = deep_clone(barrels.short_b2_stats)
 			self.parts.wpn_fps_ass_acwr_b_short.custom_stats = deep_clone(barrels.short_b2_stats)
-			
+
 			self.parts.wpn_fps_ass_acwr_covers.supported = true
 			self.parts.wpn_fps_ass_acwr_covers.stats = { value = 0 }
 
@@ -38967,7 +39092,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 				reload = 5,
 				extra_ammo = -10
 			}
-			self.parts.wpn_fps_ass_acwr_mag_smol.custom_stats = { 
+			self.parts.wpn_fps_ass_acwr_mag_smol.custom_stats = {
 				ads_speed_mult = 0.95
 			}
 			self.parts.wpn_fps_ass_acwr_mag_pmag.supported = true
@@ -38982,7 +39107,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 			self.parts.wpn_fps_pis_mr96_g_wood.supported = true
 			self.parts.wpn_fps_pis_mr96_g_wood.stats = deep_clone(grips.recoil_acc)
 			self.parts.wpn_fps_pis_mr96_g_wood.custom_stats = nil
-			
+
 			self.parts.wpn_fps_pis_mr96_flash.supported = true
 			self.parts.wpn_fps_pis_mr96_flash.stats = deep_clone(muzzle_device.muzz_acc_c)
 			self.parts.wpn_fps_pis_mr96_flash.custom_stats = deep_clone(muzzle_device.muzz_acc_c)
@@ -39033,32 +39158,32 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 			self.parts.wpn_fps_spe_raygun_body.stance_mod = {
 				wpn_fps_spe_raygun = { translation = Vector3( 0, 0, -0.15 ) }
 			}
-	
+
 			self.parts.wpn_fps_spe_raygun_o_waw = {
-				pcs = {}, 
-				type = "sight", 
-				name_id = "bm_wp_raygun_o_waw", 
-				desc_id = "bm_wp_raygun_o_waw_desc", 
-				has_description = true, 
+				pcs = {},
+				type = "sight",
+				name_id = "bm_wp_raygun_o_waw",
+				desc_id = "bm_wp_raygun_o_waw_desc",
+				has_description = true,
 				a_obj = "a_body",
 				stance_mod = {
-					wpn_fps_spe_raygun = { 
-						translation = Vector3( 0, -5, 3 ), 
+					wpn_fps_spe_raygun = {
+						translation = Vector3( 0, -5, 3 ),
 						rotation = Rotation( 0, -3.1, 0 )
 					}
 				},
-				unit = "units/payday2/weapons/wpn_upg_dummy/wpn_upg_dummy", 
-				third_unit = "units/payday2/weapons/wpn_upg_dummy/wpn_upg_dummy", 
+				unit = "units/payday2/weapons/wpn_upg_dummy/wpn_upg_dummy",
+				third_unit = "units/payday2/weapons/wpn_upg_dummy/wpn_upg_dummy",
 				dlc = "sc",
 				supported = true,
-				alt_icon = "guis/dlcs/boost_in_lootdrop/textures/pd2/blackmarket/icons/mods/wpn_fps_upg_bonus_damage_p2_sc", 
+				alt_icon = "guis/dlcs/boost_in_lootdrop/textures/pd2/blackmarket/icons/mods/wpn_fps_upg_bonus_damage_p2_sc",
 				stats = {
 					value = 0
 				},
 				internal_part = true
 			}
-	
-			table.insert(self.wpn_fps_spe_raygun.uses_parts, "wpn_fps_spe_raygun_o_waw")	
+
+			table.insert(self.wpn_fps_spe_raygun.uses_parts, "wpn_fps_spe_raygun_o_waw")
 			table.insert(self.wpn_fps_spe_raygun_npc.uses_parts, "wpn_fps_spe_raygun_o_waw")
 		end
 
@@ -39069,7 +39194,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 			self.parts.wpn_fps_ass_dd5_b_short.supported = true
 			self.parts.wpn_fps_ass_dd5_b_short.stats = deep_clone(barrels.short_b2_stats)
 			self.parts.wpn_fps_ass_dd5_b_short.custom_stats = deep_clone(barrels.short_b2_stats)
-			
+
 			self.parts.wpn_fps_ass_dd5_fg_msr.supported = true
 			self.parts.wpn_fps_ass_dd5_fg_msr.stats = {
 				recoil = -4,
@@ -39139,14 +39264,14 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 					rotation = Rotation(-0.1, 0, 0)
 				}
 			}
-	
+
 			self.parts.wpn_fps_shot_omni_m_contraband.supported = true
 			self.parts.wpn_fps_shot_omni_m_contraband.stats = {
 				value = 2,
 				spread = 1,
 				recoil = -2
 			}
-	
+
 			self.parts.wpn_fps_shot_omni_b_heavy.supported = true
 			self.parts.wpn_fps_shot_omni_b_heavy.stats = {
 				value = 8,
@@ -39154,7 +39279,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 				recoil = 4,
 				concealment = -1
 			}
-	
+
 			self.parts.wpn_fps_shot_omni_fg_amcar.supported = true
 			self.parts.wpn_fps_shot_omni_fg_amcar.stats = {
 				value = 7,
@@ -39179,7 +39304,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 				"wpn_fps_shot_omni_vg_afg_default",
 				"wpn_fps_gas_block"
 			}
-	
+
 			self.wpn_fps_shot_omni.override = self.wpn_fps_shot_omni.override or {}
 			self.wpn_fps_shot_omni.override.wpn_fps_upg_a_slug = deep_clone(shot_ammo.a_slug_auto_override)
 			self.wpn_fps_shot_omni.override.wpn_fps_upg_a_custom = deep_clone(shot_ammo.a_custom_auto_override)
@@ -39194,26 +39319,26 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 			self.wpn_fps_shot_omni.override.wpn_fps_upg_a_piercing.desc_id = "bm_wp_upg_a_piercing_9_auto_desc_per_pellet"
 			self.wpn_fps_shot_omni.override.wpn_fps_upg_a_piercing.custom_stats.rays = 9
 			self.wpn_fps_shot_omni.override.wpn_fps_upg_a_dragons_breath = deep_clone(shot_ammo.a_dragons_breath_auto_override)
-	
+
 			self.wpn_fps_shot_omni_npc.override = deep_clone(self.wpn_fps_shot_omni.override)
-	
+
 			table.insert(self.wpn_fps_shot_omni.uses_parts, "wpn_fps_m4_uupg_s_fold")
-			table.insert(self.wpn_fps_shot_omni.uses_parts, "wpn_fps_ass_m16_s_fixed")	
-	
+			table.insert(self.wpn_fps_shot_omni.uses_parts, "wpn_fps_ass_m16_s_fixed")
+
 			table.insert(self.wpn_fps_shot_omni.uses_parts, "wpn_fps_ass_m4_g_sg")
 			table.insert(self.wpn_fps_shot_omni.uses_parts, "wpn_fps_ass_m4_g_sport")
 			table.insert(self.wpn_fps_shot_omni.uses_parts, "wpn_fps_ass_m16_s_op")
 			table.insert(self.wpn_fps_shot_omni.uses_parts, "wpn_fps_ass_contraband_s_tecci")
-	
+
 			self.wpn_fps_shot_omni_npc.uses_parts = deep_clone(self.wpn_fps_shot_omni.uses_parts)
 		end
 
 		if self.parts.wpn_fps_ass_ar47_b_standard then --Tangerine's AR47
-	
+
 			self.parts.wpn_fps_ass_ar47_b_standard.forbids = self.parts.wpn_fps_ass_ar47_b_standard.forbids or {}
 			table.insert(self.parts.wpn_fps_ass_ar47_b_standard.forbids, "wpn_fps_m4_uupg_fg_rail_ext_dummy")
 			table.insert(self.parts.wpn_fps_ass_ar47_b_standard.forbids, "wpn_fps_ass_m4_os_frontsight")
-	
+
 			self.parts.wpn_fps_upg_ass_ar47_b_heavy.supported = true
 			self.parts.wpn_fps_upg_ass_ar47_b_heavy.name_id = "bm_wp_upg_ass_m4_b_beowulf"
 			self.parts.wpn_fps_upg_ass_ar47_b_heavy.has_description = false
@@ -39229,7 +39354,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 				ads_speed_mult = 1.075
 			}
 			self.parts.wpn_fps_upg_ass_ar47_b_heavy.adds = {"wpn_fps_upg_ass_ar47_b_heavy_gasblock"}
-	
+
 			self.parts.wpn_fps_upg_ass_ar47_b_short.supported = true
 			self.parts.wpn_fps_upg_ass_ar47_b_short.name_id = "bm_wp_m4_uupg_b_short"
 			self.parts.wpn_fps_upg_ass_ar47_b_short.has_description = false
@@ -39238,7 +39363,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 			table.insert(self.parts.wpn_fps_upg_ass_ar47_b_short.forbids, "wpn_fps_ass_m4_os_frontsight")
 			self.parts.wpn_fps_upg_ass_ar47_b_short.stats = deep_clone(barrels.short_b2_stats)
 			self.parts.wpn_fps_upg_ass_ar47_b_short.custom_stats = deep_clone(barrels.short_b2_stats)
-	
+
 			self.parts.wpn_fps_upg_ass_ar47_b_sd.supported = true
 			self.parts.wpn_fps_upg_ass_ar47_b_sd.name_id = "bm_wp_m4_uupg_b_sd"
 			self.parts.wpn_fps_upg_ass_ar47_b_sd.has_description = true
@@ -39257,7 +39382,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 				self.parts.wpn_fps_ass_ar47_sd_suppressor.supported = true
 				self.parts.wpn_fps_ass_ar47_sd_suppressor.stats = {value = 1}
 				self.parts.wpn_fps_ass_ar47_sd_suppressor.custom_stats = nil
-	
+
 			self.parts.wpn_fps_ass_ar47_ns_hera_supp.supported = true
 			self.parts.wpn_fps_ass_ar47_ns_hera_supp.stats = {
 				value = 8,
@@ -39272,7 +39397,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 				falloff_start_mult = 1.1,
 				falloff_end_mult = 1.1
 			}
-	
+
 			self.parts.wpn_fps_upg_ar47_fg_m4.supported = true
 			self.parts.wpn_fps_upg_ar47_fg_m4.custom_stats = nil
 			self.parts.wpn_fps_upg_ar47_fg_m4.stats = {
@@ -39287,17 +39412,17 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 				recoil = -2,
 				concealment = 1
 			}
-	
+
 			self.parts.wpn_fps_m4_lower_reciever_tan.supported = true
 			self.parts.wpn_fps_m4_lower_reciever_tan.custom_stats = nil
 			self.parts.wpn_fps_m4_lower_reciever_tan.stats = {
 				value = 0
 			}
-	
+
 			self.parts.wpn_fps_upg_ar47_s_mod0_pad.supported = true
 			self.parts.wpn_fps_upg_ar47_s_mod0_pad.stats = deep_clone(stocks.adj_rec_stats)
 			self.parts.wpn_fps_upg_ar47_s_mod0_pad.custom_stats = deep_clone(stocks.adj_rec_stats)
-	
+
 			self.parts.wpn_fps_ass_ar47_m_blk.supported = true
 			self.parts.wpn_fps_ass_ar47_m_blk.stats = {
 				value = 10,
@@ -39308,7 +39433,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 				falloff_start_mult = 0.75,
 				falloff_end_mult = 0.75
 			}
-	
+
 			self.parts.wpn_fps_ass_ar47_vg_stubby.supported = true
 			self.parts.wpn_fps_ass_ar47_vg_stubby.stats = {
 				value = 3,
@@ -39316,7 +39441,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 				concealment = 1
 			}
 			self.parts.wpn_fps_ass_ar47_vg_stubby.custom_stats = nil
-	
+
 			self.parts.wpn_fps_ass_ar47_vg_long.supported = true
 			self.parts.wpn_fps_ass_ar47_vg_long.stats = {
 				value = 2,
@@ -39324,7 +39449,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 				concealment = -1
 			}
 			self.parts.wpn_fps_ass_ar47_vg_long.custom_stats = nil
-	
+
 			self.parts.wpn_fps_ass_ar47_vg_ergo.supported = true
 			self.parts.wpn_fps_ass_ar47_vg_ergo.stats = {
 				value = 5,
@@ -39333,10 +39458,10 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 				concealment = -2
 			}
 			self.parts.wpn_fps_ass_ar47_vg_ergo.custom_stats = nil
-	
+
 			if self.parts.wpn_fps_ass_ar47_b_ck then --Update
 				self.parts.wpn_fps_ass_ar47_b_ck.custom_stats = nil
-		
+
 				self.parts.wpn_fps_ass_ar47_body_ck.forbids = { "wpn_fps_upg_ass_ar47_b_sd" }
 				self.parts.wpn_fps_ass_ar47_body_ck.override.wpn_fps_upg_m4_s_adapter = {
 					unit = "units/mods/weapons/wpn_fps_ass_ar47_set2/wpn_fps_ass_ar47_s_ck_adapter"
@@ -39345,7 +39470,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 					unit = "units/payday2/weapons/wpn_upg_dummy/wpn_upg_dummy",
 					third_unit = "units/payday2/weapons/wpn_upg_dummy/wpn_upg_dummy"
 				}
-		
+
 				for k, used_part_id in ipairs(self.wpn_fps_ass_ar47.uses_parts) do
 					if self.parts[used_part_id] and self.parts[used_part_id].type then
 					if self.parts[used_part_id].type == "barrel" then
@@ -39396,15 +39521,15 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 						}
 					end
 					end
-		
+
 					self.parts.wpn_fps_ass_ar47_body_ck_switch.supported = true
 					self.parts.wpn_fps_ass_ar47_body_ck_switch.no_cull = true
 				end
 			end
 		end
-	
+
 		if self.parts.wpn_fps_snp_sierra458_bush_switch then --Tangerine and PlayBONK's FTAC Recon :^) (V5 minimum)
-	
+
 			self.parts.wpn_fps_snp_sierra458_body_msecho.override.wpn_fps_upg_sierra458_o_backup = {
 				unit = "units/payday2/weapons/wpn_upg_dummy/wpn_upg_dummy",
 				third_unit = "units/payday2/weapons/wpn_upg_dummy/wpn_upg_dummy",
@@ -39416,7 +39541,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 					}
 				}
 			}
-			self.parts.wpn_fps_snp_sierra458_body_ecr.custom_stats = { 
+			self.parts.wpn_fps_snp_sierra458_body_ecr.custom_stats = {
 				burst_fire = {
 					count = 3,
 					rof_mult = 1.3,
@@ -39442,7 +39567,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 				alert_size = -1
 			}
 			self.parts.wpn_fps_snp_sierra458_ns_scout.custom_stats = nil
-	
+
 			self.parts.wpn_fps_snp_sierra458_b_old.supported = true
 			self.parts.wpn_fps_snp_sierra458_b_old.stats = deep_clone(barrels.long_b1_stats)
 			self.parts.wpn_fps_snp_sierra458_b_old.stats.recoil = 4
@@ -39453,14 +39578,14 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 			self.parts.wpn_fps_snp_sierra458_b_ecr.supported = true
 			self.parts.wpn_fps_snp_sierra458_b_ecr.stats = deep_clone(barrels.short_b1_stats)
 			self.parts.wpn_fps_snp_sierra458_b_ecr.custom_stats = deep_clone(barrels.short_b1_stats)
-	
+
 			self.parts.wpn_fps_upg_sierra458_fg_edge.supported = true
 			self.parts.wpn_fps_upg_sierra458_fg_edge.stats = {
 				value = 0,
 				recoil = 2,
 				concealment = -1
 			}
-	
+
 			self.parts.wpn_fps_snp_sierra458_fg_mk12.supported = true
 			self.parts.wpn_fps_snp_sierra458_fg_mk12.adds = nil
 			self.parts.wpn_fps_snp_sierra458_fg_mk12.stats = {
@@ -39469,21 +39594,21 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 				recoil = 2,
 				concealment = -3
 			}
-	
+
 			self.parts.wpn_fps_upg_sierra458_fg_shepheard.supported = true
 			self.parts.wpn_fps_upg_sierra458_fg_shepheard.stats = {
 				value = 0,
 				spread = -1,
 				recoil = 2
 			}
-	
+
 			self.parts.wpn_fps_snp_sierra458_upper_milspec.supported = true
 			self.parts.wpn_fps_snp_sierra458_upper_milspec.stats = {
 				value = 0,
 				spread = -1,
 				recoil = 2
 			}
-	
+
 			self.parts.wpn_fps_snp_sierra458_lower_milspec.supported = true
 			self.parts.wpn_fps_snp_sierra458_lower_milspec.has_description = false
 			self.parts.wpn_fps_snp_sierra458_lower_milspec.custom_stats = nil
@@ -39493,7 +39618,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 				concealment = 1,
 				recoil = -2
 			}
-	
+
 			self.parts.wpn_fps_snp_sierra458_m_bush.supported = true
 			self.parts.wpn_fps_snp_sierra458_m_bush.keep_damage = true
 			self.parts.wpn_fps_snp_sierra458_m_bush.stats = {
@@ -39505,7 +39630,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 				rof_mult = 0.9,
 				damage_min_mult = 1.3333
 			}
-	
+
 			self.parts.wpn_fps_snp_sierra458_bush_switch.supported = true
 			self.parts.wpn_fps_snp_sierra458_bush_switch.no_cull = true
 			self.parts.wpn_fps_snp_sierra458_bush_switch.custom_stats = {
@@ -39514,7 +39639,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 				dot_data_name = "weapon_tranq_medium",
 				can_shoot_through_enemy_unlim = false
 			}
-	
+
 			self.parts.wpn_fps_snp_sierra458_m_d60.supported = true
 			self.parts.wpn_fps_snp_sierra458_m_d60.stats = {
 				value = 0,
@@ -39525,7 +39650,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 			self.parts.wpn_fps_snp_sierra458_m_d60.custom_stats = {
 				ads_speed_mult = 1.135
 			}
-			
+
 			--.50 Beowulf mags
 				self.parts.wpn_fps_snp_sierra458_m_beowulf.supported = true
 				self.parts.wpn_fps_snp_sierra458_m_beowulf.keep_damage = true
@@ -39568,7 +39693,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 					falloff_start_mult = 0.8,
 					falloff_end_mult = 0.862068
 				}
-	
+
 				self.parts.wpn_fps_snp_sierra458_m_beoplus.custom_stats = {
 					alt_desc = "bm_w_sierra458_beo_desc",
 					ads_speed_mult = 1.1,
@@ -39583,14 +39708,14 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 					ammo_pickup_max_mul = 0.6,
 					sms = 0.9
 				}
-	
+
 			self.parts.wpn_fps_upg_sierra458_o_backup.supported = true
 			self.parts.wpn_fps_upg_sierra458_o_backup.stats = { value = 0 }
 			self.parts.wpn_fps_upg_sierra458_o_backup.stance_mod.wpn_fps_snp_sierra458 = {
 				translation = Vector3(0.0125, -3, 0.45),
 				rotation = Rotation(0.055, -0.4, 0)
 			}
-	
+
 			self.wpn_fps_snp_sierra458.adds.wpn_fps_snp_sierra458_m_standard = nil
 			self.wpn_fps_snp_sierra458.adds.wpn_fps_snp_sierra458_m_d60 = nil
 		end
@@ -39607,8 +39732,8 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 			self.parts.wpn_fps_pis_polar9_g_ergo.stats = deep_clone(grips.quickdraw_1)
 			self.parts.wpn_fps_pis_polar9_g_ergo.custom_stats = deep_clone(grips.quickdraw_1)
 			self.parts.wpn_fps_pis_polar9_g_sport.supported = true
-			self.parts.wpn_fps_pis_polar9_g_sport.stats = { 
-				value = 4, 
+			self.parts.wpn_fps_pis_polar9_g_sport.stats = {
+				value = 4,
 				spread = -1,
 				concealment = -1,
 				reload = 2
@@ -39616,7 +39741,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 
 			self.parts.wpn_fps_pis_polar9_m_extended.supported = true
 			self.parts.wpn_fps_pis_polar9_m_extended.stats = {
-				value = 1, 
+				value = 1,
 				extra_ammo = 10,
 				concealment = -1,
 				reload = -3
@@ -39625,7 +39750,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 				ads_speed_mult = 1.025
 			}
 			self.wpn_fps_pis_x_polar9.override.wpn_fps_pis_polar9_m_extended.stats = {
-				value = 1, 
+				value = 1,
 				extra_ammo = 20,
 				concealment = -1,
 				reload = -3
@@ -39669,7 +39794,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 		end
 
 		if self.parts.wpn_fps_upg_m4_hera_lower then --Tangerine's AK/AR Mod Pack
-			
+
 			--Hera parts
 			self.parts.wpn_fps_upg_m4_hera_lower.supported = true
 			self.parts.wpn_fps_upg_m4_hera_lower.stats = {
@@ -39690,7 +39815,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 				spread = 1,
 				concealment = -1
 			}
-	
+
 			self.parts.wpn_fps_upg_m4_s_hera_paint.supported = true
 			self.parts.wpn_fps_upg_m4_s_hera_paint.stats = deep_clone(stocks.adj_to_thumb_stats)
 			self.parts.wpn_fps_upg_m4_s_hera_paint.custom_stats = deep_clone(stocks.adj_to_thumb_stats)
@@ -39700,7 +39825,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 					table.insert(self.parts.wpn_fps_upg_m4_s_hera_paint.forbids, part_id)
 				end
 			end
-			
+
 			--St. Victor
 			self.parts.wpn_fps_upg_m4_victor_lower.supported = true
 			self.parts.wpn_fps_upg_m4_victor_lower.stats = {
@@ -39720,11 +39845,11 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 			}
 			self.parts.wpn_fps_upg_m4_b_victor.custom_stats = nil
 			self.parts.wpn_fps_upg_m4_b_victor.forbids = { "wpn_fps_m4_uupg_fg_rail_ext_dummy" }
-	
+
 			--??
 			self.parts.wpn_fps_ass_ar47_g_ergo.supported = true
 			self.parts.wpn_fps_ass_ar47_g_ergo.stats = deep_clone(grips.recoil_acc)
-	
+
 			--TTI
 			self.parts.wpn_fps_snp_tti_body_receiverlower_223.supported = true
 			self.parts.wpn_fps_snp_tti_body_receiverlower_223.stats = {
@@ -39745,7 +39870,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 				recoil = 2,
 				concealment = -2
 			}
-			
+
 			--M4/M16 parts
 			self.parts.wpn_fps_ass_m16_fg_s552.supported = true
 			self.parts.wpn_fps_ass_m16_fg_s552.stats = {
@@ -39753,7 +39878,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 				recoil = -2,
 				spread = 1
 			}
-	
+
 			self.parts.wpn_fps_upg_ass_amcar_fg_mp5a5.supported = true
 			self.parts.wpn_fps_upg_ass_amcar_fg_mp5a5.adds = nil
 			self.parts.wpn_fps_upg_ass_amcar_fg_mp5a5.stats = {
@@ -39761,7 +39886,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 				recoil = 2,
 				concealment = -1
 			}
-		
+
 			self.parts.wpn_fps_ass_m4_fg_vietnam_akcar.supported = true
 			self.parts.wpn_fps_ass_m4_fg_vietnam_akcar.adds = nil
 			self.parts.wpn_fps_ass_m4_fg_vietnam_akcar.stats = {
@@ -39769,7 +39894,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 				recoil = -4,
 				concealment = 2
 			}
-		
+
 			self.parts.wpn_fps_m4_uupg_m_sharps.supported = true
 			self.parts.wpn_fps_m4_uupg_m_sharps.has_description = false
 			self.parts.wpn_fps_m4_uupg_m_sharps.desc_id = ""
@@ -39782,22 +39907,22 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 				rof_mult = 0.9,
 				damage_min_mult = 1.25
 			}
-		
+
 			self.parts.wpn_fps_upg_m4_m_d60.supported = true
 			self.parts.wpn_fps_upg_m4_m_d60.has_description = false
 			self.parts.wpn_fps_upg_m4_m_d60.desc_id = ""
 			self.parts.wpn_fps_upg_m4_m_d60.stats = deep_clone(self.parts.wpn_fps_upg_m4_m_quad.stats)
 			self.parts.wpn_fps_upg_m4_m_d60.custom_stats = deep_clone(self.parts.wpn_fps_upg_m4_m_quad.custom_stats)
-	
+
 			--HK416c parts
 			self.parts.wpn_fps_ass_tecci_fg_contraband.supported = true
 			self.parts.wpn_fps_ass_tecci_fg_contraband.stats = deep_clone(barrels.long_b2_stats)
 			self.parts.wpn_fps_ass_tecci_fg_contraband.custom_stats = deep_clone(barrels.long_b2_stats)
-	
+
 			self.parts.wpn_fps_ass_tecci_s_wire.supported = true
 			self.parts.wpn_fps_ass_tecci_s_wire.stats = deep_clone(stocks.adj_to_nocheeks_stats)
 			self.parts.wpn_fps_ass_tecci_s_wire.custom_stats = deep_clone(stocks.adj_to_nocheeks_stats)
-	
+
 			self.parts.wpn_fps_ass_tecci_m_jungle_m4.custom_stats = nil
 			self.parts.wpn_fps_ass_tecci_m_jungle.supported = true
 			self.parts.wpn_fps_ass_tecci_m_jungle.stats = {
@@ -39810,7 +39935,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 			self.parts.wpn_fps_ass_tecci_m_jungle.custom_stats = {
 				ads_speed_mult = 0.9
 			}
-	
+
 			self.parts.wpn_fps_ass_tecci_m_jungle_m4.supported = true
 			self.parts.wpn_fps_ass_tecci_m_jungle_m4.stats = {
 				value = 2,
@@ -39818,8 +39943,8 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 				concealment = -1,
 				reload = 3
 			}
-	
-	
+
+
 			--SRS Supp.
 			self.parts.wpn_fps_upg_ns_ass_smg_desertfox.supported = true
 			self.parts.wpn_fps_upg_ns_ass_smg_desertfox.has_description = true
@@ -39827,17 +39952,17 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 			self.parts.wpn_fps_upg_ns_ass_smg_desertfox.stats = deep_clone(muzzle_device.supp_acc2_c)
 			self.parts.wpn_fps_upg_ns_ass_smg_desertfox.custom_stats = deep_clone(muzzle_device.supp_acc2_c)
 			self.parts.wpn_fps_upg_ns_ass_smg_desertfox.perks = {"silencer"}
-	
+
 			--HCAR stock
 			self.parts.wpn_fps_upg_m4_s_hcar.supported = true
 			self.parts.wpn_fps_upg_m4_s_hcar.stats = deep_clone(stocks.adj_hvy_acc_stats)
 			self.parts.wpn_fps_upg_m4_s_hcar.custom_stats = deep_clone(stocks.adj_hvy_acc_stats)
-	
+
 			--Contender stock
 			self.parts.wpn_fps_upg_m4_s_contender_normal.supported = true
 			self.parts.wpn_fps_upg_m4_s_contender_normal.stats = deep_clone(stocks.adj_hvy_rec_stats)
 			self.parts.wpn_fps_upg_m4_s_contender_normal.custom_stats = deep_clone(stocks.adj_hvy_rec_stats)
-	
+
 			--AK12 stock
 			self.parts.wpn_fps_ass_hera_s_russian.supported = true
 			self.parts.wpn_fps_ass_hera_s_russian.stats = deep_clone(stocks.adj_acc_stats)
@@ -39846,7 +39971,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 			self.parts.wpn_fps_upg_m4_s_cut.supported = true
 			self.parts.wpn_fps_upg_m4_s_cut.stats = deep_clone(stocks.adj_acc_stats)
 			self.parts.wpn_fps_upg_m4_s_cut.custom_stats = deep_clone(stocks.adj_acc_stats)
-			
+
 			self.parts.wpn_fps_upg_m4_s_pts_v2.supported = true
 			self.parts.wpn_fps_upg_m4_s_pts_v2.stats = deep_clone(stocks.adj_acc_stats)
 			self.parts.wpn_fps_upg_m4_s_pts_v2.custom_stats = deep_clone(stocks.adj_acc_stats)
@@ -39854,7 +39979,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 			self.parts.wpn_fps_upg_m4_s_magless.supported = true
 			self.parts.wpn_fps_upg_m4_s_magless.stats = {value = 0}
 			self.parts.wpn_fps_upg_m4_s_magless.custom_stats = {}
-	
+
 			for factory_id, i in pairs(self) do
 				if self[factory_id] and self[factory_id .. "_npc"] then
 					if self[factory_id].uses_parts and table.contains(self[factory_id].uses_parts, "wpn_fps_upg_m4_s_standard") then
@@ -39949,11 +40074,11 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 					end
 				end
 			end
-	
+
 			self.parts.wpn_fps_upg_ak_m_nato.supported = true
 			self.parts.wpn_fps_upg_ak_m_nato.has_description = false
 			self.parts.wpn_fps_upg_ak_m_nato.desc_id = ""
-			self.parts.wpn_fps_upg_ak_m_nato.stats = { 
+			self.parts.wpn_fps_upg_ak_m_nato.stats = {
 				value = 2,
 				recoil = 2
 			}
@@ -39965,7 +40090,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 			self.parts.wpn_fps_upg_ak_m_ak101.supported = true
 			self.parts.wpn_fps_upg_ak_m_ak101.has_description = false
 			self.parts.wpn_fps_upg_ak_m_ak101.desc_id = ""
-			self.parts.wpn_fps_upg_ak_m_ak101.stats = { 
+			self.parts.wpn_fps_upg_ak_m_ak101.stats = {
 				value = 2,
 				spread = -1,
 				recoil = 2,
@@ -39975,11 +40100,11 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 				falloff_end_mult = 1.2,
 				damage_min_mult = 0.8
 			}
-			
+
 			self.parts.wpn_fps_ass_flint_m_ak19.supported = true
 			self.parts.wpn_fps_ass_flint_m_ak19.has_description = false
 			self.parts.wpn_fps_ass_flint_m_ak19.desc_id = ""
-			self.parts.wpn_fps_ass_flint_m_ak19.stats = { 
+			self.parts.wpn_fps_ass_flint_m_ak19.stats = {
 				value = 2,
 				spread = -1,
 				recoil = 4
@@ -39988,7 +40113,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 				falloff_end_mult = 1.2,
 				damage_min_mult = 0.8
 			}
-	
+
 			self.parts.wpn_fps_upg_ak_m_double.supported = true
 			self.parts.wpn_fps_upg_ak_m_double.has_description = false
 			self.parts.wpn_fps_upg_ak_m_double.desc_id = ""
@@ -40000,12 +40125,12 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 				falloff_start_mult = 0.75,
 				falloff_end_mult = 0.75
 			}
-	
-	
+
+
 			self.parts.wpn_fps_upg_bdgr_b_loud.supported = true
 			self.parts.wpn_fps_upg_bdgr_b_loud.stats = deep_clone(barrels.long_b3_stats)
 			self.parts.wpn_fps_upg_bdgr_b_loud.custom_stats = deep_clone(barrels.long_b3_stats)
-	
+
 			self.parts.wpn_fps_lmg_rpk_fg_modern.supported = true
 			self.parts.wpn_fps_lmg_rpk_fg_modern.stats = {
 				value = 6,
@@ -40014,7 +40139,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 				concealment = -2
 			}
 			self.parts.wpn_fps_lmg_rpk_fg_modern.custom_stats = nil
-	
+
 			self.parts.wpn_fps_upg_ak_fg_modern.supported = true
 			self.parts.wpn_fps_upg_ak_fg_modern.stats = {
 				value = 6,
@@ -40023,7 +40148,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 				concealment = -2
 			}
 			self.parts.wpn_fps_upg_ak_fg_modern.custom_stats = nil
-	
+
 			self.parts.wpn_fps_smg_akmsu_fg_mar.supported = true
 			self.parts.wpn_fps_smg_akmsu_fg_mar.stats = {
 				value = 4,
@@ -40034,7 +40159,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 			self.parts.wpn_fps_smg_akmsu_fg_mar.custom_stats = nil
 			self.parts.wpn_fps_smg_akmsu_fg_mar.forbids = self.parts.wpn_fps_smg_akmsu_fg_mar.forbids or {}
 			table.insert(self.parts.wpn_fps_smg_akmsu_fg_mar.forbids, "wpn_fps_pis_usp_fl_adapter")
-	
+
 			self.parts.wpn_fps_upg_ak_b_galil.supported = true
 			self.parts.wpn_fps_upg_ak_b_galil.stats = {
 				value = 4,
@@ -40042,26 +40167,26 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 				spread = -1
 			}
 			self.parts.wpn_fps_upg_ak_b_galil.custom_stats = nil
-	
+
 			self.parts.wpn_fps_upg_ak_b_galil_bipod.supported = true
 			self.parts.wpn_fps_upg_ak_b_galil_bipod.stats = deep_clone(barrels.long_b3_stats)
 			self.parts.wpn_fps_upg_ak_b_galil_bipod.stats.recoil = 4
 			self.parts.wpn_fps_upg_ak_b_galil_bipod.stats.concealment = -5
 			self.parts.wpn_fps_upg_ak_b_galil_bipod.custom_stats = deep_clone(barrels.long_b3_stats)
 			self.parts.wpn_fps_upg_ak_b_galil_bipod.custom_stats.ads_speed_mult = 1.025
-	
+
 			self.parts.wpn_fps_upg_ak_g_galil.supported = true
 			self.parts.wpn_fps_upg_ak_g_galil.stats = deep_clone(grips.dual_stat_1)
 			self.parts.wpn_fps_upg_ak_g_galil.custom_stats = deep_clone(grips.dual_stat_1)
-	
+
 			self.parts.wpn_fps_ass_ak_g_m249.supported = true
 			self.parts.wpn_fps_ass_ak_g_m249.stats = deep_clone(grips.recoil_acc)
 			self.parts.wpn_fps_ass_ak_g_m249.custom_stats = nil
-	
+
 			self.parts.wpn_fps_ass_ak_g_vityaz.supported = true
 			self.parts.wpn_fps_ass_ak_g_vityaz.stats = deep_clone(grips.quickdraw_1)
 			self.parts.wpn_fps_ass_ak_g_vityaz.custom_stats = deep_clone(grips.quickdraw_1)
-	
+
 			self.parts.wpn_fps_upg_m16_fg_edge.supported = true
 			self.parts.wpn_fps_upg_m16_fg_edge.stats = {
 				value = 8,
@@ -40069,7 +40194,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 				recoil = 2,
 				concealment = -2
 			}
-	
+
 			self.parts.wpn_fps_smg_vityaz_fg_wood.supported = true
 			self.parts.wpn_fps_smg_vityaz_fg_wood.stats = {
 				value = 3,
@@ -40077,72 +40202,72 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 				spread = -1
 			}
 			self.parts.wpn_fps_smg_vityaz_fg_wood.custom_stats = nil
-	
+
 			self.parts.wpn_fps_smg_vityaz_s_wood.supported = true
 			self.parts.wpn_fps_smg_vityaz_s_wood.stats = deep_clone(stocks.folder_to_fixed_rec3_stats)
 			self.parts.wpn_fps_smg_vityaz_s_wood.custom_stats = deep_clone(stocks.folder_to_fixed_rec3_stats)
-	
+
 			self.parts.wpn_fps_smg_vityaz_s_flint.supported = true
 			self.parts.wpn_fps_smg_vityaz_s_flint.stats = deep_clone(stocks.folder_to_adj_acc2_stats)
 			self.parts.wpn_fps_smg_vityaz_s_flint.custom_stats = deep_clone(stocks.folder_to_adj_acc2_stats)
-	
+
 			self.parts.wpn_fps_upg_ak_body_magwell.supported = true
 			self.parts.wpn_fps_upg_ak_body_magwell.stats = {
-				value = 5, 
+				value = 5,
 				concealment = -1,
 				reload = 1
 			}
-	
+
 			self.parts.wpn_fps_shot_saiga_body_magwell.supported = true
 			self.parts.wpn_fps_shot_saiga_body_magwell.stats = {
-				value = 5, 
+				value = 5,
 				concealment = -1,
 				reload = 1
 			}
-	
+
 			self.parts.wpn_fps_shot_saiga_fg_mar.supported = true
 			self.parts.wpn_fps_shot_saiga_fg_mar.stats = {
-				value = 4, 
+				value = 4,
 				concealment = 2,
 				recoil = -2,
 				spread = -1
 			}
 			self.parts.wpn_fps_shot_saiga_fg_sar.supported = true
 			self.parts.wpn_fps_shot_saiga_fg_sar.stats = {
-				value = 4, 
+				value = 4,
 				concealment = 1,
-				spread = -1 
+				spread = -1
 			}
-	
+
 			self.parts.wpn_upg_ak_fg_saiga_ultimak.supported = true
 			self.parts.wpn_upg_ak_fg_saiga_ultimak.stats = {
-				value = 4, 
+				value = 4,
 				concealment = 1,
 				recoil = -2
 			}
-	
+
 			self.parts.wpn_upg_ak_fg_saiga.supported = true
 			self.parts.wpn_upg_ak_fg_saiga.stats = {
-				value = 4, 
+				value = 4,
 				concealment = 1,
 				recoil = -2
 			}
-	
+
 			self.parts.wpn_fps_ass_flint_dh_galil.supported = true
 			self.parts.wpn_fps_ass_flint_dh_galil.stats = {
-				value = 4, 
+				value = 4,
 				concealment = -1,
 				recoil = 2
 			}
-	
+
 			self.parts.wpn_upg_ak_s_folded.supported = true
 			self.parts.wpn_upg_ak_s_folded.stats = deep_clone(stocks.fold_folder_stats)
 			self.parts.wpn_upg_ak_s_folded.custom_stats = deep_clone(stocks.fold_folder_stats)
-	
+
 			self.parts.wpn_fps_upg_ak_s_asval.supported = true
 			self.parts.wpn_fps_upg_ak_s_asval.stats = {}
 			self.parts.wpn_fps_upg_ak_s_asval.custom_stats = {}
-	
+
 			self.parts.wpn_fps_upg_ak_m_bakeband.supported = true
 			self.parts.wpn_fps_upg_ak_m_bakeband.desc_id = ""
 			self.parts.wpn_fps_upg_ak_m_bakeband.has_description = false
@@ -40215,7 +40340,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 						third_unit = "units/payday2/weapons/wpn_third_smg_mp5_pts/wpn_third_smg_mp5_s_adjust"
 					}
 				}
-		
+
 				for i, part_id in pairs(self.wpn_fps_ass_g3.uses_parts) do
 					if self.parts[part_id] and self.parts[part_id].type then
 						if self.parts[part_id].type == "foregrip" then
@@ -40261,7 +40386,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 						unit = "units/mods/weapons/wpn_fps_ass_galil_intermediate/wpn_fps_ass_galil_m_intermediate_new",
 						third_unit = "units/mods/weapons/wpn_third_ass_galil_intermediate/wpn_third_ass_galil_m_intermediate_new"
 					},
-					wpn_fps_ass_galil_fg_sar = { 
+					wpn_fps_ass_galil_fg_sar = {
 						unit = "units/mods/weapons/wpn_fps_ass_galil_intermediate/wpn_fps_ass_galil_fg_intermediate",
 						third_unit = "units/mods/weapons/wpn_third_ass_galil_intermediate/wpn_third_ass_galil_fg_intermediate"
 					}
@@ -40345,7 +40470,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 
 			--Two Tone CAR-4
 				self.parts.wpn_fps_ass_m4_body_tantone.supported = true
-				self.parts.wpn_fps_ass_m4_body_tantone.stats = { 
+				self.parts.wpn_fps_ass_m4_body_tantone.stats = {
 					value = 8,
 					recoil = -4,
 					spread = -3,
@@ -40395,9 +40520,9 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 				for k, used_part_id in ipairs(self.wpn_fps_ass_74.uses_parts) do
 					if self.parts[used_part_id] and self.parts[used_part_id].type then
 						if not table.contains(self.wpn_fps_ass_74.default_blueprint, used_part_id) then
-							if self.parts[used_part_id].type == "barrel" or 
-							self.parts[used_part_id].type == "foregrip" or 
-							self.parts[used_part_id].type == "magazine" or 
+							if self.parts[used_part_id].type == "barrel" or
+							self.parts[used_part_id].type == "foregrip" or
+							self.parts[used_part_id].type == "magazine" or
 							self.parts[used_part_id].type == "upper_reciever" then
 								table.insert(self.parts.wpn_fps_ass_ak_body_creedmoor.forbids, used_part_id )
 							end
@@ -40407,7 +40532,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 								unit = "units/mods/weapons/wpn_fps_ass_ak_creedmoor/wpn_fps_ass_ak_lower_creedmoor",
 								adds = { "wpn_fps_ak_bolt" }
 							}
-						end 
+						end
 					end
 				end
 
@@ -40625,7 +40750,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 						end
 					end
 				end
-		
+
 			--MAC-10
 				self.parts.wpn_fps_smg_mac10_body_m4_v2.supported = true
 				self.parts.wpn_fps_smg_mac10_body_m4_v2.stats = {
@@ -40643,7 +40768,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 					"wpn_fps_smg_mac10_s_no",
 					"wpn_fps_smg_mac10_s_skel"
 				}
-		
+
 			--1911
 				self.parts.wpn_fps_pis_1911_body_sporty.supported = true
 				self.parts.wpn_fps_pis_1911_body_sporty.stats = {
@@ -40746,7 +40871,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 								unit = "units/mods/weapons/wpn_fps_ass_g36_stanag/wpn_fps_ass_g36_vg_afg_cut",
 								third_unit = "units/payday2/weapons/wpn_third_upg_vg_ass_smg_afg/wpn_third_upg_vg_ass_smg_afg"
 							}
-						end 
+						end
 					end
 				end
 		end
@@ -40863,7 +40988,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 		end
 
 		if self.parts.wpn_fps_pis_glock_m_pmag then --Glock mags
-			
+
 			--Glock Mags
 				self.parts.wpn_fps_pis_glock_m_pmag.supported = true
 				self.parts.wpn_fps_pis_glock_m_pmag.stats = {
@@ -41121,7 +41246,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 					reload = 5,
 					extra_ammo = -16
 				}
-				self.parts.wpn_fps_ass_sub2000_m_short.custom_stats = { 
+				self.parts.wpn_fps_ass_sub2000_m_short.custom_stats = {
 					ads_speed_mult = 0.95
 				}
 
@@ -41149,7 +41274,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 					reload = 5,
 					extra_ammo = -13
 				}
-				self.parts.wpn_fps_smg_fmg9_m_short.custom_stats = { 
+				self.parts.wpn_fps_smg_fmg9_m_short.custom_stats = {
 					ads_speed_mult = 0.95
 				}
 
@@ -41288,7 +41413,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 					reload = 5,
 					extra_ammo = -10
 				}
-				self.parts.wpn_fps_ass_modl_m_5.custom_stats = { 
+				self.parts.wpn_fps_ass_modl_m_5.custom_stats = {
 					ads_speed_mult = 0.95
 				}
 				--FM
@@ -41299,7 +41424,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 					reload = 3,
 					extra_ammo = -5
 				}
-				self.parts.wpn_fps_ass_modl_m_4.custom_stats = { 
+				self.parts.wpn_fps_ass_modl_m_4.custom_stats = {
 					ads_speed_mult = 0.975
 				}
 				--EX 1
@@ -41310,7 +41435,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 					reload = -4,
 					extra_ammo = 10
 				}
-				self.parts.wpn_fps_ass_modl_m_2.custom_stats = { 
+				self.parts.wpn_fps_ass_modl_m_2.custom_stats = {
 					ads_speed_mult = 1.05
 				}
 				--EX 2
@@ -41321,7 +41446,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 					reload = -5,
 					extra_ammo = 20
 				}
-				self.parts.wpn_fps_ass_modl_m_3.custom_stats = { 
+				self.parts.wpn_fps_ass_modl_m_3.custom_stats = {
 					ads_speed_mult = 1.075
 				}
 
@@ -41474,7 +41599,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 					reload = 5,
 					extra_ammo = -10
 				}
-				self.parts.wpn_fps_smg_r31_m_fastreload2.custom_stats = { 
+				self.parts.wpn_fps_smg_r31_m_fastreload2.custom_stats = {
 					ads_speed_mult = 0.95,
 					adj_timers = {
 						reload_exit_empty = 0.85,
@@ -41489,7 +41614,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 					reload = -4,
 					extra_ammo = 10
 				}
-				self.parts.wpn_fps_smg_r31_m_extclip.custom_stats = { 
+				self.parts.wpn_fps_smg_r31_m_extclip.custom_stats = {
 					ads_speed_mult = 1.05
 				}
 				--EX 2
@@ -41500,7 +41625,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 					reload = -5,
 					extra_ammo = 20
 				}
-				self.parts.wpn_fps_smg_r31_m_extclip2.custom_stats = { 
+				self.parts.wpn_fps_smg_r31_m_extclip2.custom_stats = {
 					ads_speed_mult = 1.075,
 					reload_non_empty_anim_mult = 0.88,
 					adj_timers = {
@@ -41709,7 +41834,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 			}
 			self.parts.wpn_fps_shot_or12_45steel.stats = { value = 0, gadget_zoom = 1 }
 			self.parts.wpn_fps_shot_or12_45steel.custom_stats = nil
-				
+
 			self.wpn_fps_shot_or12.override = self.wpn_fps_shot_or12.override or {}
 			self.wpn_fps_shot_or12.override.wpn_fps_upg_a_slug = deep_clone(shot_ammo.a_slug_semi_override)
 			self.wpn_fps_shot_or12.override.wpn_fps_upg_a_custom = deep_clone(shot_ammo.a_custom_semi_override)
@@ -41796,7 +41921,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 							translation = Vector3(-0.06, -8, -0.42),
 							rotation = Rotation(0.01, 0, 0)
 						}
-					}	
+					}
 				},
 			}
 
@@ -41894,7 +42019,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 
 
 			self.parts.wpn_fps_sho_bp12_s_ext.supported = true
-			self.parts.wpn_fps_sho_bp12_s_ext.stats = { 
+			self.parts.wpn_fps_sho_bp12_s_ext.stats = {
 				value = 2,
 				recoil = 2,
 				concealment = -1
@@ -41902,7 +42027,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 		end
 
 		--Helldivers 2 AR-23 (v4)
-		if self.parts.wpn_fps_ass_ar23_body then 
+		if self.parts.wpn_fps_ass_ar23_body then
 			--AR-23 Optic
 			self.parts.wpn_fps_ass_ar23_optic_2.stance_mod = deep_clone(self.parts.wpn_fps_upg_o_specter.stance_mod)
 			for i, weap in pairs(self.parts.wpn_fps_ass_ar23_optic_2.stance_mod) do
@@ -42044,7 +42169,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 			for i, part_id in pairs(self.wpn_fps_ass_ar23.uses_parts) do
 				if self.parts[part_id] and self.parts[part_id].type then
 					if self.parts[part_id].pcs then
-						if ((self.parts[part_id].global_value and self.parts[part_id].global_value ~= "fiery_hylie_mod") or not self.parts[part_id].global_value) and 
+						if ((self.parts[part_id].global_value and self.parts[part_id].global_value ~= "fiery_hylie_mod") or not self.parts[part_id].global_value) and
 							(self.parts[part_id].type == "sight" or self.parts[part_id].type == "barrel_ext" or self.parts[part_id].type == "custom" or self.parts[part_id].type == "second_sight") then
 							self.wpn_fps_ass_ar23.uses_parts[i] = "resmod_dummy"
 						end
@@ -42060,7 +42185,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 			for i, part_id in pairs(self.wpn_fps_ass_sta52.uses_parts) do
 				if self.parts[part_id] and self.parts[part_id].type then
 					if self.parts[part_id].pcs then
-						if ((self.parts[part_id].global_value and self.parts[part_id].global_value ~= "fiery_hylie_mod") or not self.parts[part_id].global_value) and 
+						if ((self.parts[part_id].global_value and self.parts[part_id].global_value ~= "fiery_hylie_mod") or not self.parts[part_id].global_value) and
 							(self.parts[part_id].type == "sight" or self.parts[part_id].type == "barrel_ext" or self.parts[part_id].type == "custom" or self.parts[part_id].type == "second_sight") then
 							self.wpn_fps_ass_sta52.uses_parts[i] = "resmod_dummy"
 						end
@@ -42073,7 +42198,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 		--Helldivers 2 BR-14
 		if self.parts.wpn_fps_ass_br14_m_std then
 			self.parts.wpn_fps_ass_br14_optic.supported = true
-			self.parts.wpn_fps_ass_br14_optic.stats = { 
+			self.parts.wpn_fps_ass_br14_optic.stats = {
 				value = 0,
 				zoom = 5,
 				base_zoom_off = 2
@@ -42088,7 +42213,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 			for i, part_id in pairs(self.wpn_fps_ass_br14.uses_parts) do
 				if self.parts[part_id] and self.parts[part_id].type then
 					if self.parts[part_id].pcs then
-						if ((self.parts[part_id].global_value and self.parts[part_id].global_value ~= "fiery_hylie_mod") or not self.parts[part_id].global_value) and 
+						if ((self.parts[part_id].global_value and self.parts[part_id].global_value ~= "fiery_hylie_mod") or not self.parts[part_id].global_value) and
 							(self.parts[part_id].type == "barrel_ext" or self.parts[part_id].type == "custom") then
 							self.wpn_fps_ass_br14.uses_parts[i] = "resmod_dummy"
 						end
@@ -42100,7 +42225,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 
 		if self.parts.wpn_fps_smg_reprimand_dh then
 			self.parts.wpn_fps_smg_reprimand_optic.supported = true
-			self.parts.wpn_fps_smg_reprimand_optic.stats = { 
+			self.parts.wpn_fps_smg_reprimand_optic.stats = {
 				value = 0,
 				zoom = 1,
 				base_zoom_off = 1
@@ -42115,7 +42240,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 			for i, part_id in pairs(self.wpn_fps_smg_reprimand.uses_parts) do
 				if self.parts[part_id] and self.parts[part_id].type then
 					if self.parts[part_id].pcs then
-						if ((self.parts[part_id].global_value and self.parts[part_id].global_value ~= "fiery_hylie_mod") or not self.parts[part_id].global_value) and 
+						if ((self.parts[part_id].global_value and self.parts[part_id].global_value ~= "fiery_hylie_mod") or not self.parts[part_id].global_value) and
 							(self.parts[part_id].type == "sight" or self.parts[part_id].type == "barrel_ext" or self.parts[part_id].type == "custom") then
 							self.wpn_fps_smg_reprimand.uses_parts[i] = "resmod_dummy"
 						end
@@ -42130,7 +42255,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 			for i, part_id in pairs(self.wpn_fps_smg_sta11.uses_parts) do
 				if self.parts[part_id] and self.parts[part_id].type then
 					if self.parts[part_id].pcs then
-						if ((self.parts[part_id].global_value and self.parts[part_id].global_value ~= "fiery_hylie_mod") or not self.parts[part_id].global_value) and 
+						if ((self.parts[part_id].global_value and self.parts[part_id].global_value ~= "fiery_hylie_mod") or not self.parts[part_id].global_value) and
 							(self.parts[part_id].type == "sight" or self.parts[part_id].type == "barrel_ext" or self.parts[part_id].type == "custom") then
 							self.wpn_fps_smg_sta11.uses_parts[i] = "resmod_dummy"
 						end
@@ -42153,7 +42278,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 				custom_stats = {} --Just to load the soundbank into memory
 			}
 			self.parts.wpn_fps_sickle_optic.supported = true
-			self.parts.wpn_fps_sickle_optic.stats = { 
+			self.parts.wpn_fps_sickle_optic.stats = {
 				value = 0,
 				zoom = 5,
 				base_zoom_off = 2
@@ -42259,7 +42384,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 				self.parts.wpn_fps_sho_haymaker_m_30rnd_pd3.custom_stats = {
 					ads_speed_mult = 1.15
 				}
-		
+
 			--STOCKs
 				self.parts.wpn_fps_sho_haymaker_s_no.supported = true
 				self.parts.wpn_fps_sho_haymaker_s_no.stats = deep_clone(stocks.remove_adj_stats)
@@ -42500,7 +42625,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 				alert_size = -1
 			}
 			self.parts.wpn_fps_pis_pm_ns_supp.perks = {"silencer"}
-	
+
 			self.parts.wpn_fps_pis_pm_ns_comp.supported = true
 			self.parts.wpn_fps_pis_pm_ns_comp.desc_id = "bm_wp_upg_flash_hider"
 			self.parts.wpn_fps_pis_pm_ns_comp.has_description = true
@@ -42536,7 +42661,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 			self.parts.wpn_fps_pis_pmm_conversion.custom_stats = nil
 
 			self.parts.wpn_fps_pis_pm_m_modern.supported = true
-			self.parts.wpn_fps_pis_pm_m_modern.stats = { 
+			self.parts.wpn_fps_pis_pm_m_modern.stats = {
 				value = 2,
 				extra_ammo = 4,
 				concealment = -2,
@@ -42544,7 +42669,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 			}
 			self.parts.wpn_fps_pis_pm_m_modern.custom_stats = { ads_speed_mult = 1.025 }
 			self.parts.wpn_fps_pis_pm_m_extended.supported = true
-			self.parts.wpn_fps_pis_pm_m_extended.stats = { 
+			self.parts.wpn_fps_pis_pm_m_extended.stats = {
 				value = 1,
 				extra_ammo = 2,
 				concealment = -1,
@@ -42655,6 +42780,62 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 			self.wpn_fps_shot_toz194.override.wpn_fps_upg_a_dragons_breath = deep_clone(shot_ammo.a_dragons_breath_pump_override)
 		end
 
+		if self.parts.wpn_fps_shot_mossberg590_b_medium then
+			self.parts.wpn_fps_shot_mossberg590_b_medium.supported = true
+			self.parts.wpn_fps_shot_mossberg590_b_medium.stats = {
+				value = 3,
+				spread = -1,
+				concealment = 1,
+				extra_ammo = -1
+			}
+			self.parts.wpn_fps_shot_mossberg590_b_medium.custom_stats = deep_clone(barrels.short_b1_stats)
+			self.parts.wpn_fps_shot_mossberg590_b_short.supported = true
+			self.parts.wpn_fps_shot_mossberg590_b_short.stats = {
+				value = 3,
+				spread = -2,
+				concealment = 2,
+				extra_ammo = -2
+			}
+			self.parts.wpn_fps_shot_mossberg590_b_short.custom_stats = deep_clone(barrels.short_b2_stats)
+
+			self.parts.wpn_fps_shot_mossberg590_b_silencer.supported = true
+			self.parts.wpn_fps_shot_mossberg590_b_silencer.stats = {
+				value = 2,
+				suppression = 12,
+				alert_size = -1
+			}
+			self.parts.wpn_fps_shot_mossberg590_b_silencer.custom_stats = {}
+			self.parts.wpn_fps_shot_mossberg590_b_silencer.perks = {"silencer"}
+
+			self.parts.wpn_fps_shot_mossberg590_s_magpul_sga.supported = true
+			self.parts.wpn_fps_shot_mossberg590_s_magpul_sga.stats = deep_clone(stocks.fixed_to_hvy_acc_stats)
+			self.parts.wpn_fps_shot_mossberg590_s_magpul_sga.custom_stats = deep_clone(stocks.fixed_to_hvy_acc_stats)
+			self.parts.wpn_fps_shot_mossberg590_s_shockwave.supported = true
+			self.parts.wpn_fps_shot_mossberg590_s_shockwave.stats = deep_clone(stocks.remove_fixed_stats)
+			self.parts.wpn_fps_shot_mossberg590_s_shockwave.custom_stats = deep_clone(stocks.remove_fixed_stats)
+
+			self.parts.wpn_fps_shot_mossberg590_fg_magpul_moe.supported = true
+			self.parts.wpn_fps_shot_mossberg590_fg_magpul_moe.stats = {
+				value = 3,
+				recoil = -2,
+				concealment = 1
+			}
+
+			self.parts.wpn_fps_shot_mossberg590_heat_shield.supported = true
+			self.parts.wpn_fps_shot_mossberg590_heat_shield.stats = {
+				value = 0,
+				recoil = 2,
+				concealment = -1
+			}
+
+			self.parts.wpn_fps_shot_mossberg590_tactical_rail.supported = true
+			self.parts.wpn_fps_shot_mossberg590_tactical_rail.stats = {
+				value = 3,
+				recoil = 2,
+				concealment = -1
+			}
+		end
+
 		if self.parts.wpn_fps_pis_welrod_b_short then
 			self.parts.wpn_fps_pis_welrod_b_short.supported = true
 			self.parts.wpn_fps_pis_welrod_b_short.stats = deep_clone(barrels.short_b2_stats)
@@ -42742,7 +42923,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 		self.wpn_fps_sho_x_coach.override.wpn_fps_upg_a_custom_free.custom_stats.rays = 4
 		self.wpn_fps_sho_x_coach.override.wpn_fps_upg_a_piercing = {custom_stats = deep_clone(shot_ammo.a_piercing_heavy_override.custom_stats)}
 		self.wpn_fps_sho_x_coach.override.wpn_fps_upg_a_piercing.custom_stats.rays = 9
-		
+
 		table.insert(self.wpn_fps_sho_x_coach.uses_parts, "wpn_fps_sho_coach_b_short" )
 		table.insert(self.wpn_fps_sho_x_coach.uses_parts, "wpn_fps_sho_coach_b_long" )
 		self.wpn_fps_sho_x_coach_npc.uses_parts = deep_clone(self.wpn_fps_sho_x_coach.uses_parts)
@@ -42757,10 +42938,10 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 			concealment = 0
 		}
 	end
-	
+
 	if SystemFS:exists("assets/mod_overrides/Akimbo 5-7") then
 		self.wpn_fps_pis_x_lemming.override.wpn_fps_pis_lemming_m_ext.stats = {
-			value = 1, 
+			value = 1,
 			extra_ammo = 20,
 			concealment = -1,
 			reload = -3
@@ -42770,7 +42951,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 			table.insert(self.wpn_fps_pis_x_lemming.uses_parts, "wpn_fps_pis_lemming_b_long" )
 		end
 	end
-	
+
 
 	if SystemFS:exists("assets/mod_overrides/Classic Weapon Animations") then
 		self.parts.wpn_fps_pis_g17_m_standard.unit = "units/payday2/weapons/wpn_fps_pis_g17_pts/wpn_fps_pis_g17_m_standard"
@@ -42778,61 +42959,61 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 
 	if self.parts.wpn_fps_ass_ns_g_sup1 then -- Gambyt's Sneaky Suppressor Pack
 		self.parts.wpn_fps_ass_ns_g_sup1.supported = true
-		self.parts.wpn_fps_ass_ns_g_sup1.stats = { 
+		self.parts.wpn_fps_ass_ns_g_sup1.stats = {
 			value = 2,
 			suppression = 12,
 			alert_size = -1,
 			recoil = -1,
 			spread = 1,
 			concealment = -1
-		}	
-		self.parts.wpn_fps_ass_ns_g_sup2.supported = true	
-		self.parts.wpn_fps_ass_ns_g_sup2.stats = { 
+		}
+		self.parts.wpn_fps_ass_ns_g_sup2.supported = true
+		self.parts.wpn_fps_ass_ns_g_sup2.stats = {
 			value = 2,
 			suppression = 12,
 			alert_size = -1,
 			recoil = -1,
 			spread = 1,
 			concealment = -1
-		}			
-		self.parts.wpn_fps_ass_ns_g_sup3.supported = true			
-		self.parts.wpn_fps_ass_ns_g_sup3.stats = { 
+		}
+		self.parts.wpn_fps_ass_ns_g_sup3.supported = true
+		self.parts.wpn_fps_ass_ns_g_sup3.stats = {
 			value = 2,
 			suppression = 12,
 			alert_size = -1,
 			recoil = -1,
 			spread = 1,
 			concealment = -1
-		}			
-		self.parts.wpn_fps_ass_ns_g_sup4.supported = true			
-		self.parts.wpn_fps_ass_ns_g_sup4.stats = { 
+		}
+		self.parts.wpn_fps_ass_ns_g_sup4.supported = true
+		self.parts.wpn_fps_ass_ns_g_sup4.stats = {
 			value = 5,
 			suppression = 12,
 			alert_size = -1,
 			spread = 2,
 			recoil = -2,
 			concealment = -2
-		}		
-		self.parts.wpn_fps_ass_ns_g_sup5.supported = true		
-		self.parts.wpn_fps_ass_ns_g_sup5.stats = { 
+		}
+		self.parts.wpn_fps_ass_ns_g_sup5.supported = true
+		self.parts.wpn_fps_ass_ns_g_sup5.stats = {
 			value = 2,
 			suppression = 12,
 			alert_size = -1,
 			recoil = -1,
 			spread = 1,
 			concealment = -1
-		}		
-		self.parts.wpn_fps_ass_ns_g_sup6.supported = true		
-		self.parts.wpn_fps_ass_ns_g_sup6.stats = { 
+		}
+		self.parts.wpn_fps_ass_ns_g_sup6.supported = true
+		self.parts.wpn_fps_ass_ns_g_sup6.stats = {
 			value = 2,
 			suppression = 12,
 			alert_size = -1,
 			recoil = -1,
 			spread = 1,
 			concealment = -1
-		}							
-		self.parts.wpn_fps_ass_ns_g_sup7.supported = true							
-		self.parts.wpn_fps_ass_ns_g_sup7.stats = { 
+		}
+		self.parts.wpn_fps_ass_ns_g_sup7.supported = true
+		self.parts.wpn_fps_ass_ns_g_sup7.stats = {
 			value = 10,
 			suppression = 12,
 			alert_size = -1,
@@ -42840,7 +43021,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 			recoil = 1
 		}
 		self.parts.wpn_fps_ass_ns_g_sup8.supported = true
-		self.parts.wpn_fps_ass_ns_g_sup8.stats = { 
+		self.parts.wpn_fps_ass_ns_g_sup8.stats = {
 			value = 2,
 			suppression = 12,
 			alert_size = -1,
@@ -42849,34 +43030,34 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 			concealment = -1
 		}
 		self.parts.wpn_fps_ass_ns_g_sup9.supported = true
-		self.parts.wpn_fps_ass_ns_g_sup9.stats = { 
+		self.parts.wpn_fps_ass_ns_g_sup9.stats = {
 			value = 10,
 			suppression = 12,
 			alert_size = -1,
 			spread = 2,
 			recoil = -2,
 			concealment = -2
-		}						
+		}
 		table.remove(self.parts.wpn_fps_pis_pl14_b_comp.forbids, 1) --not a good way of fixing it, but it works, yeah?
 		table.remove(self.parts.wpn_fps_pis_pl14_b_comp.forbids, 1)
-		table.remove(self.parts.wpn_fps_pis_pl14_b_comp.forbids, 1)				
-		table.remove(self.parts.wpn_fps_pis_pl14_b_comp.forbids, 1)				
+		table.remove(self.parts.wpn_fps_pis_pl14_b_comp.forbids, 1)
+		table.remove(self.parts.wpn_fps_pis_pl14_b_comp.forbids, 1)
 	end
 
 	if self.parts.wpn_fps_rail_covers then 	--Kden and Silent Enforcer's Rail Covers
 		self.parts.wpn_fps_rc_dd.supported = true
-		self.parts.wpn_fps_rc_dd.stats = { 
+		self.parts.wpn_fps_rc_dd.stats = {
 				value = 0
-			}			
-		self.parts.wpn_fps_rail_covers.supported = true			
-		self.parts.wpn_fps_rail_covers.stats = { 
+			}
+		self.parts.wpn_fps_rail_covers.supported = true
+		self.parts.wpn_fps_rail_covers.stats = {
 				value = 0
-			}	
+			}
 	end
 
 	if self.parts.wpn_fps_upg_m4_m_x15drum then --Pawcio's M4 X 15 Drum Magazine
 		self.parts.wpn_fps_upg_m4_m_x15drum.supported = true
-		self.parts.wpn_fps_upg_m4_m_x15drum.stats = { 
+		self.parts.wpn_fps_upg_m4_m_x15drum.stats = {
 			value = 3,
 			concealment = -3,
 			reload = -5,
@@ -42890,7 +43071,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 				reload = -5,
 				extra_ammo = 30
 			}
-		}				
+		}
 	end
 
 	if self.parts.wpn_fps_snp_fyjs_supp then
@@ -42908,16 +43089,16 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 
 	if self.wpn_fps_pis_amt then -- Matthelzor, Gambyt, >:3, and Alcat's Automag .44
 			self.parts.wpn_fps_pis_amt_a_357.pcs = nil
-			self.parts.wpn_fps_pis_amt_a_357.supported = true	
+			self.parts.wpn_fps_pis_amt_a_357.supported = true
 			self.parts.wpn_fps_pis_amt_a_357.stats = { value = 0 }
 			self.parts.wpn_fps_pis_amt_a_357.custom_stats = nil
 
 			self.parts.wpn_fps_pis_amt_a_44.pcs = nil
-			self.parts.wpn_fps_pis_amt_a_44.supported = true	
+			self.parts.wpn_fps_pis_amt_a_44.supported = true
 			self.parts.wpn_fps_pis_amt_a_44.stats = { value = 0 }
 			self.parts.wpn_fps_pis_amt_a_44.custom_stats = nil
 
-			self.parts.wpn_fps_pis_amt_m_extended.supported = true		
+			self.parts.wpn_fps_pis_amt_m_extended.supported = true
 			self.parts.wpn_fps_pis_amt_m_extended.stats = {
 				value = 5,
 				concealment = -3,
@@ -42926,17 +43107,17 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 			}
 			self.parts.wpn_fps_pis_amt_m_extended.custom_stats = {
 				ads_speed_mult = 1.075
-			}	
+			}
 
 			self.parts.wpn_fps_pis_amt_b_long.supported = true
 			self.parts.wpn_fps_pis_amt_b_long.stats = deep_clone(barrels.long_b3_stats)
 			self.parts.wpn_fps_pis_amt_b_long.custom_stats = deep_clone(barrels.long_b3_stats)
 
-			self.parts.wpn_fps_pis_amt_g_smooth.supported = true	
+			self.parts.wpn_fps_pis_amt_g_smooth.supported = true
 			self.parts.wpn_fps_pis_amt_g_smooth.stats = deep_clone(grips.quickdraw_1)
 			self.parts.wpn_fps_pis_amt_g_smooth.custom_stats = deep_clone(grips.quickdraw_1)
 
-			self.parts.wpn_fps_pis_amt_g_rosewood.supported = true		
+			self.parts.wpn_fps_pis_amt_g_rosewood.supported = true
 			self.parts.wpn_fps_pis_amt_g_rosewood.stats = deep_clone(grips.recoil_acc)
 
 			self.wpn_fps_pis_amt.override = self.wpn_fps_pis_amt.override or {}
@@ -42944,12 +43125,12 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 
 	if self.parts.wpn_fps_ass_famas_body_feline then
 		self.parts.wpn_fps_ass_famas_body_feline.supported = true
-		self.parts.wpn_fps_ass_famas_body_feline.stats = { 
+		self.parts.wpn_fps_ass_famas_body_feline.stats = {
 			value = 7,
 			recoil = -4,
 			concealment = 2,
 		}
-		
+
 		self.parts.wpn_fps_ass_famas_m_dual.supported = true
 		self.parts.wpn_fps_ass_famas_m_dual.stats = deep_clone(self.parts.wpn_fps_m4_upg_m_quick.stats)
 		self.parts.wpn_fps_ass_famas_m_dual.custom_stats = { ads_speed_mult = 1.025 }
@@ -43003,7 +43184,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 		self.parts.wpn_fps_smg_mac10_ns_ghetto.sound_switch = {
 			suppressed = "suppressed_c"
 		}
-		
+
 		self.parts.wpn_fps_smg_mac10_ns_blade.supported = true
 		self.parts.wpn_fps_smg_mac10_ns_blade.has_description = false
 		self.parts.wpn_fps_smg_mac10_ns_blade.stats = deep_clone(muzzle_device.muzz_dual2_c)
@@ -43017,7 +43198,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 			concealment = -1,
 		}
 		self.parts.wpn_fps_smg_mac10_vg_strap.override_weapon = nil
-		
+
 		self.parts.wpn_fps_smg_mac10_anim_suppgrip.pcs = nil
 		self.parts.wpn_fps_smg_mac10_s_nil.pcs = nil
 	end
@@ -43213,21 +43394,21 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 			self.wpn_fps_ass_xr2.override = {}
 		end
 
-		self.wpn_fps_ass_xr2.override.wpn_fps_upg_vg_ass_smg_verticalgrip = { 
+		self.wpn_fps_ass_xr2.override.wpn_fps_upg_vg_ass_smg_verticalgrip = {
 			stats = {
 				value = 2,
 				recoil = 2,
 				concealment = -1
 			}
 		}
-		self.wpn_fps_ass_xr2.override.wpn_fps_upg_vg_ass_smg_stubby = { 
+		self.wpn_fps_ass_xr2.override.wpn_fps_upg_vg_ass_smg_stubby = {
 			stats = {
 				value = 1,
 				recoil = -2,
 				concealment = 1
 			}
 		}
-		self.wpn_fps_ass_xr2.override.wpn_fps_smg_schakal_vg_surefire = { 
+		self.wpn_fps_ass_xr2.override.wpn_fps_smg_schakal_vg_surefire = {
 			stats = {
 				value = 5,
 				recoil = 2,
@@ -43395,7 +43576,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 			self.parts[part_id].stats = deep_clone(self.parts.wpn_fps_m4_upg_m_quick.stats)
 			self.parts[part_id].custom_stats = nil
 		end
-		
+
 		-- Nothingburger
 		mags = {
 			'wpn_fps_upg_m_dura',
@@ -43467,7 +43648,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 				reload = 5,
 				extra_ammo = -20
 			}
-			self.parts[part_id].custom_stats = { 
+			self.parts[part_id].custom_stats = {
 				ads_speed_mult = 0.95
 			}
 		end
@@ -43504,9 +43685,9 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 			ads_speed_mult = 1.025
 		}
 		self.parts.wpn_fps_upg_m_pro.stats = {
-			value = 2, 
-			extra_ammo = 7, 
-			reload = -3, 
+			value = 2,
+			extra_ammo = 7,
+			reload = -3,
 			concealment = -1
 		}
 
@@ -44040,14 +44221,14 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 		}
 
 		local steelsight_id = nil
-	
+
 		for part_id, steelsight_data in pairs(optic_steelsights) do
 			steelsight_id = part_id .. "_steelsight"
 			self.parts[part_id].steelsight_visible = false
 			self.parts[part_id].adds = self.parts[part_id].adds or {}
-	
+
 			table.insert(self.parts[part_id].adds, steelsight_id)
-	
+
 			self.parts[steelsight_id] = steelsight_data
 			self.parts[steelsight_id].steelsight_visible = true
 			self.parts[steelsight_id].steelsight_parent = part_id
@@ -44081,7 +44262,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 				"screen"
 			}
 		}
-		
+
 		self.parts.wpn_fps_snp_srs99_s7_scope_steelsight.visibility = {
 			{
 				objects = {
@@ -44145,7 +44326,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 					custom_stats = { big_scope = true }
 				}
 			end
-		end	
+		end
 
 		table.insert(self.wpn_fps_snp_srs99_s7.uses_parts, "wpn_fps_snp_srs99_s7_scope_reticle")
 	end
@@ -44250,17 +44431,17 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 		self.parts.wpn_fps_upg_ak12_mag_ext.custom_stats = { ads_speed_mult = 1.05 }
 
 		self.wpn_fps_ass_ak12.override = self.wpn_fps_ass_ak12.override or {}
-		self.wpn_fps_ass_ak12.override.wpn_fps_upg_vg_ass_smg_verticalgrip = { 
+		self.wpn_fps_ass_ak12.override.wpn_fps_upg_vg_ass_smg_verticalgrip = {
 			stats = {}
 		}
-		self.wpn_fps_ass_ak12.override.wpn_fps_upg_vg_ass_smg_stubby = { 
+		self.wpn_fps_ass_ak12.override.wpn_fps_upg_vg_ass_smg_stubby = {
 			stats = {
 				value = 1,
 				recoil = -2,
 				concealment = 1
 			}
 		}
-		self.wpn_fps_ass_ak12.override.wpn_fps_smg_schakal_vg_surefire = { 
+		self.wpn_fps_ass_ak12.override.wpn_fps_smg_schakal_vg_surefire = {
 			stats = {}
 		}
 
@@ -44315,7 +44496,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 			stats = {
 				value = 0
 			},
-			override = { 
+			override = {
 				wpn_fps_hmcar_lower_receiver = {
 					unit = "units/payday2/weapons/wpn_fps_ass_m4_pts/wpn_fps_m4_lower_reciever",
 					third_unit = "units/payday2/weapons/wpn_third_ass_m4_pts/wpn_third_m4_lower_reciever",
@@ -44386,7 +44567,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 			alert_size = -1
 		}
 		self.parts.wpn_fps_upg_jackhammer_barrel_supp.custom_stats = nil
-		
+
 		self.parts.wpn_fps_upg_jackhammer_barrel_no_brake.supported = true
 		self.parts.wpn_fps_upg_jackhammer_barrel_no_brake.stats = {
 			value = 1,
@@ -44394,7 +44575,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 			concealment = 1
 		}
 		self.parts.wpn_fps_upg_jackhammer_barrel_no_brake.custom_stats = nil
-		
+
 		self.parts.wpn_fps_upg_jackhammer_barrel_long.supported = true
 		self.parts.wpn_fps_upg_jackhammer_barrel_long.stats = deep_clone(barrels.long_b2_stats)
 		self.parts.wpn_fps_upg_jackhammer_barrel_long.custom_stats = deep_clone(barrels.long_b2_stats)
@@ -44402,7 +44583,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 		self.wpn_fps_shot_jackhammer.override = self.wpn_fps_shot_jackhammer.override or {}
 		self.wpn_fps_shot_jackhammer.override.wpn_fps_upg_a_slug = deep_clone(shot_ammo.a_slug_semi_override)
 		self.wpn_fps_shot_jackhammer.override.wpn_fps_upg_a_custom = deep_clone(shot_ammo.a_custom_semi_override)
-		self.wpn_fps_shot_jackhammer.override.wpn_fps_upg_a_custom_free = deep_clone(shot_ammo.a_custom_semi_override)	
+		self.wpn_fps_shot_jackhammer.override.wpn_fps_upg_a_custom_free = deep_clone(shot_ammo.a_custom_semi_override)
 		self.wpn_fps_shot_jackhammer.override.wpn_fps_upg_a_explosive = deep_clone(shot_ammo.a_explosive_semi_override)
 		self.wpn_fps_shot_jackhammer.override.wpn_fps_upg_a_rip = deep_clone(shot_ammo.a_rip_semi_override)
 		self.wpn_fps_shot_jackhammer.override.wpn_fps_upg_a_piercing = deep_clone(shot_ammo.a_piercing_semi_override)
@@ -44419,7 +44600,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 		self.parts.wpn_fps_rsass_barrel_short.custom_stats = deep_clone(barrels.short_b3_stats)
 
 		self.wpn_fps_ass_rsass.override = self.wpn_fps_ass_rsass.override or {}
-	
+
 		self.wpn_fps_ass_rsass.override.wpn_fps_upg_m4_s_standard = {
 			stats = deep_clone(stocks.fixed_to_adj_dual_stats),
 			custom_stats = deep_clone(stocks.fixed_to_adj_dual_stats)
@@ -44678,9 +44859,9 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 			falloff_start_mult = 0.525,
 			falloff_end_mult = 0.525,
 			ads_speed_mult = 0.85
-		} 
+		}
 		self.parts.wpn_fps_upg_svd_b_draco.forbids = { "wpn_fps_snp_siltstone_fg_polymer" }
-		self.parts.wpn_fps_upg_svd_b_draco.override = { 
+		self.parts.wpn_fps_upg_svd_b_draco.override = {
 			wpn_fps_snp_siltstone_fg_wood = {
 				unit = "units/mods/weapons/wpn_fps_svd_upg_fg_draco/wpn_fps_svd_upg_fg_draco"
 			}
@@ -44789,18 +44970,18 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 			value = 0,
 			concealment = 2
 		}
-		
+
 		self.parts.wpn_fps_lmg_fg42_so_custom.pcs = nil
 		self.parts.wpn_fps_lmg_fg42_so_waw.pcs = nil
 
 		table.insert(self.wpn_fps_lmg_fg42.uses_parts, "wpn_fps_upg_o_specter")
-		table.insert(self.wpn_fps_lmg_fg42.uses_parts, "wpn_fps_upg_o_aimpoint")	
+		table.insert(self.wpn_fps_lmg_fg42.uses_parts, "wpn_fps_upg_o_aimpoint")
 		table.insert(self.wpn_fps_lmg_fg42.uses_parts, "wpn_fps_upg_o_docter")
 		table.insert(self.wpn_fps_lmg_fg42.uses_parts, "wpn_fps_upg_o_eotech")
 		table.insert(self.wpn_fps_lmg_fg42.uses_parts, "wpn_fps_upg_o_t1micro")
 		table.insert(self.wpn_fps_lmg_fg42.uses_parts, "wpn_fps_upg_o_rx30")
-		table.insert(self.wpn_fps_lmg_fg42.uses_parts, "wpn_fps_upg_o_rx01")	
-		table.insert(self.wpn_fps_lmg_fg42.uses_parts, "wpn_fps_upg_o_reflex")	
+		table.insert(self.wpn_fps_lmg_fg42.uses_parts, "wpn_fps_upg_o_rx01")
+		table.insert(self.wpn_fps_lmg_fg42.uses_parts, "wpn_fps_upg_o_reflex")
 		table.insert(self.wpn_fps_lmg_fg42.uses_parts, "wpn_fps_upg_o_eotech_xps")
 		table.insert(self.wpn_fps_lmg_fg42.uses_parts, "wpn_fps_upg_o_cmore")
 		table.insert(self.wpn_fps_lmg_fg42.uses_parts, "wpn_fps_upg_o_aimpoint_2")
@@ -44824,9 +45005,9 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 		self.wpn_fps_lmg_fg42.adds = self.wpn_fps_lmg_fg42.adds or {}
 		for i, part_id in pairs(self.wpn_fps_lmg_fg42.uses_parts) do
 			if part_id ~= "wpn_fps_lmg_fg42_o_zfg42" and part_id ~= "wpn_fps_lmg_fg42_o_zf4" and part_id ~= "wpn_fps_lmg_fg42_o_dummy" then
-				if self.parts[part_id] and self.parts[part_id].type and self.parts[part_id].type == "sight" then	
+				if self.parts[part_id] and self.parts[part_id].type and self.parts[part_id].type == "sight" then
 					self.wpn_fps_lmg_fg42.adds[part_id] = { "wpn_fps_smg_thompson_o_adapter" }
-					self.wpn_fps_lmg_fg42.override[part_id] = { 
+					self.wpn_fps_lmg_fg42.override[part_id] = {
 						override = {
 							wpn_fps_lmg_fg42_fo_std = {
 								unit = "units/mods/weapons/wpn_fps_lmg_fg42_pts/wpn_fps_lmg_fg42_fo_fold"
@@ -44882,7 +45063,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 			alert_size = -1
 		}
 		self.parts.wpn_fps_pis_pb_ns_std.custom_stats = nil
-		
+
 		self.parts.wpn_fps_pis_pb_gr_wood.supported = true
 		self.parts.wpn_fps_pis_pb_gr_wood.stats = deep_clone(grips.recoil_1)
 		self.parts.wpn_fps_pis_pb_gr_classic.supported = true
@@ -44942,9 +45123,9 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 				end
 			end
 		end
-		
+
 		table.insert(self.wpn_fps_snp_kar98k.uses_parts, "wpn_fps_upg_o_shortdot_dmc")
-		
+
 		self.parts.wpn_fps_snp_kar98k_body_1935_black_dummy.supported = true
 		self.parts.wpn_fps_snp_kar98k_body_1935_black_dummy.stats = { value = 0 }
 		self.parts.wpn_fps_snp_kar98k_body_1935_black_dummy.custom_stats = nil
@@ -44957,7 +45138,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 		self.parts.wpn_fps_snp_kar98k_b_standard.supported = true
 		self.parts.wpn_fps_snp_kar98k_b_standard.stats = deep_clone(barrels.long_b1_stats)
 		self.parts.wpn_fps_snp_kar98k_b_standard.custom_stats = deep_clone(barrels.long_b1_stats)
-		
+
 		self.parts.wpn_fps_snp_kar98k_b_sniper.supported = true
 		self.parts.wpn_fps_snp_kar98k_b_sniper.stats = {
 			value = 2,
@@ -45185,7 +45366,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 		self.parts.wpn_fps_snp_iuhTTIPlus_gl.supported = true
 		self.parts.wpn_fps_snp_iuhTTIPlus_gl.stats = {
 			value = 0--10,
-			--total_ammo_mod = -68, 
+			--total_ammo_mod = -68,
 			--concealment = -4
 		}
 		self.parts.wpn_fps_snp_iuhTTIPlus_gl.custom_stats = {
@@ -45293,7 +45474,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 			stats = deep_clone(stocks.fixed_acc_stats),
 			custom_stats = deep_clone(stocks.fixed_acc_stats)
 		}
-	
+
 		self.wpn_fps_snp_iuhTTIPlus.override.wpn_fps_ass_tecci_s_wire = {
 			stats = deep_clone(stocks.fixed_to_nocheeks_stats),
 			custom_stats = deep_clone(stocks.fixed_to_nocheeks_stats)
@@ -45312,7 +45493,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 		self.wpn_fps_ass_akm_nomag.stock_adapter = "wpn_upg_ak_s_adapter"
 		self.wpn_fps_ass_akm_nomag.stock_adapter = "wpn_upg_ak_s_adapter"
 		self.wpn_fps_ass_akm_nomag.override = self.wpn_fps_ass_akm_nomag.override or {}
-	
+
 		self.wpn_fps_ass_akm_nomag.override.wpn_fps_upg_m4_s_standard = {
 			stats = deep_clone(stocks.nocheeks_to_adj_dual_stats),
 			custom_stats = deep_clone(stocks.nocheeks_to_adj_dual_stats)
@@ -45357,12 +45538,12 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 		self.wpn_fps_ass_akm_nomag.override.wpn_fps_rpg7_sight_adapter = {
 			custom_stats = { big_scope = true }
 		}
-	
+
 		table.insert(self.wpn_fps_ass_akm_nomag.uses_parts, "wpn_fps_snp_victor_s_mod0")
-		
+
 		--Plastic Stock
 		table.insert(self.wpn_fps_ass_akm_nomag.uses_parts, "wpn_fps_lmg_rpk_s_standard")
-	
+
 		self.wpn_fps_ass_akm_nomag_npc.uses_parts = deep_clone(self.wpn_fps_ass_akm_nomag.uses_parts)
 	end
 
@@ -45413,7 +45594,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 
 		self.parts.wpn_fps_sho_abzats_m_big.supported = true
 		self.parts.wpn_fps_sho_abzats_m_big.desc_id = ""
-		self.parts.wpn_fps_sho_abzats_m_big.stats = { 
+		self.parts.wpn_fps_sho_abzats_m_big.stats = {
 			value = 5,
 			concealment = -4,
 			reload = -6,
@@ -45425,7 +45606,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 
 		self.parts.wpn_fps_sho_abzats_body_upgrade.supported = true
 		self.parts.wpn_fps_sho_abzats_body_upgrade.desc_id = ""
-		self.parts.wpn_fps_sho_abzats_body_upgrade.stats = { 
+		self.parts.wpn_fps_sho_abzats_body_upgrade.stats = {
 			value = 5,
 			recoil = -2,
 			spread = -4
@@ -45461,7 +45642,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 			value = 0,
 			zoom = 30
 		}
-		
+
 		self.parts.wpn_fps_upg_m712_scope.supported = true
 		self.parts.wpn_fps_upg_m712_scope.desc_id = "bm_wp_upg_o_2"
 		self.parts.wpn_fps_upg_m712_scope.stats = {
@@ -45616,9 +45797,9 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 		for used_part_id, i in pairs(self.parts) do
 			if self.parts[used_part_id] and self.parts[used_part_id].pcs then
 				if self.parts[used_part_id].type and self.parts[used_part_id].type == "vertical_grip" or
-					(self.parts[used_part_id].type == "magazine" and 
-						self.parts[used_part_id].stats and 
-						self.parts[used_part_id].stats.extra_ammo and 
+					(self.parts[used_part_id].type == "magazine" and
+						self.parts[used_part_id].stats and
+						self.parts[used_part_id].stats.extra_ammo and
 						self.parts[used_part_id].stats.extra_ammo >= 15) then
 					table.insert(self.parts.wpn_fps_ass_m203.forbids, used_part_id)
 				end
@@ -45937,7 +46118,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 		self.parts.wpn_fps_upg_ns_pis_tact_flash.stats = deep_clone(muzzle_device.muzz_con_a)
 		self.parts.wpn_fps_upg_ns_pis_tact_flash.custom_stats = deep_clone(muzzle_device.muzz_con_a)
 		self.parts.wpn_fps_upg_ns_pis_tact_flash.custom_stats.muzzleflash = "effects/payday2/particles/weapons/9mm_auto_silence_fps"
-		
+
 		self.parts.wpn_fps_upg_ns_pis_yhm.supported = true
 		self.parts.wpn_fps_upg_ns_pis_yhm.stats = deep_clone(muzzle_device.muzz_rec_c)
 		self.parts.wpn_fps_upg_ns_pis_yhm.custom_stats = nil
@@ -45965,7 +46146,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 		self.parts.wpn_fps_upg_ns_ass_yhm_slant.has_description = false
 		self.parts.wpn_fps_upg_ns_ass_yhm_slant.stats = deep_clone(muzzle_device.muzz_dual_c)
 		self.parts.wpn_fps_upg_ns_ass_yhm_slant.custom_stats = deep_clone(muzzle_device.muzz_dual_c)
-		
+
 		self.parts.wpn_fps_upg_ns_ass_vortex.supported = true
 		self.parts.wpn_fps_upg_ns_ass_vortex.has_description = true
 		self.parts.wpn_fps_upg_ns_ass_vortex.desc_id = "bm_wp_upg_flash_hider"
@@ -45980,7 +46161,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 
 		self.parts.wpn_fps_upg_ns_shot_nomad.supported = true
 		self.parts.wpn_fps_upg_ns_shot_nomad.stats = deep_clone(muzzle_device.muzz_rec_c)
-		self.parts.wpn_fps_upg_ns_shot_nomad.custom_stats = {}			
+		self.parts.wpn_fps_upg_ns_shot_nomad.custom_stats = {}
 
 	end
 
@@ -45989,14 +46170,14 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 		self.parts.wpn_fps_ass_akm_m_helo.stats = deep_clone(self.parts.wpn_fps_upg_m4_m_drum.stats)
 		self.parts.wpn_fps_ass_akm_m_helo.custom_stats = deep_clone(self.parts.wpn_fps_upg_m4_m_drum.custom_stats)
 	end
-	
+
 	if self.parts.wpn_fps_upg_o_p90_ring then
 		self.parts.wpn_fps_upg_o_p90_ring.supported = true
 		self.parts.wpn_fps_upg_o_p90_ring.desc_id = "bm_wp_upg_o_1_1"
 		self.parts.wpn_fps_upg_o_p90_ring.stats = {
 			value = 3,
 			zoom = 1
-		}		
+		}
 	end
 
 	if self.parts.wpn_fps_snp_dl_iron_sight then
@@ -46026,7 +46207,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 
 		self.parts.wpn_fps_snp_dl_o_rail.supported = true
 		self.parts.wpn_fps_snp_dl_o_rail.stats = { value = 0 }
-		
+
 		self.parts.wpn_fps_spec_bolt.supported = true
 		self.parts.wpn_fps_spec_bolt.stats = {
 			value = 5,
@@ -46056,10 +46237,10 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 		self.parts.wpn_fps_snp_dl_m_long.custom_stats = {
 			ads_speed_mult = 1.025
 		}
-		
+
 		self.parts.wpn_fps_snp_dl_s_gripext.pcs = nil
 		self.parts.wpn_fps_snp_dl_s_gripfold.pcs = nil
-		
+
 		self.parts.wpn_fps_snp_dl_s_gripext.supported = true
 		self.parts.wpn_fps_snp_dl_s_gripext.stats = deep_clone(stocks.fixed_to_nocheeks_stats)
 		self.parts.wpn_fps_snp_dl_s_gripext.custom_stats = deep_clone(stocks.fixed_to_nocheeks_stats)
@@ -46141,7 +46322,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 				has_description = true,
 				override = {
 					wpn_fps_lmg_mg42_reciever = {
-						unit = "units/mods/weapons/wpn_fps_lmg_mg42_receiver_hinature/wpn_fps_lmg_mg42_receiver_hinature" 
+						unit = "units/mods/weapons/wpn_fps_lmg_mg42_receiver_hinature/wpn_fps_lmg_mg42_receiver_hinature"
 					},
 					wpn_fps_lmg_mg42_b_mg42 = {
 						override = {},
@@ -46189,10 +46370,10 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 				has_description = true,
 				override = {
 					wpn_fps_pis_c96_body_standard = {
-						unit = "units/mods/weapons/wpn_fps_pis_c96_body_mkultra/wpn_fps_pis_c96_body_mkultra" 
+						unit = "units/mods/weapons/wpn_fps_pis_c96_body_mkultra/wpn_fps_pis_c96_body_mkultra"
 					},
 					wpn_fps_pis_c96_g_standard = {
-						unit = "units/mods/weapons/wpn_fps_pis_c96_g_mkultra/wpn_fps_pis_c96_g_mkultra" 
+						unit = "units/mods/weapons/wpn_fps_pis_c96_g_mkultra/wpn_fps_pis_c96_g_mkultra"
 					}
 				}
 			}
@@ -46248,7 +46429,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 					end
 				end
 			end
-		
+
 		--Logic & Reason
 			self.parts.wpn_fps_smg_shepheard_cnuy_yuuka = {
 				type = "legendary",
@@ -46270,7 +46451,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 						third_unit = "units/payday2/weapons/wpn_upg_dummy/wpn_upg_dummy"
 					},
 					wpn_fps_smg_shepheard_body = {
-						unit = "units/mods/weapons/wpn_fps_smg_shepheard_body_100kg/wpn_fps_smg_shepheard_body_100kg" 
+						unit = "units/mods/weapons/wpn_fps_smg_shepheard_body_100kg/wpn_fps_smg_shepheard_body_100kg"
 					},
 					wpn_fps_smg_shepheard_s_standard = {
 						unit = "units/mods/weapons/wpn_fps_smg_shepheard_s_100kg/wpn_fps_smg_shepheard_s_100kg"
@@ -46295,15 +46476,15 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 						self.parts.wpn_fps_smg_shepheard_cnuy_yuuka.override[used_part_id] = {
 							override = {},
 							adds = {},
-							unit = "units/mods/weapons/wpn_fps_smg_shepheard_body_100kg/wpn_fps_smg_shepheard_body_100kg" 
+							unit = "units/mods/weapons/wpn_fps_smg_shepheard_body_100kg/wpn_fps_smg_shepheard_body_100kg"
 						}
 					elseif self.parts[used_part_id].type == "magazine" then
 						self.parts.wpn_fps_smg_shepheard_cnuy_yuuka.override[used_part_id] = {
-							unit = "units/mods/weapons/wpn_fps_smg_shepheard_m_100kg/wpn_fps_smg_shepheard_m_100kg" 
+							unit = "units/mods/weapons/wpn_fps_smg_shepheard_m_100kg/wpn_fps_smg_shepheard_m_100kg"
 						}
 					elseif self.parts[used_part_id].type == "stock" then
 						self.parts.wpn_fps_smg_shepheard_cnuy_yuuka.override[used_part_id] = {
-							unit = "units/mods/weapons/wpn_fps_smg_shepheard_s_100kg/wpn_fps_smg_shepheard_s_100kg" 
+							unit = "units/mods/weapons/wpn_fps_smg_shepheard_s_100kg/wpn_fps_smg_shepheard_s_100kg"
 						}
 					elseif self.parts[used_part_id].type == "exclusive_set" then
 						table.insert(self.parts.wpn_fps_smg_shepheard_cnuy_yuuka.forbids, used_part_id)
@@ -46441,11 +46622,11 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 			end
 			--]]
 
-			--[[ --disabling this for now; if it works, it works. if it doesn't ¯\_(ツ)_/¯ 
+			--[[ --disabling this for now; if it works, it works. if it doesn't ¯\_(ツ)_/¯
 			if self[factory_id].uses_parts and (table.contains(self[factory_id].uses_parts, "wpn_fps_upg_o_sig") or table.contains(self[factory_id].uses_parts, "wpn_fps_upg_o_xpsg33_magnifier"))
 			and not table.contains(self[factory_id].uses_parts, "wpn_fps_upg_fl_ass_smg_sho_pointshoot")  then
 				self[factory_id].uses_parts[500] = "wpn_fps_upg_fl_ass_smg_sho_pointshoot"
-			
+
 				self[factory_id .. "_npc"].uses_parts = deep_clone(self[factory_id].uses_parts)
 			end
 
@@ -46489,7 +46670,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 											"wpn_fps_upg_fl_ass_smg_sho_pointshoot"
 										}
 									end
-								end 
+								end
 							end
 						end
 					end
@@ -46576,7 +46757,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 							table.insert(self.parts[used_part_id].forbids, part_id)
 						end
 					end
-				end	
+				end
 				attachment_list = {
 					"wpn_fps_upg_ns_ass_filter"
 				}
@@ -46795,7 +46976,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 					end
 				end
 			end
-			
+
 			if table.contains(self[factory_id].uses_parts, "wpn_fps_ass_m16_s_fixed") then
 				attachment_list = {
 
@@ -46918,8 +47099,8 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 					end
 				end
 			end
-			if table.contains(self[factory_id].default_blueprint, "wpn_upg_ak_s_skfoldable_vanilla") 
-				or table.contains(self[factory_id].default_blueprint, "wpn_fps_ass_asval_s_standard") 
+			if table.contains(self[factory_id].default_blueprint, "wpn_upg_ak_s_skfoldable_vanilla")
+				or table.contains(self[factory_id].default_blueprint, "wpn_fps_ass_asval_s_standard")
 				or table.contains(self[factory_id].default_blueprint, "wpn_fps_smg_coal_s_standard") then
 				attachment_list = {
 					"wpn_fps_ass_galil_s_skeletal",
@@ -47075,7 +47256,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 	--Glock Exclusive set
 	for k, used_part_id in ipairs(self.wpn_fps_pis_g17.uses_parts) do
 		if self.parts[used_part_id] and self.parts[used_part_id].type then
-			if not table.contains(self.wpn_fps_pis_g17.default_blueprint, used_part_id) and 
+			if not table.contains(self.wpn_fps_pis_g17.default_blueprint, used_part_id) and
 			not table.contains(self.parts.wpn_fps_pis_g17_ck.forbids, used_part_id) then
 				if self.parts[used_part_id].type == "slide" then
 					table.insert(self.parts.wpn_fps_pis_g17_ck.forbids, used_part_id)
@@ -47230,26 +47411,26 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 				self[factory_id].adds.wpn_fps_upg_vg_ass_smg_stubby = deep_clone(self[factory_id].adds.wpn_fps_upg_fl_pis_laser)
 				self[factory_id].adds.wpn_fps_smg_schakal_vg_surefire = deep_clone(self[factory_id].adds.wpn_fps_upg_fl_pis_laser)
 			end
-	
+
 			self[factory_id .. "_npc"].uses_parts = deep_clone(self[factory_id].uses_parts)
 			self[factory_id .. "_npc"].override = deep_clone(self[factory_id].override)
-	
+
 			for part_id, i in pairs(self[factory_id].override) do
 				attachment_list = {
 					"wpn_fps_upg_vg_ass_smg_verticalgrip",
 					"wpn_fps_upg_vg_ass_smg_stubby",
 					"wpn_fps_smg_schakal_vg_surefire"
 				}
-	
+
 				for _, override_id in ipairs(attachment_list) do
-					if part_id == override_id then	
+					if part_id == override_id then
 						for k, uses_part_id in pairs(self[factory_id].uses_parts) do
-							if self.parts[uses_part_id] and self.parts[uses_part_id].type and self.parts[uses_part_id].type == "gadget" and 
+							if self.parts[uses_part_id] and self.parts[uses_part_id].type and self.parts[uses_part_id].type == "gadget" and
 								not self[factory_id].override[override_id].allow_gadgets then
 
 								table.insert(self[factory_id].override[override_id].forbids, uses_part_id)
 
-							end 
+							end
 						end
 					end
 				end
@@ -47467,7 +47648,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 				end
 			end
 		end
-	end	
+	end
 	if self.parts.wpn_fps_ass_m4_body_tantone then
 		for k, used_part_id in ipairs(self.wpn_fps_ass_m4.uses_parts) do
 			if self.parts[used_part_id] and self.parts[used_part_id].type then
@@ -47529,7 +47710,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 	if self.parts.wpn_fps_pis_m1911_body_killer then
 		for k, used_part_id in ipairs(self.wpn_fps_pis_m1911.uses_parts) do
 			if self.parts[used_part_id] and self.parts[used_part_id].type then
-				if not table.contains(self.wpn_fps_pis_m1911.default_blueprint, used_part_id) and 
+				if not table.contains(self.wpn_fps_pis_m1911.default_blueprint, used_part_id) and
 				not table.contains(self.parts.wpn_fps_pis_m1911_body_killer.forbids, used_part_id) then
 					if self.parts[used_part_id].type == "slide" or
 					self.parts[used_part_id].type == "sight" then
@@ -47895,7 +48076,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 					adds = {},
 					override = {},
 					unit = "units/payday2_cash/safes/sputnik/weapons/wpn_fps_ass_74_rodina_pts/wpn_upg_ak_fg_legend",
-					third_unit = "units/payday2_cash/safes/sputnik/weapons/wpn_fps_ass_74_rodina_pts/wpn_third_upg_ak_fg_legend",	
+					third_unit = "units/payday2_cash/safes/sputnik/weapons/wpn_fps_ass_74_rodina_pts/wpn_third_upg_ak_fg_legend",
 				}
 			elseif self.parts[used_part_id].type == "grip" then
 				self.parts.wpn_fps_upg_vlad_rodina_legend.override[used_part_id] = {
@@ -48215,7 +48396,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 			if self.parts[used_part_id].type == "barrel" then
 				self.parts.wpn_fps_upg_the_big_kahuna.override[used_part_id] = {
 					unit = "units/payday2_cash/safes/surf/weapons/wpn_fps_shot_r870_b_legend/wpn_fps_shot_r870_b_legendary",
-					third_unit = "units/payday2_cash/safes/surf/weapons/wpn_fps_shot_r870_b_legend/wpn_third_shot_r870_b_legendary",	
+					third_unit = "units/payday2_cash/safes/surf/weapons/wpn_fps_shot_r870_b_legend/wpn_third_shot_r870_b_legendary",
 				}
 			elseif self.parts[used_part_id].type == "magazine" or self.parts[used_part_id].type == "grip" or self.parts[used_part_id].type == "barrel_ext" then
 				self.parts.wpn_fps_upg_the_big_kahuna.override[used_part_id] = {
@@ -48285,7 +48466,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 			elseif self.parts[used_part_id].type == "grip" then
 				self.parts.wpn_fps_upg_santa_slayers_legend.override[used_part_id] = {
 					unit = "units/payday2_cash/safes/flake/weapons/wpn_fps_pis_1911_g_legendary/wpn_fps_pis_1911_g_legendary",
-					third_unit = "units/payday2_cash/safes/flake/weapons/wpn_fps_pis_1911_g_legendary/wpn_third_pis_1911_g_legendary"	
+					third_unit = "units/payday2_cash/safes/flake/weapons/wpn_fps_pis_1911_g_legendary/wpn_third_pis_1911_g_legendary"
 				}
 			elseif self.parts[used_part_id].type == "vertical_grip" then
 				self.parts.wpn_fps_upg_santa_slayers_legend.override[used_part_id] = {
@@ -48296,7 +48477,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 			end
 		end
 	end
-	
+
 	self.parts.wpn_fps_upg_santa_slayers_legend.override.wpn_fps_upg_fl_ass_peq15_flashlight = {
 		a_obj = "g_laser"
 	}
@@ -48319,11 +48500,11 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 		override = {
 			wpn_fps_snp_model70_b_standard = {
 				unit = "units/payday2_cash/safes/bah/weapons/wpn_fps_snp_model70_legendary_pts/wpn_fps_snp_model70_b_legend",
-				third_unit = "units/payday2_cash/safes/bah/weapons/wpn_fps_snp_model70_legendary_pts/wpn_third_snp_model70_b_legend"		
+				third_unit = "units/payday2_cash/safes/bah/weapons/wpn_fps_snp_model70_legendary_pts/wpn_third_snp_model70_b_legend"
 			},
 			wpn_fps_snp_model70_s_standard = {
 				unit = "units/payday2_cash/safes/bah/weapons/wpn_fps_snp_model70_legendary_pts/wpn_fps_snp_model70_s_legend",
-				third_unit = "units/payday2_cash/safes/bah/weapons/wpn_fps_snp_model70_legendary_pts/wpn_third_snp_model70_s_legend"		
+				third_unit = "units/payday2_cash/safes/bah/weapons/wpn_fps_snp_model70_legendary_pts/wpn_third_snp_model70_s_legend"
 			}
 		}
 	}
@@ -48333,12 +48514,12 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 			if self.parts[used_part_id].type == "barrel" then
 				self.parts.wpn_fps_upg_baaah_legend.override[used_part_id] = {
 					unit = "units/payday2_cash/safes/bah/weapons/wpn_fps_snp_model70_legendary_pts/wpn_fps_snp_model70_b_legend",
-					third_unit = "units/payday2_cash/safes/bah/weapons/wpn_fps_snp_model70_legendary_pts/wpn_third_snp_model70_b_legend"	
+					third_unit = "units/payday2_cash/safes/bah/weapons/wpn_fps_snp_model70_legendary_pts/wpn_third_snp_model70_b_legend"
 				}
 			elseif self.parts[used_part_id].type == "stock" then
 				self.parts.wpn_fps_upg_baaah_legend.override[used_part_id] = {
 					unit = "units/payday2_cash/safes/bah/weapons/wpn_fps_snp_model70_legendary_pts/wpn_fps_snp_model70_s_legend",
-					third_unit = "units/payday2_cash/safes/bah/weapons/wpn_fps_snp_model70_legendary_pts/wpn_third_snp_model70_s_legend"	
+					third_unit = "units/payday2_cash/safes/bah/weapons/wpn_fps_snp_model70_legendary_pts/wpn_third_snp_model70_s_legend"
 				}
 			end
 		end
@@ -48494,7 +48675,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 			},
 		}
 	}
-	
+
 	for k, used_part_id in ipairs(self.wpn_fps_ass_m16.uses_parts) do
 		if self.parts[used_part_id] and self.parts[used_part_id].type then
 			if self.parts[used_part_id].type == "barrel" then
@@ -48772,7 +48953,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 					third_unit = "units/payday2_cash/safes/grunt/weapons/wpn_third_ass_tecci_legendary/wpn_third_ass_tecci_fg_legend",
 				}
 			elseif self.parts[used_part_id].type == "stock" then
-				self.parts.wpn_fps_upg_tecci_legend.override[used_part_id] = {	
+				self.parts.wpn_fps_upg_tecci_legend.override[used_part_id] = {
 					unit = "units/payday2_cash/safes/grunt/weapons/wpn_fps_ass_tecci_legendary/wpn_fps_ass_tecci_s_legend",
 					third_unit = "units/payday2_cash/safes/grunt/weapons/wpn_third_ass_tecci_legendary/wpn_third_ass_tecci_s_legend",
 				}
@@ -48814,7 +48995,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 			},
 			wpn_fps_ass_m14_body_ruger = {
 				unit = "units/payday2_cash/safes/lones/weapons/wpn_fps_ass_m14_legendary_pts/wpn_fps_ass_m14_body_legendary",
-				third_unit = "units/payday2_cash/safes/lones/weapons/wpn_fps_ass_m14_legendary_pts/wpn_third_ass_m14_body_legendary",			
+				third_unit = "units/payday2_cash/safes/lones/weapons/wpn_fps_ass_m14_legendary_pts/wpn_third_ass_m14_body_legendary",
 			},
 			wpn_fps_ass_m14_body_upper = {
 				unit = "units/payday2_cash/safes/lones/weapons/wpn_fps_ass_m14_legendary_pts/wpn_fps_ass_m14_body_upper_legendary",
@@ -48835,9 +49016,9 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 					third_unit = "units/payday2_cash/safes/lones/weapons/wpn_fps_ass_m14_legendary_pts/wpn_third_ass_m14_b_legendary",
 				}
 			elseif self.parts[used_part_id].type == "stock" then
-				self.parts.wpn_fps_upg_m14_legend.override[used_part_id] = {	
+				self.parts.wpn_fps_upg_m14_legend.override[used_part_id] = {
 					unit = "units/payday2_cash/safes/lones/weapons/wpn_fps_ass_m14_legendary_pts/wpn_fps_ass_m14_body_legendary",
-					third_unit = "units/payday2_cash/safes/lones/weapons/wpn_fps_ass_m14_legendary_pts/wpn_third_ass_m14_body_legendary",		
+					third_unit = "units/payday2_cash/safes/lones/weapons/wpn_fps_ass_m14_legendary_pts/wpn_third_ass_m14_body_legendary",
 				}
 			end
 		end
@@ -48870,7 +49051,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 			wpn_fps_upg_m4_g_standard = {
 				unit = "units/payday2/weapons/wpn_upg_dummy/wpn_upg_dummy",
 				third_unit = "units/payday2/weapons/wpn_upg_dummy/wpn_upg_dummy",
-			},			
+			},
 			wpn_fps_shot_shorty_m_extended_short = {
 				unit = "units/payday2/weapons/wpn_upg_dummy/wpn_upg_dummy",
 				third_unit = "units/payday2/weapons/wpn_upg_dummy/wpn_upg_dummy",
@@ -48894,11 +49075,11 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 			wpn_fps_snp_tti_g_grippy = {
 				unit = "units/payday2/weapons/wpn_upg_dummy/wpn_upg_dummy",
 				third_unit = "units/payday2/weapons/wpn_upg_dummy/wpn_upg_dummy",
-			},				
+			},
 			wpn_fps_upg_g_m4_surgeon = {
 				unit = "units/payday2/weapons/wpn_upg_dummy/wpn_upg_dummy",
 				third_unit = "units/payday2/weapons/wpn_upg_dummy/wpn_upg_dummy",
-			},			
+			},
 			wpn_fps_shot_r870_s_nostock_vanilla = {
 				unit = "units/payday2_cash/safes/lones/weapons/wpn_fps_shot_shorty_legendary_pts/wpn_fps_shot_shorty_s_legendary",
 				third_unit = "units/payday2_cash/safes/lones/weapons/wpn_fps_shot_shorty_legendary_pts/wpn_third_shot_shorty_s_legendary",
@@ -48929,7 +49110,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 				unit = "units/payday2_cash/safes/lones/weapons/wpn_fps_shot_shorty_legendary_pts/wpn_fps_shot_shorty_s_legendary",
 				third_unit = "units/payday2_cash/safes/lones/weapons/wpn_fps_shot_shorty_legendary_pts/wpn_third_shot_shorty_s_legendary",
 				forbids = {}
-			}			
+			}
 		}
 	}
 
@@ -48941,20 +49122,20 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 					third_unit = "units/payday2_cash/safes/lones/weapons/wpn_fps_shot_shorty_legendary_pts/wpn_third_shot_shorty_b_legendary",
 				}
 			elseif self.parts[used_part_id].type == "foregrip" then
-				self.parts.wpn_fps_upg_serbu_legend.override[used_part_id] = {	
+				self.parts.wpn_fps_upg_serbu_legend.override[used_part_id] = {
 					unit = "units/payday2_cash/safes/lones/weapons/wpn_fps_shot_shorty_legendary_pts/wpn_fps_shot_shorty_fg_legendary",
 					third_unit = "units/payday2_cash/safes/lones/weapons/wpn_fps_shot_shorty_legendary_pts/wpn_third_shot_shorty_fg_legendary",
 				}
 			elseif self.parts[used_part_id].type == "grip" then
-				self.parts.wpn_fps_upg_serbu_legend.override[used_part_id] = {	
+				self.parts.wpn_fps_upg_serbu_legend.override[used_part_id] = {
 					unit = "units/payday2/weapons/wpn_upg_dummy/wpn_upg_dummy",
 					third_unit = "units/payday2/weapons/wpn_upg_dummy/wpn_upg_dummy",
 				}
 			elseif self.parts[used_part_id].type == "stock" then
-				self.parts.wpn_fps_upg_serbu_legend.override[used_part_id] = {	
+				self.parts.wpn_fps_upg_serbu_legend.override[used_part_id] = {
 					unit = "units/payday2_cash/safes/lones/weapons/wpn_fps_shot_shorty_legendary_pts/wpn_fps_shot_shorty_s_legendary",
 					third_unit = "units/payday2_cash/safes/lones/weapons/wpn_fps_shot_shorty_legendary_pts/wpn_third_shot_shorty_s_legendary",
-					forbids = {}		
+					forbids = {}
 				}
 			end
 		end
@@ -49034,13 +49215,13 @@ if self.wpn_fps_pis_shatters_fury then
 	}
 	self.wpn_fps_pis_shatters_fury.override = self.wpn_fps_pis_shatters_fury.override or {}
 	self.wpn_fps_pis_shatters_fury.override.wpn_fps_pis_rage_lock = { forbids = {} }
-	self.wpn_fps_pis_shatters_fury.override.wpn_fps_pis_shatters_fury_body_smooth = { 
+	self.wpn_fps_pis_shatters_fury.override.wpn_fps_pis_shatters_fury_body_smooth = {
 		override = {
 			wpn_fps_pis_shatters_fury_body_standard = {
 				unit = "units/payday2/weapons/wpn_upg_dummy/wpn_upg_dummy",
 				third_unit = "units/payday2/weapons/wpn_upg_dummy/wpn_upg_dummy"
-			} 
-		} 
+			}
+		}
 	}
 
 	for i, part_id in pairs(self.wpn_fps_pis_shatters_fury.uses_parts) do
@@ -49057,7 +49238,7 @@ if self.wpn_fps_pis_shatters_fury then
 	end
 	table.insert(self.wpn_fps_pis_shatters_fury.uses_parts, "wpn_fps_upg_o_xpsg33_magnifier")
 	table.insert(self.wpn_fps_pis_shatters_fury.uses_parts, "wpn_fps_upg_o_sig")
-	table.insert(self.wpn_fps_pis_shatters_fury.uses_parts, "wpn_fps_upg_o_uh")		
+	table.insert(self.wpn_fps_pis_shatters_fury.uses_parts, "wpn_fps_upg_o_uh")
 	table.insert(self.wpn_fps_pis_shatters_fury.uses_parts, "wpn_fps_upg_o_fc1")
 	table.insert(self.wpn_fps_pis_shatters_fury.uses_parts, "wpn_fps_upg_o_tf90")
 	table.insert(self.wpn_fps_pis_shatters_fury.uses_parts, "wpn_fps_upg_o_bmg")
@@ -49113,14 +49294,14 @@ if self.wpn_fps_pis_socom then
 	self.parts.wpn_fps_upg_fl_pis_socomlam.stats = { value = 1 }
 	--Part Additions
 	table.insert(self.wpn_fps_pis_usp.uses_parts, "wpn_fps_upg_fl_pis_socomlam")
-	table.insert(self.wpn_fps_pis_usp_npc.uses_parts, "wpn_fps_upg_fl_pis_socomlam")		
+	table.insert(self.wpn_fps_pis_usp_npc.uses_parts, "wpn_fps_upg_fl_pis_socomlam")
 
-	self.wpn_fps_pis_usp_npc.uses_parts = deep_clone(self.wpn_fps_pis_usp.uses_parts)	
+	self.wpn_fps_pis_usp_npc.uses_parts = deep_clone(self.wpn_fps_pis_usp.uses_parts)
 
 	table.insert(self.wpn_fps_pis_x_usp.uses_parts, "wpn_fps_upg_fl_pis_socomlam")
-	table.insert(self.wpn_fps_pis_x_usp_npc.uses_parts, "wpn_fps_upg_fl_pis_socomlam")		
+	table.insert(self.wpn_fps_pis_x_usp_npc.uses_parts, "wpn_fps_upg_fl_pis_socomlam")
 
-	self.wpn_fps_pis_x_usp_npc.uses_parts = deep_clone(self.wpn_fps_pis_x_usp.uses_parts)	
+	self.wpn_fps_pis_x_usp_npc.uses_parts = deep_clone(self.wpn_fps_pis_x_usp.uses_parts)
 end
 
 --Deal with legendary and semi-hidden mods so they don't waste time triggering custom mod stat generation.
@@ -49208,7 +49389,7 @@ for _, part in pairs(self.parts) do
 					cosmetic_part = nil
 				end
 			end
-	
+
 			if not cosmetic_part then
 				self:generate_custom_mod_stats(part)
 			end
@@ -49240,11 +49421,11 @@ for _, part in pairs(self.parts) do
 			end
 			if no_vfgs and part.type == "vertical_grip" then
 				part.pcs = nil
-			end 
+			end
 		end
 	end
 end
-	
+
 --SC mod shit below--
 
 	self.parts.wpn_fps_upg_a_slug_fire = {
@@ -49261,7 +49442,7 @@ end
 			value = 10,
 			concealment = -5,
 			total_ammo_mod = -5,
-			damage = 74,	
+			damage = 74,
 			recoil = -2,
 			spread = 12,
 			suppression = -1,
@@ -49321,7 +49502,7 @@ end
 			reload = 5,
 			extra_ammo = -30,
 		}
-	}		
+	}
 	self.parts.wpn_fps_upg_extra_mp_lock = {
 		type = "extra",
 		name_id = "bm_wp_upg_extra_mp_lock",
@@ -49445,7 +49626,7 @@ end
 			value = 0,
 			total_ammo_mod = 0,
 			damage = 0
-		},		
+		},
 		internal_part = true
 	}
 	self.parts.wpn_fps_upg_ammo_40sw = {
@@ -49509,7 +49690,7 @@ end
 		"wpn_fps_upg_i_slower_rof"
 	})
 	table.list_append(self.wpn_fps_lmg_hk21.uses_parts, {
-		"wpn_fps_upg_i_faster_rof"	
+		"wpn_fps_upg_i_faster_rof"
 	})
 	table.list_append(self.wpn_fps_lmg_m249.uses_parts, {
 		"wpn_fps_upg_i_faster_rof"
@@ -49582,46 +49763,46 @@ if self.wpn_fps_smg_ak5s then
 			wpn_fps_ass_g36_g_sniper_bit = {unit="units/mods/weapons/wpn_fps_ass_g36_pts/wpn_fps_ass_g36_g_sniper_bit_black"}
 			}
 	end
-	
+
 	if SystemFS:exists("assets/mod_overrides/SCAR-H Improved - Black/units") then
 			self.parts.wpn_fps_ass_scar_m_extended.override = {
 			wpn_fps_ass_scar_m_extended = {unit="units/mods/weapons/wpn_fps_ass_scar_pts/wpn_fps_ass_scar_m_extended_black"},
 			wpn_fps_ass_scar_m_extended_strap = {unit="units/mods/weapons/wpn_fps_ass_scar_pts/wpn_fps_ass_scar_m_extended_strap_black"}
 			}
 	end
-	
+
 	if SystemFS:exists("assets/mod_overrides/SCAR-H Improved - Black/units") then
 			self.parts.wpn_fps_ass_scar_g_tan.override = {
 			wpn_fps_ass_scar_g_tan = {unit="units/mods/weapons/wpn_fps_ass_scar_pts/wpn_fps_ass_scar_g_tan_2"},
 			}
 	end
-	
+
 	if SystemFS:exists("assets/mod_overrides/Eagle Heavy Two Tone/units") then
 			self.parts.wpn_fps_ass_scar_m_extended.override = {
 			wpn_fps_ass_scar_m_extended = {unit="units/mods/weapons/wpn_fps_ass_scar_pts/wpn_fps_ass_scar_m_extended_black"},
 			wpn_fps_ass_scar_m_extended_strap = {unit="units/mods/weapons/wpn_fps_ass_scar_pts/wpn_fps_ass_scar_m_extended_strap_black"}
 			}
 	end
-	
+
 	if SystemFS:exists("assets/mod_overrides/Eagle Heavy Two Tone (Speedpull)/units") then
 			self.parts.wpn_fps_ass_scar_m_extended.override = {
 			wpn_fps_ass_scar_m_extended = {unit="units/mods/weapons/wpn_fps_ass_scar_pts/wpn_fps_ass_scar_m_extended_black"},
 			wpn_fps_ass_scar_m_extended_strap = {unit="units/mods/weapons/wpn_fps_ass_scar_pts/wpn_fps_ass_scar_m_extended_strap_black"}
 			}
 	end
-	
+
 	if SystemFS:exists("assets/mod_overrides/AK5 Black/units") then
 			self.parts.wpn_fps_ass_ak5_s_pts.override = {
 			wpn_fps_ass_ak5_s_pts = {unit="units/mods/weapons/wpn_fps_ass_ak5_pts/wpn_fps_ass_ak5_s_pts_black"}
 			}
 	end
-	
+
 	if SystemFS:exists("assets/mod_overrides/Extra Attachments Compilation+-/main.xml") then
 			self.parts.wpn_fps_vg_vmp_pod.pcs = nil
 			self.parts.wpn_fps_vg_vmp_cheems.pcs = nil
 			self.parts.wpn_fps_vg_vmp_vert.pcs = nil
 	end
-	
+
 	if SystemFS:exists("assets/mod_overrides/Vertical grip attachment pack/main.xml") then
 			self.parts.wpn_fps_vg_vmp_stubby.pcs = nil
 			self.parts.wpn_fps_vg_vmp_medium.pcs = nil
@@ -49630,7 +49811,7 @@ if self.wpn_fps_smg_ak5s then
 			self.parts.wpn_fps_vg_vmp_cheems.pcs = nil
 			self.parts.wpn_fps_vg_vmp_vert.pcs = nil
 	end
-	
+
 	if SystemFS:exists("assets/mod_overrides/Improved weapon modification/mod.txt") then
 			self.parts.wpn_fps_ass_ak_fg_waffle.pcs = nil
 	end
@@ -49643,13 +49824,13 @@ if self.wpn_fps_smg_ak5s then
 		self.parts.wpn_fps_vg_vmp_cheems.pcs = nil
 		self.parts.wpn_fps_vg_vmp_vert.pcs = nil
 	end
-	
+
 	if SystemFS:exists("assets/mod_overrides/AMCAR Various Attachment/main.xml") then
 			self.parts.wpn_fps_ass_m4_m_stick_amcar.pcs = nil
 	end
-	
+
 	if SystemFS:exists("mods/Original Pack/mod.txt") then
-		self.parts.wpn_fps_ass_s552_m_ak.pcs = nil					
+		self.parts.wpn_fps_ass_s552_m_ak.pcs = nil
 		self.parts.wpn_fps_upg_ns_ass_smg_heavy.pcs = nil
 		self.parts.wpn_fps_upg_ns_ass_smg_russian.pcs = nil
 		self.parts.wpn_fps_ass_m4_m_stick.pcs = nil
@@ -49662,16 +49843,16 @@ if self.wpn_fps_smg_ak5s then
 		self.parts.wpn_fps_vg_vmp_pod.pcs = nil
 		self.parts.wpn_fps_vg_vmp_cheems.pcs = nil
 		self.parts.wpn_fps_vg_vmp_vert.pcs = nil
-		self.parts.wpn_fps_aug_b_big.pcs = nil		
+		self.parts.wpn_fps_aug_b_big.pcs = nil
 	end
 
 	self.parts.wpn_fps_smg_thompson_barrel_short.override.wpn_fps_smg_thompson_fg_custom = {unit="units/mods/weapons/wpn_fps_smg_m1928_pts/wpn_fps_smg_thompson_fg_custom_short"}
-	
+
 	table.insert(self.parts.wpn_fps_ass_g36_s_sl8.forbids, "wpn_fps_ass_g36_g_sniper")
 
 	table.insert(self.parts.wpn_fps_m4_uupg_b_sd.forbids, "wpn_fps_upg_ns_pis_putnik")
 
-	
+
 	self.parts.wpn_fps_pis_judge_body_raybull.animations = {
 		reload_not_empty = "reload_not_empty",
 		reload = "reload"
@@ -49681,13 +49862,13 @@ if self.wpn_fps_smg_ak5s then
 	self.parts.wpn_fps_snp_r700_b_short.override = {
 		wpn_fps_snp_r700_o_is = {unit="units/mods/weapons/wpn_fps_snp_r700_pts/wpn_fps_snp_r700_o_is_short"}
 	}
-	
+
 	self.parts.wpn_fps_shot_m37_b_short.override = {
 		wpn_fps_shot_m37_b_front_prong = {unit="units/mods/weapons/wpn_fps_shot_m37_pts/wpn_fps_shot_m37_b_front_prong_2"}
 	}
-	
+
 	self.parts.wpn_fps_shot_shorty_s_solid_short.forbids={"wpn_fps_shot_r870_b_ithaca"}
-	
+
 	self.parts.wpn_fps_shot_shorty_s_nostock_short.forbids={"wpn_fps_shot_r870_b_ithaca"}
 
 	-- Test
@@ -49847,12 +50028,12 @@ if self.wpn_fps_smg_ak5s then
 	self.parts.wpn_fps_shot_m37_b_ridge.forbids={"wpn_fps_shot_m37_o_circle", "wpn_fps_shot_m37_o_classic"}
 	self.parts.wpn_fps_shot_m37_o_circle.forbids={"wpn_fps_shot_m37_b_ridge"}
 	self.parts.wpn_fps_shot_m37_o_classic.forbids={"wpn_fps_shot_m37_b_ridge"}
-	
-	
+
+
 	self.parts.wpn_fps_pis_m1911_sl_hardballer.override = {
 		wpn_fps_pis_m1911_sl_standard_classic_dots = {unit="units/mods/weapons/wpn_fps_pis_m1911_pts/wpn_fps_pis_m1911_sl_hardballer_classic_dots"}
 	}
-	
+
 	self.parts.wpn_fps_pis_m1911_sl_match.override = {
 		wpn_fps_pis_m1911_sl_standard_classic_dots = {unit="units/mods/weapons/wpn_fps_pis_m1911_pts/wpn_fps_pis_m1911_sl_match_classic_dots"}
 	}
@@ -49905,28 +50086,28 @@ Hooks:PostHook(WeaponFactoryTweakData, "init", "dd5paintf", function(self)
 
 		if self.parts.wpn_fps_upg_o_cqb then --Vanilla Mod Pack
 
-			table.insert(self.wpn_fps_ass_dd5.uses_parts, "wpn_fps_upg_fl_ass_smg_sho_pointshoot")			
-			table.insert(self.wpn_fps_ass_dd5.uses_parts, "wpn_fps_ass_m4_s_russian")		
+			table.insert(self.wpn_fps_ass_dd5.uses_parts, "wpn_fps_upg_fl_ass_smg_sho_pointshoot")
+			table.insert(self.wpn_fps_ass_dd5.uses_parts, "wpn_fps_ass_m4_s_russian")
 			table.insert(self.wpn_fps_ass_dd5.uses_parts, "wpn_fps_ass_m4_g_sg")
-			table.insert(self.wpn_fps_ass_dd5.uses_parts, "wpn_fps_ass_tecci_s_minicontra")		
+			table.insert(self.wpn_fps_ass_dd5.uses_parts, "wpn_fps_ass_tecci_s_minicontra")
 
 			self.parts.wpn_fps_upg_fl_ass_smg_sho_pointshoot.stance_mod.wpn_fps_ass_dd5 = {
 				translation = Vector3(-4, 0, -13),
-				rotation = Rotation(0, 0, -35)			
+				rotation = Rotation(0, 0, -35)
 			}
-		
+
 		end
 
 		if self.parts.wpn_fps_m4_g_wrap then
-		
+
 			table.insert(self.wpn_fps_ass_dd5.uses_parts, "wpn_fps_m4_g_wrap")
-		
+
 		end
 
 		if self.parts.wpn_fps_upg_o_claymore then --Vanilla-Style Sights
-		
+
 			self.parts.wpn_fps_upg_o_claymore.stance_mod.wpn_fps_ass_dd5 = deep_clone(self.parts.wpn_fps_upg_o_specter.stance_mod.wpn_fps_ass_m16)
-			self.parts.wpn_fps_upg_o_katabatic.stance_mod.wpn_fps_ass_dd5 = deep_clone(self.parts.wpn_fps_upg_o_specter.stance_mod.wpn_fps_ass_m16)	
+			self.parts.wpn_fps_upg_o_katabatic.stance_mod.wpn_fps_ass_dd5 = deep_clone(self.parts.wpn_fps_upg_o_specter.stance_mod.wpn_fps_ass_m16)
 			self.parts.wpn_fps_upg_o_ncstar_micro_1.stance_mod.wpn_fps_ass_dd5 = deep_clone(self.parts.wpn_fps_upg_o_specter.stance_mod.wpn_fps_ass_m16)
 			self.parts.wpn_fps_upg_o_northtac_ass.stance_mod.wpn_fps_ass_dd5 = deep_clone(self.parts.wpn_fps_upg_o_specter.stance_mod.wpn_fps_ass_m16)
 
@@ -49939,20 +50120,20 @@ Hooks:PostHook(WeaponFactoryTweakData, "init", "dd5paintf", function(self)
 
 			table.insert(self.wpn_fps_ass_dd5.uses_parts, "wpn_fps_upg_m_308pmag")
 			table.insert(self.wpn_fps_ass_dd5.uses_parts, "wpn_fps_upg_m_kac10")
-			table.insert(self.wpn_fps_ass_dd5.uses_parts, "wpn_fps_upg_m_308dmmag")		
-			table.insert(self.wpn_fps_ass_dd5.uses_parts, "wpn_fps_upg_m_kac20")	
-		
+			table.insert(self.wpn_fps_ass_dd5.uses_parts, "wpn_fps_upg_m_308dmmag")
+			table.insert(self.wpn_fps_ass_dd5.uses_parts, "wpn_fps_upg_m_kac20")
+
 		end
 
 		if self.parts.wpn_fps_upg_o_handle_ar45 then --SBR .45
-		
+
 			table.insert(self.wpn_fps_ass_dd5.uses_parts, "wpn_fps_upg_o_handle_ar45")
 			table.insert(self.wpn_fps_ass_dd5.uses_parts, "wpn_fps_upg_o_mbus_pro_ar45")
 			table.insert(self.wpn_fps_ass_dd5.uses_parts, "wpn_fps_smg_ar45_fg_long")
 
 			self.parts.wpn_fps_smg_ar45_fg_long.forbids = self.parts.wpn_fps_smg_ar45_fg_long.forbids or {}
 			table.insert(self.parts.wpn_fps_smg_ar45_fg_long.forbids, "wpn_fps_ass_dd5_b_short")
-			
+
 			self.parts.wpn_fps_upg_o_mbus_pro_ar45.forbids = self.parts.wpn_fps_upg_o_mbus_pro_ar45.forbids or {}
 			table.insert(self.parts.wpn_fps_upg_o_mbus_pro_ar45.forbids, "wpn_fps_ass_dd5_o_dd_extra")
 
@@ -49961,7 +50142,7 @@ Hooks:PostHook(WeaponFactoryTweakData, "init", "dd5paintf", function(self)
 
 			self.parts.wpn_fps_upg_o_mbus_pro_ar45.stance_mod.wpn_fps_ass_dd5 = {
 				translation = Vector3(0, -8, -0),
-				rotation = Rotation(0, 0, 0)			
+				rotation = Rotation(0, 0, 0)
 			}
 
 			self.wpn_fps_ass_dd5.override = self.wpn_fps_ass_dd5.override or {}
@@ -49975,7 +50156,7 @@ Hooks:PostHook(WeaponFactoryTweakData, "init", "dd5paintf", function(self)
 					wpn_fps_upg_o_mbus_pro_rear = {
 						unit = "units/mods/weapons/wpn_fps_upg_o_mbus_pro_ar45/wpn_fps_upg_o_mbus_pro_rear",
 						third_unit = "units/mods/weapons/wpn_fps_upg_o_mbus_pro_ar45/wpn_third_upg_o_mbus_pro_rear",
-						a_obj = "a_o_rear"				
+						a_obj = "a_o_rear"
 					}
 				}
 			}
@@ -49992,7 +50173,7 @@ Hooks:PostHook(WeaponFactoryTweakData, "init", "dd5paintf", function(self)
 							wpn_fps_upg_o_mbus_pro_rear = {
 								unit = "units/mods/weapons/wpn_fps_upg_o_mbus_pro_ar45/wpn_fps_upg_o_mbus_pro_rear",
 								third_unit = "units/mods/weapons/wpn_fps_upg_o_mbus_pro_ar45/wpn_third_upg_o_mbus_pro_rear",
-								a_obj = "a_o_rear"				
+								a_obj = "a_o_rear"
 							}
 						}
 					},
@@ -50001,7 +50182,7 @@ Hooks:PostHook(WeaponFactoryTweakData, "init", "dd5paintf", function(self)
 					}
 				}
 			}
-		
+
 		end
 
 	end
@@ -50020,52 +50201,52 @@ Hooks:PostHook(WeaponFactoryTweakData, "init", "mallninj762init", function(self)
 			table.insert(self.wpn_fps_ass_ar47.uses_parts, "wpn_fps_ass_m4_s_russian")
 			table.insert(self.wpn_fps_ass_ar47.uses_parts, "wpn_fps_ass_m16_s_op")
 			table.insert(self.wpn_fps_ass_ar47.uses_parts, "wpn_fps_upg_fl_ass_smg_sho_pointshoot")
-	
+
 			table.insert(self.wpn_fps_ass_bdgr.uses_parts, "wpn_fps_m4_lower_reciever_tan")
-			
+
 			table.insert(self.wpn_fps_ass_sg416.uses_parts, "wpn_fps_m4_lower_reciever_tan")
-			
+
 			table.insert(self.wpn_fps_shot_amr12.uses_parts, "wpn_fps_m4_lower_reciever_tan")
 			table.insert(self.wpn_fps_shot_amr12.uses_parts, "wpn_fps_upg_ar47_upper_reciever_tecci")
-		
-			self.parts.wpn_fps_upg_fl_ass_smg_sho_pointshoot.stance_mod.wpn_fps_ass_ar47 = 
+
+			self.parts.wpn_fps_upg_fl_ass_smg_sho_pointshoot.stance_mod.wpn_fps_ass_ar47 =
 			{
 				translation = Vector3(-3.5, 0, -11.5),
 				rotation = Rotation(0, 0, -45)
 			}
-	
+
 		else
 			-- vanilla mod pack not installed
 		end
 
 		if BeardLib.Utils:FindMod("Vanilla Styled Weapon Mods Legacy") then
 			table.insert(self.wpn_fps_ass_ar47.uses_parts, "wpn_fps_m4_g_wrap")
-		
+
 		else
 			-- vanilla mod pack not installed
 		end
-	
-		self.parts.wpn_fps_upg_o_45iron.stance_mod.wpn_fps_ass_ar47 = 
-		{
-			translation = Vector3(-3.5, 0, -11.5), 
-			rotation = Rotation(0, 0, -45)
-		}
-		self.parts.wpn_fps_upg_o_45rds.stance_mod.wpn_fps_ass_ar47 = 
+
+		self.parts.wpn_fps_upg_o_45iron.stance_mod.wpn_fps_ass_ar47 =
 		{
 			translation = Vector3(-3.5, 0, -11.5),
 			rotation = Rotation(0, 0, -45)
 		}
-		self.parts.wpn_fps_upg_o_45rds_v2.stance_mod.wpn_fps_ass_ar47 = 
+		self.parts.wpn_fps_upg_o_45rds.stance_mod.wpn_fps_ass_ar47 =
 		{
 			translation = Vector3(-3.5, 0, -11.5),
 			rotation = Rotation(0, 0, -45)
 		}
-		self.parts.wpn_fps_upg_o_45steel.stance_mod.wpn_fps_ass_ar47 = 
+		self.parts.wpn_fps_upg_o_45rds_v2.stance_mod.wpn_fps_ass_ar47 =
 		{
 			translation = Vector3(-3.5, 0, -11.5),
 			rotation = Rotation(0, 0, -45)
 		}
-	
+		self.parts.wpn_fps_upg_o_45steel.stance_mod.wpn_fps_ass_ar47 =
+		{
+			translation = Vector3(-3.5, 0, -11.5),
+			rotation = Rotation(0, 0, -45)
+		}
+
 		self.parts.wpn_fps_upg_ass_ar47_b_heavy_gasblock = deep_clone(self.parts.wpn_fps_m4_uupg_fg_rail_ext)
 		self.parts.wpn_fps_upg_ass_ar47_b_heavy_gasblock.unit = "units/pd2_dlc_opera/weapons/wpn_fps_ass_tecci_pts/wpn_fps_ass_tecci_b_standard"
 		self.parts.wpn_fps_upg_ass_ar47_b_heavy_gasblock.third_unit = "units/pd2_dlc_opera/weapons/wpn_fps_ass_tecci_pts/wpn_third_ass_tecci_b_standard"
@@ -50076,8 +50257,8 @@ Hooks:PostHook(WeaponFactoryTweakData, "init", "mallninj762init", function(self)
 				}
 			}
 		}
-	
-		self.parts.wpn_fps_upg_ass_ar47_b_heavy.adds = { "wpn_fps_upg_ass_ar47_b_heavy_gasblock" }	
+
+		self.parts.wpn_fps_upg_ass_ar47_b_heavy.adds = { "wpn_fps_upg_ass_ar47_b_heavy_gasblock" }
 	end
 end)
 
@@ -50096,18 +50277,18 @@ Hooks:PostHook(WeaponFactoryTweakData, "init", "socomstuff_init", function(self)
 		else
 			-- vanilla mod pack not installed
 		end
-	
+
 		if BeardLib.Utils:FindMod("Vanilla Styled Weapon Mods Legacy") then
 			table.insert(self.wpn_fps_snp_sierra458.uses_parts, "wpn_fps_m4_g_wrap")
-		
+
 		else
 			-- vanilla mod pack legacy not installed
 		end
-	
+
 		if BeardLib.Utils:FindMod("AR AK Mods") then
 			table.insert(self.wpn_fps_snp_sierra458.uses_parts, "wpn_fps_upg_m4_s_hera")
 			table.insert(self.wpn_fps_snp_sierra458.uses_parts, "wpn_fps_ass_tecci_s_wire")
-		
+
 		else
 			-- AR AK mod pack not installed
 		end
@@ -50122,19 +50303,19 @@ end)
 Hooks:PostHook(WeaponFactoryTweakData, "init", "sig_sauer_xm250_mod_init", function(self)
 	if self.parts.wpn_fps_lmg_sig_xm250_irons_angled then
 		self.parts.wpn_fps_lmg_sig_xm250_irons_angled.stance_mod.wpn_fps_lmg_sig_xm250 = {
-				 translation = Vector3(-1.87, -4, -9.15),	 
+				 translation = Vector3(-1.87, -4, -9.15),
 				 rotation = Rotation(0, 0, -45)
 				 }
-					 
-		
+
+
 		self.parts.wpn_fps_lmg_sig_xm250_optic_ngsw.override = {
 			wpn_fps_lmg_sig_xm250_irons_angled = {
 				stance_mod = {
 					wpn_fps_lmg_sig_xm250 = {
 					translation = Vector3(-1.85, -3, -11.15),
-					rotation = Rotation(0, 0, -45)	
+					rotation = Rotation(0, 0, -45)
 					}
-				}	
+				}
 			},
 		}
 	end
@@ -50152,7 +50333,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "init", "amtInit", function(self)
 	if self.wpn_fps_pis_amt then
 		if not self.wpn_fps_pis_amt.adds then
 			self.wpn_fps_pis_amt.adds = {}
-		end    
+		end
 
 		self.wpn_fps_pis_amt.adds.wpn_fps_upg_o_specter = {
 			"wpn_fps_pis_rage_o_adapter"
@@ -50310,7 +50491,7 @@ Hooks:PostHook(WeaponFactoryTweakData, "init", "FPSixModInit", function(self)
 				translation = Vector3(0, -6, -0.1),
 				rotation = Rotation(0, 0.5, 0)
 			}
-		}	
+		}
 		self.parts.wpn_fps_shot_fpsix_o_sgcqb.stance_mod = {
 			wpn_fps_shot_fpsix = {
 				translation = Vector3(0, -6, -1.15),
@@ -50533,7 +50714,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "init", "degle_elfive_time", function(se
 				a_obj = "a_ns",
 				parent = "barrel"
 			}
-			}		
+			}
 		if self.parts.wpn_fps_upg_am_gomerpyle then
 			table.insert(self.wpn_fps_pis_limafive.uses_parts, "wpn_fps_upg_am_gomerpyle")
 		end
@@ -50547,7 +50728,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "init", "StrikeOneModInit", function(sel
 		self.parts.wpn_fps_upg_o_rmr.stance_mod.wpn_fps_pis_rusglock = {translation = Vector3(0, 0, 0),rotation = Rotation(0, 0, 0)}
 	end
 end)
-Hooks:PostHook( WeaponFactoryTweakData, "init", "qbz95Init", function(self)	
+Hooks:PostHook( WeaponFactoryTweakData, "init", "qbz95Init", function(self)
 	if self.parts.wpn_fps_ass_qbz95_bipod then
 		self.parts.wpn_fps_ass_qbz95_fg_rails.stance_mod = {
 			wpn_fps_ass_qbz95 = {
@@ -50669,9 +50850,9 @@ Hooks:PostHook(WeaponFactoryTweakData, "init", "resmod_cap", function(self)
 		self.parts.wpn_fps_ass_groza_m_speed.a_obj = "a_m_fix"
 
 		self.wpn_fps_ass_groza.override = self.wpn_fps_ass_groza.override or {}
-		self.wpn_fps_ass_groza.override.wpn_upg_ak_m_drum = { a_obj = "a_m_fix" } 
-		self.wpn_fps_ass_groza.override.wpn_fps_upg_ak_m_quad = { a_obj = "a_m_fix" } 
-		self.wpn_fps_ass_groza.override.wpn_fps_upg_ak_m_uspalm = { a_obj = "a_m_fix" } 
+		self.wpn_fps_ass_groza.override.wpn_upg_ak_m_drum = { a_obj = "a_m_fix" }
+		self.wpn_fps_ass_groza.override.wpn_fps_upg_ak_m_quad = { a_obj = "a_m_fix" }
+		self.wpn_fps_ass_groza.override.wpn_fps_upg_ak_m_uspalm = { a_obj = "a_m_fix" }
 
 		self.wpn_fps_ass_asval.override = self.wpn_fps_ass_asval.override or {}
 		self.wpn_fps_ass_asval.override.wpn_fps_ass_groza_m_speed = {
@@ -50802,7 +50983,7 @@ Hooks:PostHook(WeaponFactoryTweakData, "init", "resmod_npc_weaps", function(self
 		"wpn_fps_upg_o_docter"
 	}
 	self.wpn_fps_lmg_hk21_pdth_npc = deep_clone(self.wpn_fps_lmg_hk21_pdth)
-	self.wpn_fps_lmg_hk21_pdth_npc.unit = "units/pd2_dlc_gage_lmg/weapons/wpn_fps_lmg_hk21/wpn_fps_lmg_hk21_npc"	
+	self.wpn_fps_lmg_hk21_pdth_npc.unit = "units/pd2_dlc_gage_lmg/weapons/wpn_fps_lmg_hk21/wpn_fps_lmg_hk21_npc"
 
 	self.wpn_fps_ass_amcar_idf = deep_clone(self.wpn_fps_ass_amcar)
 	self.wpn_fps_ass_amcar_idf.real_factory_id = "wpn_fps_ass_amcar"
@@ -50977,7 +51158,7 @@ Hooks:PostHook(WeaponFactoryTweakData, "init", "resmod_npc_weaps", function(self
 		"wpn_fps_upg_o_leupold",
 		"wpn_fps_upg_o_45rds",
 		"wpn_fps_upg_m4_s_mk46",
-		"wpn_fps_upg_fl_ass_utg",	
+		"wpn_fps_upg_fl_ass_utg",
 		"wpn_fps_ass_shak12_ns_muzzle",
 		"wpn_fps_upg_m4_g_standard_vanilla"
 	}

--- a/lua/sc/tweak_data/weapontweakdata.lua
+++ b/lua/sc/tweak_data/weapontweakdata.lua
@@ -16989,6 +16989,52 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 				self.acwr.sounds.magazine_empty = "wp_rifle_slide_lock"
 				self.acwr.use_underbarrel_anim = "contraband"
 				self.acwr.timers = deep_clone(self.contraband.timers)
+
+				self.acwr2.recategorize = { "light_ar" }
+				self.acwr2.damage_type = "assault_rifle"
+				self.acwr2.tactical_reload = 1
+				self.acwr2.nato = true
+				self.acwr2.BURST_FIRE = false
+				self.acwr2.ADAPTIVE_BURST_SIZE = false
+				self.acwr2.FIRE_MODE = "auto"
+				self.acwr2.CLIP_AMMO_MAX = 30
+				self.acwr2.AMMO_MAX = 150
+				self.acwr2.fire_mode_data.fire_rate = 0.0833333333
+				self.acwr2.kick = self.stat_info.kick_tables.moderate_kick
+				self.acwr2.kick_pattern = {
+					{0, self.stat_info.kick_tables.right_kick},
+					{9, self.stat_info.kick_tables.vertical_kick},
+					{11, self.stat_info.kick_tables.left_kick},
+					{15, self.stat_info.kick_tables.vertical_kick},
+					{20, self.stat_info.kick_tables.right_kick}
+				}
+				self.acwr2.supported = true
+				self.acwr2.ads_speed = 0.280
+				self.acwr2.damage_falloff = {
+					start_dist = 2400,
+					end_dist = 5800,
+					min_mult = 0.5
+				}
+				self.acwr2.stats = {
+					damage = 24,
+					spread = 77,
+					recoil = 83,
+					spread_moving = 6,
+					zoom = 1,
+					concealment = 26,
+					suppression = 9,
+					alert_size = 2,
+					extra_ammo = 101,
+					total_ammo_mod = 400,
+					value = 1,
+					reload = 20
+				}
+				self.acwr2.stats_modifiers = nil
+				self.acwr2.panic_suppression_chance = 0.05
+				self.acwr2.lock_slide = true
+				self.acwr2.reload_speed_multiplier = 1.05
+				self.acwr2.sounds.magazine_empty = "wp_rifle_slide_lock"
+				self.acwr2.timers = deep_clone(self.new_m4.timers)
 			end
 
 			if self.mr96 then 

--- a/lua/sc/tweak_data/weapontweakdata.lua
+++ b/lua/sc/tweak_data/weapontweakdata.lua
@@ -121,7 +121,7 @@ local crew_wep_preset = {
 		fire_rate = 3.75,
 		damage = 9.0 / 1.25
 	},
-	sniper_bolt = {	
+	sniper_bolt = {
 		mag_capacity = 5,
 		fire_rate = 7.5,
 		damage = 18.0 / 1.25
@@ -178,7 +178,7 @@ local crew_wep_preset = {
 		self.sentry_gun.challenges.weapon = "sentry_gun"
 		self.sentry_gun.suppression = 0.8
 	end
-	
+
 	function WeaponTweakData:_set_normal()
 
 		local diff_reduction = 3
@@ -227,12 +227,12 @@ local crew_wep_preset = {
 
 		--Bot sidearm--
 		self.beretta92_npc.DAMAGE = 1.8
-		
+
 		--Everything else--
 		for i, wep_id in ipairs(damage_set.smg) do
 			self[ wep_id ].DAMAGE = crew_wep_preset.smg.damage - diff_reduction
 		end
-		
+
 		for i, wep_id in ipairs(damage_set.assault_rifle) do
 			self[ wep_id ].DAMAGE = crew_wep_preset.assault_rifle.damage - diff_reduction
 		end
@@ -257,7 +257,7 @@ local crew_wep_preset = {
 			self[ wep_id ].DAMAGE = crew_wep_preset.lmg.damage - diff_reduction
 		end
 	end
-	
+
 	function WeaponTweakData:_set_hard()
 		local diff_reduction = 3
 
@@ -309,7 +309,7 @@ local crew_wep_preset = {
 		for i, wep_id in ipairs(damage_set.smg) do
 			self[ wep_id ].DAMAGE = crew_wep_preset.smg.damage - diff_reduction
 		end
-		
+
 		for i, wep_id in ipairs(damage_set.assault_rifle) do
 			self[ wep_id ].DAMAGE = crew_wep_preset.assault_rifle.damage - diff_reduction
 		end
@@ -334,7 +334,7 @@ local crew_wep_preset = {
 			self[ wep_id ].DAMAGE = crew_wep_preset.lmg.damage - diff_reduction
 		end
 	end
-	
+
 	function WeaponTweakData:_set_overkill()
 		local diff_reduction = 2
 
@@ -386,7 +386,7 @@ local crew_wep_preset = {
 		for i, wep_id in ipairs(damage_set.smg) do
 			self[ wep_id ].DAMAGE = crew_wep_preset.smg.damage - diff_reduction
 		end
-		
+
 		for i, wep_id in ipairs(damage_set.assault_rifle) do
 			self[ wep_id ].DAMAGE = crew_wep_preset.assault_rifle.damage - diff_reduction
 		end
@@ -411,7 +411,7 @@ local crew_wep_preset = {
 			self[ wep_id ].DAMAGE = crew_wep_preset.lmg.damage - diff_reduction
 		end
 	end
-	
+
 	function WeaponTweakData:_set_overkill_145()
 		local diff_reduction = 1
 
@@ -464,7 +464,7 @@ local crew_wep_preset = {
 		for i, wep_id in ipairs(damage_set.smg) do
 			self[ wep_id ].DAMAGE = crew_wep_preset.smg.damage - diff_reduction
 		end
-		
+
 		for i, wep_id in ipairs(damage_set.assault_rifle) do
 			self[ wep_id ].DAMAGE = crew_wep_preset.assault_rifle.damage - diff_reduction
 		end
@@ -488,7 +488,7 @@ local crew_wep_preset = {
 		for i, wep_id in ipairs(damage_set.lmg) do
 			self[ wep_id ].DAMAGE = crew_wep_preset.lmg.damage - diff_reduction
 		end
-		
+
 		if job == "chew" or job == "bridge" or job == "hox_1" then
 			self.swat_van_turret_module.HEALTH_INIT = 675
 			self.swat_van_turret_module.SHIELD_HEALTH_INIT = 90
@@ -498,19 +498,19 @@ local crew_wep_preset = {
 			self.swat_van_turret_module.SHIELD_HEALTH_INIT = 180
 			self.swat_van_turret_module.AUTO_REPAIR = true
 		end
-				
+
 		self.ceiling_turret_module.HEALTH_INIT = 675
 		self.ceiling_turret_module.SHIELD_HEALTH_INIT = 90
 		self.ceiling_turret_module_no_idle.HEALTH_INIT = 675
 		self.ceiling_turret_module_no_idle.SHIELD_HEALTH_INIT = 90
 		self.ceiling_turret_module_longer_range.HEALTH_INIT = 675
-		self.ceiling_turret_module_longer_range.SHIELD_HEALTH_INIT = 90		
+		self.ceiling_turret_module_longer_range.SHIELD_HEALTH_INIT = 90
 		self.aa_turret_module.HEALTH_INIT = 675
 		self.aa_turret_module.SHIELD_HEALTH_INIT = 90
 		self.crate_turret_module.HEALTH_INIT = 337.5
-		self.crate_turret_module.SHIELD_HEALTH_INIT = 45		
+		self.crate_turret_module.SHIELD_HEALTH_INIT = 45
 	end
-	
+
 	function WeaponTweakData:_set_easy_wish()
 		local diff_reduction = 0
 
@@ -563,7 +563,7 @@ local crew_wep_preset = {
 		for i, wep_id in ipairs(damage_set.smg) do
 			self[ wep_id ].DAMAGE = crew_wep_preset.smg.damage - diff_reduction
 		end
-		
+
 		for i, wep_id in ipairs(damage_set.assault_rifle) do
 			self[ wep_id ].DAMAGE = crew_wep_preset.assault_rifle.damage - diff_reduction
 		end
@@ -587,7 +587,7 @@ local crew_wep_preset = {
 		for i, wep_id in ipairs(damage_set.lmg) do
 			self[ wep_id ].DAMAGE = crew_wep_preset.lmg.damage - diff_reduction
 		end
-		
+
 		if job == "chew" or job == "bridge" or job == "hox_1" then
 			self.swat_van_turret_module.HEALTH_INIT = 787.5
 			self.swat_van_turret_module.SHIELD_HEALTH_INIT = 105
@@ -598,7 +598,7 @@ local crew_wep_preset = {
 			self.swat_van_turret_module.AUTO_REPAIR = true
 		end
 		self.swat_van_turret_module.BAG_DMG_MUL = 14.58375
-	
+
 		self.ceiling_turret_module.HEALTH_INIT = 787.5
 		self.ceiling_turret_module.BAG_DMG_MUL = 14.58375
 		self.ceiling_turret_module.SHIELD_HEALTH_INIT = 105
@@ -613,9 +613,9 @@ local crew_wep_preset = {
 		self.aa_turret_module.SHIELD_HEALTH_INIT = 105
 		self.crate_turret_module.HEALTH_INIT = 393.75
 		self.crate_turret_module.BAG_DMG_MUL = 14.58375
-		self.crate_turret_module.SHIELD_HEALTH_INIT = 52.5			
+		self.crate_turret_module.SHIELD_HEALTH_INIT = 52.5
 	end
-	
+
 	function WeaponTweakData:_set_overkill_290()
 		local diff_reduction = 0
 
@@ -668,7 +668,7 @@ local crew_wep_preset = {
 		for i, wep_id in ipairs(damage_set.smg) do
 			self[ wep_id ].DAMAGE = crew_wep_preset.smg.damage - diff_reduction
 		end
-		
+
 		for i, wep_id in ipairs(damage_set.assault_rifle) do
 			self[ wep_id ].DAMAGE = crew_wep_preset.assault_rifle.damage - diff_reduction
 		end
@@ -702,7 +702,7 @@ local crew_wep_preset = {
 			self.swat_van_turret_module.AUTO_REPAIR = true
 		end
 		self.swat_van_turret_module.BAG_DMG_MUL = 10
-		
+
 		self.ceiling_turret_module.HEALTH_INIT = 787.5
 		self.ceiling_turret_module.BAG_DMG_MUL = 10
 		self.ceiling_turret_module.SHIELD_HEALTH_INIT = 105
@@ -717,13 +717,13 @@ local crew_wep_preset = {
 		self.aa_turret_module.SHIELD_HEALTH_INIT = 105
 		self.crate_turret_module.HEALTH_INIT = 393.75
 		self.crate_turret_module.BAG_DMG_MUL = 10
-		self.crate_turret_module.SHIELD_HEALTH_INIT = 52.5	
-	
+		self.crate_turret_module.SHIELD_HEALTH_INIT = 52.5
+
 		--Sniper Trail for Snipers
 		self.m14_sniper_npc.trail_effect = Idstring("effects/particles/weapons/sniper_trail_sc")
 		self.m14_sniper_npc.use_sniper_trail = true
 	end
-	
+
 	function WeaponTweakData:_set_sm_wish()
 		local diff_reduction = 0
 
@@ -776,7 +776,7 @@ local crew_wep_preset = {
 		for i, wep_id in ipairs(damage_set.smg) do
 			self[ wep_id ].DAMAGE = crew_wep_preset.smg.damage - diff_reduction
 		end
-		
+
 		for i, wep_id in ipairs(damage_set.assault_rifle) do
 			self[ wep_id ].DAMAGE = crew_wep_preset.assault_rifle.damage - diff_reduction
 		end
@@ -810,42 +810,42 @@ local crew_wep_preset = {
 			self.swat_van_turret_module.SHIELD_HEALTH_INIT = 210
 			self.swat_van_turret_module.AUTO_REPAIR = true
 		end
-	
+
 		self.swat_van_turret_module.BAG_DMG_MUL = 11.4375
-				
+
 		self.ceiling_turret_module.HEALTH_INIT = 900
 		self.ceiling_turret_module.BAG_DMG_MUL = 11.4375
 		self.ceiling_turret_module.SHIELD_HEALTH_INIT = 105
-	
+
 		self.ceiling_turret_module_no_idle.HEALTH_INIT = 900
 		self.ceiling_turret_module_no_idle.BAG_DMG_MUL = 11.4375
 		self.ceiling_turret_module_no_idle.SHIELD_HEALTH_INIT = 105
-		
+
 		self.ceiling_turret_module_longer_range.HEALTH_INIT = 900
 		self.ceiling_turret_module_longer_range.BAG_DMG_MUL = 11.4375
-		self.ceiling_turret_module_longer_range.SHIELD_HEALTH_INIT = 105		
-		
+		self.ceiling_turret_module_longer_range.SHIELD_HEALTH_INIT = 105
+
 		self.aa_turret_module.HEALTH_INIT = 900
 		self.aa_turret_module.BAG_DMG_MUL = 11.4375
-		self.aa_turret_module.SHIELD_HEALTH_INIT = 105		
-		
+		self.aa_turret_module.SHIELD_HEALTH_INIT = 105
+
 		self.crate_turret_module.HEALTH_INIT = 900
 		self.crate_turret_module.BAG_DMG_MUL = 11.4375
-		self.crate_turret_module.SHIELD_HEALTH_INIT = 52.5			
-		
+		self.crate_turret_module.SHIELD_HEALTH_INIT = 52.5
+
 		self.swat_van_turret_module.AUTO_REPAIR_MAX_COUNT = 3
 		self.ceiling_turret_module.AUTO_REPAIR_MAX_COUNT = 3
 		self.ceiling_turret_module_no_idle.AUTO_REPAIR_MAX_COUNT = 3
 		self.aa_turret_module.AUTO_REPAIR_MAX_COUNT = 3
-	
+
 		--Sniper Trail for Snipers
 		self.m14_sniper_npc.trail_effect = Idstring("effects/particles/weapons/sniper_trail_sc")
 		self.m14_sniper_npc.use_sniper_trail = true
 	end
-	
+
 	function WeaponTweakData:_init_data_npc_melee()
 		self.npc_melee = {}
-		
+
 		--Police Baton
 		self.npc_melee.baton = {}
 		self.npc_melee.baton.unit_name = Idstring("units/payday2/characters/ene_acc_baton/ene_acc_baton")
@@ -853,7 +853,7 @@ local crew_wep_preset = {
 		self.npc_melee.baton.animation_param = "melee_baton"
 		self.npc_melee.baton.player_blood_effect = true
 		self.npc_melee.baton.armor_piercing = true
-		
+
 		--KABAR knife
 		self.npc_melee.knife_1 = {}
 		self.npc_melee.knife_1.unit_name = Idstring("units/payday2/characters/ene_acc_knife_1/ene_acc_knife_1")
@@ -861,7 +861,7 @@ local crew_wep_preset = {
 		self.npc_melee.knife_1.animation_param = "melee_knife"
 		self.npc_melee.knife_1.player_blood_effect = true
 		self.npc_melee.knife_1.armor_piercing = true
-	
+
 		--Fists
 		self.npc_melee.fists = {}
 		self.npc_melee.fists.unit_name = nil
@@ -869,7 +869,7 @@ local crew_wep_preset = {
 		self.npc_melee.fists.animation_param = "melee_fist"
 		self.npc_melee.fists.player_blood_effect = true
 		self.npc_melee.fists.armor_piercing = true
-		
+
 		--Electric Fists
 		self.npc_melee.fists_electric = deep_clone(self.npc_melee.fists)
 		self.npc_melee.fists_electric.tase_data = {
@@ -877,7 +877,7 @@ local crew_wep_preset = {
 			electrocution_time_mul = 0.5
 		}
 		self.npc_melee.fists_electric.additional_impact_sound = "buzzer_detector_hit_body"
-		
+
 		--Dozer Fists
 		self.npc_melee.fists_dozer = {}
 		self.npc_melee.fists_dozer.unit_name = nil
@@ -885,7 +885,7 @@ local crew_wep_preset = {
 		self.npc_melee.fists_dozer.animation_param = "melee_fist"
 		self.npc_melee.fists_dozer.player_blood_effect = true
 		self.npc_melee.fists_dozer.armor_piercing = true
-		
+
 		--Halloween Dozer Hammer
 		self.npc_melee.helloween = {}
 		self.npc_melee.helloween.unit_name = Idstring("units/pd2_halloween/weapons/wpn_mel_titan_hammer/wpn_mel_titan_hammer")
@@ -893,7 +893,7 @@ local crew_wep_preset = {
 		self.npc_melee.helloween.animation_param = "melee_fireaxe"
 		self.npc_melee.helloween.player_blood_effect = true
 		self.npc_melee.helloween.armor_piercing = true
-		
+
 		--Halloween Dozer Sword
 		self.npc_melee.helloween_sword = {}
 		self.npc_melee.helloween_sword.unit_name = Idstring("units/payday2/weapons/wpn_mel_hw_sword/wpn_mel_hw_sword")
@@ -901,15 +901,15 @@ local crew_wep_preset = {
 		self.npc_melee.helloween_sword.animation_param = "melee_fireaxe"
 		self.npc_melee.helloween_sword.player_blood_effect = true
 		self.npc_melee.helloween_sword.armor_piercing = true
-		
+
 		--Halloween Dozer Axe
 		self.npc_melee.helloween_axe = {}
 		self.npc_melee.helloween_axe.unit_name = Idstring("units/pd2_mod_halloween/weapons/wpn_mel_hw_axe/wpn_mel_hw_axe")
 		self.npc_melee.helloween_axe.damage = 4.5
 		self.npc_melee.helloween_axe.animation_param = "melee_fireaxe"
 		self.npc_melee.helloween_axe.player_blood_effect = true
-		self.npc_melee.helloween_axe.armor_piercing = true	
-		
+		self.npc_melee.helloween_axe.armor_piercing = true
+
 		--Summers' Buzzer
 		self.npc_melee.buzzer_summer = {}
 		self.npc_melee.buzzer_summer.unit_name = Idstring("units/pd2_dlc_vip/characters/ene_acc_buzzer_1/ene_acc_buzzer_1")
@@ -917,7 +917,7 @@ local crew_wep_preset = {
 		self.npc_melee.buzzer_summer.animation_param = "melee_freedom"
 		self.npc_melee.buzzer_summer.player_blood_effect = true
 		self.npc_melee.buzzer_summer.armor_piercing = true
-		
+
 		--Kung-Fu Master Katana
 		self.npc_melee.kf_katana = {}
 		self.npc_melee.kf_katana.unit_name = Idstring("units/pd2_dlc_pent/weapons/ene_acc_mel_sandsteel/ene_acc_mel_sandsteel")
@@ -932,24 +932,24 @@ local crew_wep_preset = {
 		self.npc_melee.claws.damage = 4.5
 		self.npc_melee.claws.animation_param = "melee_fist"
 		self.npc_melee.claws.player_blood_effect = true
-		self.npc_melee.claws.armor_piercing = true	
-		
+		self.npc_melee.claws.armor_piercing = true
+
 		--Zombie Bite
 		self.npc_melee.bite = {}
 		self.npc_melee.bite.unit_name = nil
 		self.npc_melee.bite.damage = 22 * 10
 		self.npc_melee.bite.animation_param = "melee_fist"
 		self.npc_melee.bite.player_blood_effect = true
-		self.npc_melee.bite.armor_piercing = true	
+		self.npc_melee.bite.armor_piercing = true
 		self.npc_melee.bite.lethal = true
 	end
-	
+
 	function WeaponTweakData:_set_npc_weapon_damage_multiplier(mul)
 		for name, data in pairs(self.npc_melee) do
 			data.damage = data.damage * mul
 		end
 	end
-	
+
 	function WeaponTweakData:_init_data_c45_npc()
 		self.c45_npc.categories = {"pistol"}
 		self.c45_npc.sounds.prefix = "g17_npc"
@@ -966,14 +966,14 @@ local crew_wep_preset = {
 		self.c45_npc.FIRE_MODE = "single"
 
 		self.streak_npc = deep_clone(self.c45_npc)
-		self.streak_npc.sounds.prefix = "pl14_npc"	
-		
+		self.streak_npc.sounds.prefix = "pl14_npc"
+
 		self.colt_1911_primary_npc = deep_clone(self.c45_npc)
 		self.colt_1911_primary_npc.use_data.selection_index = 2
 		self.colt_1911_primary_npc.CLIP_AMMO_MAX = 8
 		self.colt_1911_primary_npc.sounds.prefix = "c45_fire"
-		self.colt_1911_primary_npc.DAMAGE = 4.5	
-	
+		self.colt_1911_primary_npc.DAMAGE = 4.5
+
 		self.beretta92_titan_npc = deep_clone(self.c45_npc)
 		self.beretta92_titan_npc.usage = "is_revolver"
 		self.beretta92_titan_npc.sounds.prefix = "beretta_npc"
@@ -981,14 +981,14 @@ local crew_wep_preset = {
 		self.beretta92_titan_npc.CLIP_AMMO_MAX = 14
 		self.beretta92_titan_npc.alert_size = 0
 		self.beretta92_titan_npc.suppression = 0.1
-		self.beretta92_titan_npc.has_suppressor = "suppressed_a"	
+		self.beretta92_titan_npc.has_suppressor = "suppressed_a"
 	end
-	
+
 	function WeaponTweakData:_init_data_x_c45_npc()
 		self.x_c45_npc.categories = {
 			"akimbo",
 			"pistol"
-		}	
+		}
 		self.x_c45_npc.sounds.prefix = "g17_npc"
 		self.x_c45_npc.use_data.selection_index = 1
 		self.x_c45_npc.DAMAGE = 2.4
@@ -1003,30 +1003,30 @@ local crew_wep_preset = {
 		self.x_c45_npc.FIRE_MODE = "single"
 
 		self.x_streak_npc = deep_clone(self.x_c45_npc)
-		self.x_streak_npc.sounds.prefix = "pl14_npc"		
-		
-		self.x_raging_bull_meme_npc = deep_clone(self.x_c45_npc)		
+		self.x_streak_npc.sounds.prefix = "pl14_npc"
+
+		self.x_raging_bull_meme_npc = deep_clone(self.x_c45_npc)
 		self.x_raging_bull_meme_npc.sounds.prefix = "rbull_npc"
-		self.x_raging_bull_meme_npc.categories = clone(self.x_rage.categories)		
+		self.x_raging_bull_meme_npc.categories = clone(self.x_rage.categories)
 		self.x_raging_bull_meme_npc.use_data.selection_index = 1
 		self.x_raging_bull_meme_npc.hold = "akimbo_pistol"
-		self.x_raging_bull_meme_npc.FIRE_MODE = "single"	
-		
-		self.x_pm9_npc = deep_clone(self.x_c45_npc)			
-		self.x_pm9_npc.categories = {"akimbo", "smg"}	
+		self.x_raging_bull_meme_npc.FIRE_MODE = "single"
+
+		self.x_pm9_npc = deep_clone(self.x_c45_npc)
+		self.x_pm9_npc.categories = {"akimbo", "smg"}
 		self.x_pm9_npc.DAMAGE = 2
 		self.x_pm9_npc.CLIP_AMMO_MAX = 50
 		self.x_pm9_npc.NR_CLIPS_MAX = 4
 		self.x_pm9_npc.hold = "akimbo_pistol"
 		self.x_pm9_npc.alert_size = 0
-		self.x_pm9_npc.FIRE_MODE = "auto"	
+		self.x_pm9_npc.FIRE_MODE = "auto"
 		self.x_pm9_npc.sounds.prefix = "pm9_npc"
 		self.x_pm9_npc.has_suppressor = "suppressed_a"
-		self.x_pm9_npc.suppression = 0.1		
-		self.x_pm9_npc.auto = {}			
-		self.x_pm9_npc.auto.fire_rate = 0.05454545454	
+		self.x_pm9_npc.suppression = 0.1
+		self.x_pm9_npc.auto = {}
+		self.x_pm9_npc.auto.fire_rate = 0.05454545454
 	end
-	
+
 	function WeaponTweakData:_init_data_beretta92_npc()
 		self.beretta92_npc.categories = clone(self.b92fs.categories)
 		self.beretta92_npc.sounds.prefix = "beretta_npc"
@@ -1045,7 +1045,7 @@ local crew_wep_preset = {
 		self.beretta92_primary_npc = deep_clone(self.beretta92_npc)
 		self.beretta92_primary_npc.use_data.selection_index = 2
 	end
-	
+
 	function WeaponTweakData:_init_data_raging_bull_npc()
 		self.raging_bull_npc.categories = clone(self.new_raging_bull.categories)
 		self.raging_bull_npc.sounds.prefix = "rbull_npc"
@@ -1060,51 +1060,51 @@ local crew_wep_preset = {
 		self.raging_bull_npc.alert_size = 2500
 		self.raging_bull_npc.suppression = 3.2
 		self.raging_bull_npc.FIRE_MODE = "single"
-		
+
 		self.m1911_npc = deep_clone(self.raging_bull_npc)
 		self.m1911_npc.use_data.selection_index = 2
 		self.m1911_npc.CLIP_AMMO_MAX = 8
 		self.m1911_npc.sounds.prefix = "c45_npc"
 		self.m1911_npc.anim_usage = "is_pistol"
 		self.m1911_npc.hold = "pistol"
-		self.m1911_npc.reload = "pistol"		
+		self.m1911_npc.reload = "pistol"
 		self.m1911_npc.alert_size = 2500
-		self.m1911_npc.suppression = 3		
-		self.m1911_npc.DAMAGE = 4.5		
-		
+		self.m1911_npc.suppression = 3
+		self.m1911_npc.DAMAGE = 4.5
+
 		self.deagle_guard_npc = deep_clone(self.raging_bull_npc)
 		self.deagle_guard_npc.CLIP_AMMO_MAX = 8
 		self.deagle_guard_npc.anim_usage = "is_pistol"
 		self.deagle_guard_npc.hold = "pistol"
-		self.deagle_guard_npc.reload = "pistol"	
+		self.deagle_guard_npc.reload = "pistol"
 		self.deagle_guard_npc.sounds.prefix = "deagle_npc"
-		
+
 		self.peacemaker_npc = deep_clone(self.raging_bull_npc)
 		self.peacemaker_npc.DAMAGE = 9
 		self.peacemaker_npc.sounds.prefix = "pmkr45_npc"
-		self.peacemaker_npc.armor_piercing = false --Reno told me do it 
-		
+		self.peacemaker_npc.armor_piercing = false --Reno told me do it
+
 		self.x_peacemaker_npc = deep_clone(self.peacemaker_npc)
 		self.x_peacemaker_npc.DAMAGE = 9
 		self.x_peacemaker_npc.sounds.prefix = "pmkr45_npc"
-		self.x_peacemaker_npc.armor_piercing = false	
+		self.x_peacemaker_npc.armor_piercing = false
 		self.x_peacemaker_npc.CLIP_AMMO_MAX = 12
 		self.x_peacemaker_npc.NR_CLIPS_MAX = 5
 		self.x_peacemaker_npc.hold = "akimbo_pistol"
-		self.x_peacemaker_npc.FIRE_MODE = "single"				
-		
+		self.x_peacemaker_npc.FIRE_MODE = "single"
+
 		self.raging_bull_primary_npc = deep_clone(self.raging_bull_npc)
 		self.raging_bull_primary_npc.use_data.selection_index = 2
-		
-		self.x_raging_bull_npc = deep_clone(self.raging_bull_npc)		
-		self.x_raging_bull_npc.categories = clone(self.x_rage.categories)		
+
+		self.x_raging_bull_npc = deep_clone(self.raging_bull_npc)
+		self.x_raging_bull_npc.categories = clone(self.x_rage.categories)
 		self.x_raging_bull_npc.use_data.selection_index = 1
 		self.x_raging_bull_npc.CLIP_AMMO_MAX = 12
 		self.x_raging_bull_npc.NR_CLIPS_MAX = 5
 		self.x_raging_bull_npc.hold = "akimbo_pistol"
-		self.x_raging_bull_npc.FIRE_MODE = "single"		
+		self.x_raging_bull_npc.FIRE_MODE = "single"
 	end
-	
+
 	function WeaponTweakData:_init_data_m4_npc()
 		--M4
 		self.m4_npc.categories = clone(self.new_m4.categories)
@@ -1120,44 +1120,44 @@ local crew_wep_preset = {
 		self.m4_npc.alert_size = 2500
 		self.m4_npc.suppression = 2.6
 		self.m4_npc.FIRE_MODE = "auto"
-		
+
 		self.m4_secondary_npc = deep_clone(self.m4_npc)
 		self.m4_secondary_npc.use_data.selection_index = 1
-		
+
 		--AKS 74 used by Reapers
 		self.ak47_ass_npc = deep_clone(self.m4_npc)
 		self.ak47_ass_npc.sounds.prefix = "ak74_npc"
-		
+
 		--AK 103 used by Reapers
 		self.ak103_npc = deep_clone(self.m4_npc)
 		self.ak103_npc.sounds.prefix = "akm_npc"
-		
+
 		--AK 101+GP25 used by Reaper Grenadier
 		self.ak47_ass_boom_npc = deep_clone(self.ak47_ass_npc)
-		self.ak47_ass_boom_npc.sounds.prefix = "ak74_npc"	
-		
+		self.ak47_ass_boom_npc.sounds.prefix = "ak74_npc"
+
 		--Bravo Rifle
 		self.swamp_npc = deep_clone(self.m4_npc)
-		self.swamp_npc.sounds.prefix = "m16_npc"	
+		self.swamp_npc.sounds.prefix = "m16_npc"
 		self.swamp_npc.CLIP_AMMO_MAX = 60
-		
+
 		--Reaper Bravo Rifle
 		self.ak17_bravo_npc = deep_clone(self.swamp_npc)
-		self.ak17_bravo_npc.sounds.prefix = "flint_npc"	
-		self.ak17_bravo_npc.CLIP_AMMO_MAX = 60		
-		
+		self.ak17_bravo_npc.sounds.prefix = "flint_npc"
+		self.ak17_bravo_npc.CLIP_AMMO_MAX = 60
+
 		--HK417 (unused?)
 		self.sg417_npc = deep_clone(self.m4_npc)
 		self.sg417_npc.sounds.prefix = "contraband_npc"
-		
-		--HK33 
+
+		--HK33
 		self.hk33_npc = deep_clone(self.m4_npc)
 		self.hk33_npc.sounds.prefix = "g36_npc"
-		
+
 		self.hk33_bravo_npc = deep_clone(self.m4_npc)
 		self.hk33_bravo_npc.sounds.prefix = "g36_npc"
 		self.hk33_bravo_npc.CLIP_AMMO_MAX = 60
-		
+
 		--[[
 		self.sg417_npc.auto.fire_rate = 0.1
 		self.sg417_npc.CLIP_AMMO_MAX = 20
@@ -1165,22 +1165,22 @@ local crew_wep_preset = {
 		self.sg417_npc.alert_size = 3000
 		self.sg417_npc.suppression = 3
 		]]--
-		
+
 		--Zeal S553
 		self.s553_zeal_npc = deep_clone(self.m4_npc)
-		self.s553_zeal_npc.sounds.prefix = "sig552_npc"		
-		
-		--AK12 
+		self.s553_zeal_npc.sounds.prefix = "sig552_npc"
+
+		--AK12
 		self.ak12_npc = deep_clone(self.m4_npc)
 		self.ak12_npc.sounds.prefix = "flint_npc"
-	
+
 		--Sexican New Vepom Shipment
 		self.hajk_npc = deep_clone(self.m4_npc)
-		self.hajk_npc.sounds.prefix = "hajk_npc"		
-		
+		self.hajk_npc.sounds.prefix = "hajk_npc"
+
 		--M4/203 used by Grenadier
 		self.m4_boom_npc = deep_clone(self.m4_npc)
-		
+
 		--AMCAR
 		self.amcar_npc = deep_clone(self.m4_npc)
 		self.amcar_npc.sounds.prefix = "amcar_npc"
@@ -1189,12 +1189,12 @@ local crew_wep_preset = {
 		self.amcar_npc.auto.fire_rate = 0.075
 		self.amcar_npc.alert_size = 2500
 		self.amcar_npc.suppression = 2.4
-		
+
 		--AK102
 		self.ak102_npc = deep_clone(self.amcar_npc)
-		self.ak102_npc.sounds.prefix = "ak74_npc"	
+		self.ak102_npc.sounds.prefix = "ak74_npc"
 	end
-	
+
 	function WeaponTweakData:_init_data_m4_yellow_npc()
 		self.m4_yellow_npc.categories = clone(self.new_m4.categories)
 		self.m4_yellow_npc.sounds.prefix = "m4_npc"
@@ -1209,12 +1209,12 @@ local crew_wep_preset = {
 		self.m4_yellow_npc.alert_size = 2500
 		self.m4_yellow_npc.suppression = 2.6
 		self.m4_yellow_npc.FIRE_MODE = "auto"
-		
+
 		--Yellow AK used by Reaper Tasers
 		self.ak47_yellow_ass_npc = deep_clone(self.m4_yellow_npc)
-		self.ak47_yellow_ass_npc.sounds.prefix = "ak74_npc"		
+		self.ak47_yellow_ass_npc.sounds.prefix = "ak74_npc"
 	end
-	
+
 	function WeaponTweakData:_init_data_ak47_npc()
 		--AKM
 		self.ak47_npc.categories = {"assault_rifle"}
@@ -1231,7 +1231,7 @@ local crew_wep_preset = {
 		self.ak47_npc.suppression = 2.8
 		self.ak47_npc.FIRE_MODE = "auto"
 	end
-	
+
 	function WeaponTweakData:_init_data_m14_sniper_npc()
 		--MSR Rifle
 		self.m14_sniper_npc.categories = {"snp"}
@@ -1250,33 +1250,33 @@ local crew_wep_preset = {
 		self.m14_sniper_npc.suppression = 3.4
 		self.m14_sniper_npc.armor_piercing = true
 		self.m14_sniper_npc.FIRE_MODE = "single"
-		
+
 		--Reaper variant
 		self.svd_snp_npc = deep_clone(self.m14_sniper_npc)
-		
+
 		--Gangster variant
 		self.svdsil_snp_npc = deep_clone(self.m14_sniper_npc)
 		self.svdsil_snp_npc.has_suppressor = "suppressed_a"
-		
+
 		self.asval_snp_npc = deep_clone(self.m14_sniper_npc)
 		self.asval_snp_npc.has_suppressor = "suppressed_a"
 		self.asval_snp_npc.trail_effect = Idstring("effects/particles/weapons/sniper_trail_sc")
 		self.asval_snp_npc.use_sniper_trail = true
-				
+
 		--Railgun
-		self.railgun_npc = deep_clone(self.m14_sniper_npc)	
+		self.railgun_npc = deep_clone(self.m14_sniper_npc)
 		self.railgun_npc.CLIP_AMMO_MAX = 4
 		self.railgun_npc.DAMAGE = 18
-		self.railgun_npc.trail_effect = Idstring("effects/particles/weapons/sniper_trail_sc")		
-		self.railgun_npc.use_sniper_trail = true		
+		self.railgun_npc.trail_effect = Idstring("effects/particles/weapons/sniper_trail_sc")
+		self.railgun_npc.use_sniper_trail = true
 		--self.railgun_npc.sounds.prefix = "barrett_npc"
 	end
-	
+
 	function WeaponTweakData:_init_data_heavy_snp_npc()
 		--Zeal Sniper variant (unused)
-		self.heavy_snp_npc = deep_clone(self.m14_sniper_npc)	
-	end	
-	
+		self.heavy_snp_npc = deep_clone(self.m14_sniper_npc)
+	end
+
 	function WeaponTweakData:_init_data_r870_npc()
 		self.r870_npc.categories = clone(self.r870.categories)
 		self.r870_npc.sounds.prefix = "remington_npc"
@@ -1293,18 +1293,18 @@ local crew_wep_preset = {
 		self.r870_npc.rays = 6
 		self.r870_npc.spread = 3
 		self.r870_npc.FIRE_MODE = "single"
-			
+
 		self.r870_taser_npc = deep_clone(self.r870_npc)
 		self.r870_taser_npc.sounds.prefix = "keltec_npc"
 		self.r870_taser_npc.DAMAGE = 5
 		self.r870_taser_npc.CLIP_AMMO_MAX = 8
-	
+
 		self.m500_npc = deep_clone(self.r870_npc)
 		self.m500_npc.sounds.prefix = "m590_npc"
 
-		self.fort_500_npc = deep_clone(self.r870_npc)		
+		self.fort_500_npc = deep_clone(self.r870_npc)
 	end
-	
+
 	function WeaponTweakData:_init_data_mossberg_npc()
 		self.mossberg_npc.categories = {"shotgun"}
 		self.mossberg_npc.sounds.prefix = "remington_npc"
@@ -1322,7 +1322,7 @@ local crew_wep_preset = {
 		self.mossberg_npc.spread = 3
 		self.mossberg_npc.FIRE_MODE = "single"
 	end
-	
+
 	function WeaponTweakData:_init_data_mp5_npc()
 		self.mp5_npc.categories = clone(self.new_mp5.categories)
 		self.mp5_npc.sounds.prefix = "mp5_npc"
@@ -1338,16 +1338,16 @@ local crew_wep_preset = {
 		self.mp5_npc.alert_size = 2500
 		self.mp5_npc.suppression = 2.4
 		self.mp5_npc.FIRE_MODE = "auto"
-		
+
 		--Cloaker Mp5
 		self.mp5_tactical_npc = deep_clone(self.mp5_npc)
 		self.mp5_tactical_npc.has_suppressor = "suppressed_a"
 		self.mp5_tactical_npc.alert_size = 0
 		self.mp5_tactical_npc.suppression = 0.1
-		
+
 		--T. Cloaker Mp5
 		self.mp5_cloak_npc = deep_clone(self.mp5_npc)
-		
+
 		--UMP
 		self.ump_npc = deep_clone(self.mp5_npc)
 		self.ump_npc.DAMAGE = 3
@@ -1356,37 +1356,37 @@ local crew_wep_preset = {
 		self.ump_npc.CLIP_AMMO_MAX = 25
 		self.ump_npc.alert_size = 2500
 		self.ump_npc.suppression = 2.8
-		
+
 		--Los Federales UZI
 		self.uzi_npc = deep_clone(self.mp5_npc)
 		self.uzi_npc.has_suppressor = "suppressed_c"
 		self.uzi_npc.alert_size = 0
 		self.uzi_npc.suppression = 0.1
-	
+
 		--ASVAL
-		self.asval_smg_npc = deep_clone(self.mp5_npc)		
+		self.asval_smg_npc = deep_clone(self.mp5_npc)
 		self.asval_smg_npc.DAMAGE = 3
 		self.asval_smg_npc.auto.fire_rate = 0.083
 		self.asval_smg_npc.CLIP_AMMO_MAX = 25
-		self.asval_smg_npc.suppression = 2.8		
+		self.asval_smg_npc.suppression = 2.8
 		self.asval_smg_npc.alert_size = 2500
-		self.asval_smg_npc.sounds.prefix = "akmsu_npc"		
-		
+		self.asval_smg_npc.sounds.prefix = "akmsu_npc"
+
 		--vityaz
 		self.akmsu_smg_npc = deep_clone(self.mp5_npc)
 		self.akmsu_smg_npc.sounds.prefix = "vityaz_npc"
 
 		self.aksu_smg_npc = deep_clone(self.ump_npc)
 		self.aksu_smg_npc.sounds.prefix = "akmsu_npc"
-		
+
 		self.akmsu_tactical_smg_npc = deep_clone(self.mp5_tactical_npc)
 		self.akmsu_tactical_smg_npc.has_suppressor = "suppressed_c"
-	
+
 		--Autumn MPX
 		self.mpx_npc = deep_clone(self.mp5_tactical_npc)
 		self.mpx_npc.auto.fire_rate = 0.07058823529
 		self.mpx_npc.DAMAGE = 2.5
-		
+
 		--Titan HRT MP9
 		self.mp9_titan_npc = deep_clone(self.mp5_npc)
 		self.mp9_titan_npc.sounds.prefix = "mp9_npc"
@@ -1397,12 +1397,12 @@ local crew_wep_preset = {
 		self.mp9_titan_npc.alert_size = 2500
 		self.mp9_titan_npc.suppression = 2.2
 		self.mp9_titan_npc.anim_usage = "is_pistol"
-		
+
 		--Titan HRT SR2
 		self.sr2_smg_titan_npc = deep_clone(self.mp9_titan_npc)
-		self.sr2_smg_titan_npc.sounds.prefix = "sr2_npc"			
+		self.sr2_smg_titan_npc.sounds.prefix = "sr2_npc"
 	end
-	
+
 	function WeaponTweakData:_init_data_smoke_npc()
 		self.smoke_npc.categories = clone(self.new_mp5.categories)
 		self.smoke_npc.sounds.prefix = "mp5_npc"
@@ -1418,8 +1418,8 @@ local crew_wep_preset = {
 		self.smoke_npc.alert_size = 2500
 		self.smoke_npc.suppression = 2.4
 		self.smoke_npc.FIRE_MODE = "auto"
-	end	
-	
+	end
+
 	function WeaponTweakData:_init_data_mac11_npc()
 		self.mac11_npc.categories = {"smg"}
 		self.mac11_npc.sounds.prefix = "mac10_npc"
@@ -1437,7 +1437,7 @@ local crew_wep_preset = {
 		self.mac11_npc.suppression = 2.8
 		self.mac11_npc.FIRE_MODE = "auto"
 	end
-	
+
 	function WeaponTweakData:_init_data_g36_npc()
 		--G36
 		self.g36_npc.categories = clone(self.g36.categories)
@@ -1454,7 +1454,7 @@ local crew_wep_preset = {
 		self.g36_npc.suppression = 2.6
 		self.g36_npc.FIRE_MODE = "auto"
 	end
-	
+
 	function WeaponTweakData:_init_data_mp9_npc()
 		--NPC MP9
 		self.mp9_npc.categories = clone(self.mp9.categories)
@@ -1475,12 +1475,12 @@ local crew_wep_preset = {
 		self.mp9_npc.alert_size = 2500
 		self.mp9_npc.suppression = 2.2
 		self.mp9_npc.FIRE_MODE = "auto"
-		
+
 		--SR2
 		self.sr2_smg_npc = deep_clone(self.mp9_npc)
-		self.sr2_smg_npc.sounds.prefix = "sr2_npc"		
+		self.sr2_smg_npc.sounds.prefix = "sr2_npc"
 	end
-	
+
 	function WeaponTweakData:_init_data_saiga_npc()
 		--Saiga
 		self.saiga_npc.categories = clone(self.saiga.categories)
@@ -1499,12 +1499,12 @@ local crew_wep_preset = {
 		self.saiga_npc.rays = 6
 		self.saiga_npc.spread = 3
 		self.saiga_npc.FIRE_MODE = "auto"
-			
-		self.aa12_npc = deep_clone(self.saiga_npc)	
+
+		self.aa12_npc = deep_clone(self.saiga_npc)
 		self.aa12_npc.sounds.prefix = "aa12_npc"
-		
+
 		--Titan Shotgunner AA12, less lethal
-		self.aa12_conc_npc = deep_clone(self.aa12_npc)	
+		self.aa12_conc_npc = deep_clone(self.aa12_npc)
 		self.aa12_conc_npc.DAMAGE = 1
 		self.aa12_conc_npc.bullet_class = "ConcussiveInstantBulletBase"
 		self.aa12_conc_npc.concussion_data = {
@@ -1514,34 +1514,34 @@ local crew_wep_preset = {
 				mul = 0.3,
 				additional = 4
 			}
-		}	
+		}
 
-		self.saiga_conc_npc = deep_clone(self.aa12_conc_npc)	
+		self.saiga_conc_npc = deep_clone(self.aa12_conc_npc)
 		self.saiga_conc_npc.sounds.prefix = "saiga_npc"
-		
+
 		self.benelli_npc = deep_clone(self.saiga_npc)
 		self.benelli_npc.sounds.prefix = "benelli_m4_npc"
 		self.benelli_npc.DAMAGE = 4.5
 		self.benelli_npc.CLIP_AMMO_MAX = 10
 		self.benelli_npc.alert_size = 2500
-		self.benelli_npc.suppression = 3	
+		self.benelli_npc.suppression = 3
 		self.benelli_npc.auto = nil
 		self.benelli_npc.FIRE_MODE = "single"
 		self.benelli_npc.usage = "is_shotgun_semi"
 		self.benelli_npc.anim_usage = "is_shotgun_pump"
-		
+
 		self.bayou_npc = deep_clone(self.benelli_npc)
 		self.bayou_npc.sounds.prefix = "spas_npc"
 		self.bayou_npc.DAMAGE = 4.5
 		self.bayou_npc.CLIP_AMMO_MAX = 10
 		self.bayou_npc.alert_size = 2500
-		self.bayou_npc.suppression = 3	
+		self.bayou_npc.suppression = 3
 
 		--Reaper Bravo Argos
 		self.argos_bravo_npc = deep_clone(self.bayou_npc)
-		self.argos_bravo_npc.sounds.prefix = "ultima_npc"		
+		self.argos_bravo_npc.sounds.prefix = "ultima_npc"
 	end
-	
+
 	--Vanilla Deagle, less lethal (Marshal Shields)
 	function WeaponTweakData:_init_data_deagle_npc()
 		self.deagle_npc = deep_clone(self.raging_bull_npc)
@@ -1550,7 +1550,7 @@ local crew_wep_preset = {
 		self.deagle_npc.sounds.prefix = "deagle_npc"
 		self.deagle_npc.anim_usage = "is_pistol"
 		self.deagle_npc.hold = "pistol"
-		self.deagle_npc.reload = "pistol"	
+		self.deagle_npc.reload = "pistol"
 	end
 
 	--Marshal Shield Phase 2 Shotgun, less lethal
@@ -1576,8 +1576,8 @@ local crew_wep_preset = {
 				additional = 4
 			}
 		}
-	end	
-			
+	end
+
 	function WeaponTweakData:_init_data_swat_van_turret_module_npc()
 		self.swat_van_turret_module.name_id = "debug_sentry_gun"
 		self.swat_van_turret_module.DAMAGE = 2
@@ -1662,7 +1662,7 @@ local crew_wep_preset = {
 		self.swat_van_turret_module.challenges.weapon = "sentry_gun"
 		self.swat_van_turret_module.suppression = 1
 	end
-	
+
 	function WeaponTweakData:_init_data_crate_turret_module_npc()
 		self.crate_turret_module.name_id = "debug_sentry_gun"
 		self.crate_turret_module.DAMAGE = 2
@@ -1743,8 +1743,8 @@ local crew_wep_preset = {
 			weapon = "sentry_gun"
 		}
 		self.crate_turret_module.suppression = 0.8
-	end	
-	
+	end
+
 	function WeaponTweakData:_init_data_ceiling_turret_module_npc()
 		self.ceiling_turret_module.name_id = "debug_sentry_gun"
 		self.ceiling_turret_module.DAMAGE = 2
@@ -1822,9 +1822,9 @@ local crew_wep_preset = {
 		self.ceiling_turret_module_longer_range = deep_clone(self.ceiling_turret_module)
 		self.ceiling_turret_module_longer_range.CAN_GO_IDLE = false
 		self.ceiling_turret_module_longer_range.FIRE_RANGE = 30000
-		self.ceiling_turret_module_longer_range.DETECTION_RANGE = self.ceiling_turret_module_longer_range.FIRE_RANGE		
+		self.ceiling_turret_module_longer_range.DETECTION_RANGE = self.ceiling_turret_module_longer_range.FIRE_RANGE
 	end
-	
+
 	function WeaponTweakData:_init_data_aa_turret_module_npc()
 		self.aa_turret_module.name_id = "debug_sentry_gun"
 		self.aa_turret_module.DAMAGE = 2
@@ -1896,9 +1896,9 @@ local crew_wep_preset = {
 		self.aa_turret_module.challenges = {}
 		self.aa_turret_module.challenges.group = "sentry_gun"
 		self.aa_turret_module.challenges.weapon = "sentry_gun"
-		self.aa_turret_module.suppression = 1	
-	end	
-			
+		self.aa_turret_module.suppression = 1
+	end
+
 	function WeaponTweakData:_init_data_s552_npc()
 		--Sig 553
 		self.s552_npc.categories = clone(self.s552.categories)
@@ -1915,8 +1915,8 @@ local crew_wep_preset = {
 		self.s552_npc.suppression = 2.6
 		self.s552_npc.FIRE_MODE = "auto"
 		self.s552_npc.has_suppressor = "suppressed_c"
-	end	
-	
+	end
+
 	function WeaponTweakData:_init_data_scar_npc()
 		--M14/Socom 16/SCAR-H
 		self.scar_npc.categories = clone(self.scar.categories)
@@ -1935,11 +1935,11 @@ local crew_wep_preset = {
 		self.scar_npc.trail_effect = Idstring("effects/particles/weapons/titan_trail_sc")
 		self.scar_npc.use_sniper_trail = true
 		self.scar_npc.usage = "is_dmr"
-		self.scar_npc.anim_usage = "is_rifle"	
+		self.scar_npc.anim_usage = "is_rifle"
 		self.scar_secondary_npc = deep_clone(self.scar_npc)
 		self.scar_secondary_npc.use_data.selection_index = 1
 	end
-	
+
 	function WeaponTweakData:_init_data_dmr_npc()
 		--US Marshal DMR
 		self.dmr_npc = deep_clone(self.scar_npc)
@@ -1947,18 +1947,18 @@ local crew_wep_preset = {
 		self.dmr_npc.trail_effect = Idstring("effects/particles/weapons/titan_trail_sc")
 		self.dmr_npc.use_sniper_trail = true
 		self.dmr_npc.trail = nil
-		
+
 		--Type-7
-		self.type_7_npc = deep_clone(self.scar_npc)		
+		self.type_7_npc = deep_clone(self.scar_npc)
 		self.type_7_npc.DAMAGE = 1
 		self.type_7_npc.CLIP_AMMO_MAX = 10
-		self.type_7_npc.sounds.prefix = "saint_victor_npc"		
+		self.type_7_npc.sounds.prefix = "saint_victor_npc"
 		--Needs a new muzzleflash + Trail effect pls
 		--self.type_7_npc.muzzleflash =  Idstring("effects/payday2/particles/character/taser_hittarget")
 		self.type_7_npc.trail_effect = Idstring("effects/particles/weapons/akan_titan_trail_sc")
 		self.type_7_npc.use_sniper_trail = true
-	end	
-	
+	end
+
 	function WeaponTweakData:_init_data_m249_npc()
 		--M249
 		self.m249_npc.categories = clone(self.m249.categories)
@@ -1974,15 +1974,15 @@ local crew_wep_preset = {
 		self.m249_npc.alert_size = 2500
 		self.m249_npc.suppression = 2
 		self.m249_npc.FIRE_MODE = "auto"
-		
+
 		--RPK
 		self.rpk_lmg_npc = deep_clone(self.m249_npc)
-		self.rpk_lmg_npc.sounds.prefix = "rpk_npc"		
-		
+		self.rpk_lmg_npc.sounds.prefix = "rpk_npc"
+
 		--HK21
 		self.hk21_sc_npc = deep_clone(self.m249_npc)
 		self.hk21_sc_npc.sounds.prefix = "hk23e_npc"
-		
+
 		--Hatman's MG42 of EVIL
 		self.mg42_npc = deep_clone(self.m249_npc)
 		self.mg42_npc.sounds.prefix = "mg42_npc"
@@ -1997,9 +1997,9 @@ local crew_wep_preset = {
 		self.hk21_sc_npc.alert_size = 2500
 		self.hk21_sc_npc.suppression = 2.4
 		self.hk21_sc_npc.usage = "is_lmg"]]--
-		
+
 		--HK23
-		self.hk23_sc_npc = deep_clone(self.hk21_sc_npc)	
+		self.hk23_sc_npc = deep_clone(self.hk21_sc_npc)
 		self.hk23_sc_npc.use_data.selection_index = 2
 		self.hk23_sc_npc.DAMAGE = 2
 		self.hk23_sc_npc.muzzleflash = "_dmc/effects/heavy_muzzle"
@@ -2010,35 +2010,35 @@ local crew_wep_preset = {
 		self.hk23_sc_npc.hold = "rifle"
 		self.hk23_sc_npc.alert_size = 2500
 		self.hk23_sc_npc.suppression = 2.4
-		
+
 		--M60
-		self.m60_npc = deep_clone(self.m249_npc)	
+		self.m60_npc = deep_clone(self.m249_npc)
 		self.m60_npc.sounds.prefix = "m60_npc"
-	
+
 		--Bravo LMG--
-		self.m249_bravo_npc = deep_clone(self.hk23_sc_npc)	
+		self.m249_bravo_npc = deep_clone(self.hk23_sc_npc)
 		self.m249_bravo_npc.sounds.prefix = "m249_npc"
 		self.m249_bravo_npc.CLIP_AMMO_MAX = 200
-		
+
 		--Reaper Bravo LMG--
-		self.rpk74_bravo_npc = deep_clone(self.m249_bravo_npc)	
+		self.rpk74_bravo_npc = deep_clone(self.m249_bravo_npc)
 		self.rpk74_bravo_npc.sounds.prefix = "rpk_npc"
-		
+
 		--Murky Bravo M60
 		self.m60_bravo_npc = deep_clone(self.hk23_sc_npc)
 		self.m60_bravo_npc.sounds.prefix = "m60_npc"
 		self.m60_bravo_npc.CLIP_AMMO_MAX = 200
-		
+
 		--Federales Bravo HK21
 		self.hk21_bravo_npc = deep_clone(self.hk23_sc_npc)
 		self.hk21_bravo_npc.sounds.prefix = "hk23e_npc"
 		self.hk21_bravo_npc.CLIP_AMMO_MAX = 200
-		
+
 		--M60 Omnia
-		self.m60_om_npc = deep_clone(self.m249_npc)	
-		self.m60_om_npc.sounds.prefix = "m60_npc"	
+		self.m60_om_npc = deep_clone(self.m249_npc)
+		self.m60_om_npc.sounds.prefix = "m60_npc"
 	end
-	
+
 	function WeaponTweakData:_init_data_contraband_npc()
 		--HK417
 		self.contraband_npc.categories = clone(self.contraband.categories)
@@ -2053,8 +2053,8 @@ local crew_wep_preset = {
 		self.contraband_npc.hold = "rifle"
 		self.contraband_npc.alert_size = 2500
 		self.contraband_npc.suppression = 2.6
-		self.contraband_npc.FIRE_MODE = "auto"	
-	
+		self.contraband_npc.FIRE_MODE = "auto"
+
 		--M203
 		self.contraband_m203_npc.sounds.prefix = "contrabandm203_npc"
 		self.contraband_m203_npc.use_data.selection_index = 2
@@ -2069,23 +2069,23 @@ local crew_wep_preset = {
 		self.contraband_m203_npc.hold = "rifle"
 		self.contraband_m203_npc.alert_size = 2500
 		self.contraband_m203_npc.suppression = 1
-		
-		--M32 
+
+		--M32
 		self.m32_npc = deep_clone(self.contraband_m203_npc)
 		self.m32_npc.sounds.prefix = "mgl_npc"
 		self.m32_npc.anim_usage = "is_shotgun_pump"
 		self.m32_npc.usage = "is_m32"
 		self.m32_npc.projectile = "launcher_frag_m32"
-		self.m32_npc.CLIP_AMMO_MAX = 6	
+		self.m32_npc.CLIP_AMMO_MAX = 6
 		self.m32_npc.looped_reload_speed = nil
 		self.m32_npc.has_fire_animation = true
 		self.m32_npc.animations = { fire = "recoil" }
-		
+
 		self.m32_boom_npc = deep_clone(self.m32_npc)
 		self.m32_boom_npc.gl_cooldown_max = 10
 		self.m32_boom_npc.gl_speaking_cooldown = 0.9
 		self.m32_boom_npc.gl_voiceline = true
-		
+
 		--RPG-7
 		self.rpg7_npc = deep_clone(self.contraband_m203_npc)
 		self.rpg7_npc.sounds.prefix = "rpg_npc"
@@ -2093,9 +2093,9 @@ local crew_wep_preset = {
 		self.rpg7_npc.usage = "is_m32"
 		self.rpg7_npc.projectile = "rocket_frag"
 		self.rpg7_npc.CLIP_AMMO_MAX = 1
-		self.rpg7_npc.looped_reload_speed = nil		
+		self.rpg7_npc.looped_reload_speed = nil
 	end
-	
+
 	function WeaponTweakData:_init_data_mini_npc()
 		self.mini_npc.categories = clone(self.m134.categories)
 		self.mini_npc.sounds.prefix = "minigun_npc"
@@ -2110,13 +2110,13 @@ local crew_wep_preset = {
 		self.mini_npc.alert_size = 2500
 		self.mini_npc.suppression = 2
 		self.mini_npc.FIRE_MODE = "auto"
-		
+
 		--Akimbo Miniguns
-		self.x_mini_npc = deep_clone(self.mini_npc)		
+		self.x_mini_npc = deep_clone(self.mini_npc)
 		self.x_mini_npc.categories = {
 			"akimbo",
 			"minigun"
-		}	
+		}
 		self.x_mini_npc.sounds.prefix = "minigun_npc"
 		self.x_mini_npc.use_data.selection_index = 1
 		self.x_mini_npc.DAMAGE = 3
@@ -2128,9 +2128,9 @@ local crew_wep_preset = {
 		self.x_mini_npc.hold = "akimbo_pistol"
 		self.x_mini_npc.alert_size = 2500
 		self.x_mini_npc.suppression = 2
-		self.x_mini_npc.FIRE_MODE = "auto"		
+		self.x_mini_npc.FIRE_MODE = "auto"
 	end
-	
+
 	function WeaponTweakData:_init_data_flamethrower_npc()
 		--NPC flamethrower
 		self.flamethrower_npc.categories = {
@@ -2160,7 +2160,7 @@ local crew_wep_preset = {
 		self.flamethrower_npc.suppression = 3.1
 		self.flamethrower_npc.FIRE_MODE = "auto"
 	end
-	
+
 	function WeaponTweakData:_init_data_snowthrower_npc()
 		self.snowthrower_npc.categories = {
 			"flamethrower"
@@ -2188,8 +2188,8 @@ local crew_wep_preset = {
 		self.snowthrower_npc.alert_size = 2500
 		self.snowthrower_npc.suppression = 3.1
 		self.snowthrower_npc.FIRE_MODE = "auto"
-	end	
-	
+	end
+
 	--Lotta crew guns in here now--
 	--PISTOLS
 		function WeaponTweakData:_init_data_raging_bull_crew()
@@ -2228,8 +2228,8 @@ local crew_wep_preset = {
 			self.shepheard_crew.alert_size = 2500
 			self.shepheard_crew.suppression = 2.2
 			self.shepheard_crew.FIRE_MODE = "auto"
-		end	
-	
+		end
+
 		function WeaponTweakData:_init_data_erma_crew()
 			self.erma_crew.categories = clone(self.erma.categories)
 			self.erma_crew.sounds.prefix = "erma_npc"
@@ -2247,8 +2247,8 @@ local crew_wep_preset = {
 			self.erma_crew.alert_size = 2500
 			self.erma_crew.suppression = 2.2
 			self.erma_crew.FIRE_MODE = "auto"
-		end	
-	
+		end
+
 		function WeaponTweakData:_init_data_vityaz_crew()
 			self.vityaz_crew.categories = clone(self.vityaz.categories)
 			self.vityaz_crew.sounds.prefix = "vityaz_npc"
@@ -2267,8 +2267,8 @@ local crew_wep_preset = {
 			self.vityaz_crew.FIRE_MODE = "auto"
 			self.vityaz_primary_crew = deep_clone(self.vityaz_crew)
 			self.vityaz_primary_crew.use_data.selection_index = 2
-		end	
-	
+		end
+
 		function WeaponTweakData:_init_data_polymer_crew()
 			self.polymer_crew.categories = clone(self.polymer.categories)
 			self.polymer_crew.sounds.prefix = "polymer_npc"
@@ -2290,7 +2290,7 @@ local crew_wep_preset = {
 			self.polymer_crew.suppression = 2.2
 			self.polymer_crew.FIRE_MODE = "auto"
 		end
-		
+
 		function WeaponTweakData:_init_data_schakal_crew()
 			self.schakal_crew.categories = clone(self.schakal.categories)
 			self.schakal_crew.sounds.prefix = "schakal_npc"
@@ -2311,7 +2311,7 @@ local crew_wep_preset = {
 			self.schakal_crew.alert_size = 2500
 			self.schakal_crew.suppression = 2.2
 			self.schakal_crew.FIRE_MODE = "auto"
-		end	
+		end
 
 		function WeaponTweakData:_init_data_pm9_crew()
 			self.pm9_crew.categories = clone(self.pm9.categories)
@@ -2330,7 +2330,7 @@ local crew_wep_preset = {
 			self.pm9_crew.suppression = 2.2
 			self.pm9_crew.FIRE_MODE = "auto"
 		end
-	
+
 		function WeaponTweakData:_init_data_coal_crew()
 			self.coal_crew.categories = clone(self.coal.categories)
 			self.coal_crew.sounds.prefix = "coal_npc"
@@ -2371,7 +2371,7 @@ local crew_wep_preset = {
 			self.hailstorm_crew.suppression = 2.2
 			self.hailstorm_crew.FIRE_MODE = "auto"
 		end
-	
+
 	--ARs
 		function WeaponTweakData:_init_data_akm_gold_crew()
 			self.akm_gold_crew.categories = clone(self.akm_gold.categories)
@@ -2389,7 +2389,7 @@ local crew_wep_preset = {
 			self.akm_gold_crew.suppression = 2.2
 			self.akm_gold_crew.FIRE_MODE = "auto"
 		end
-		
+
 		function WeaponTweakData:_init_data_amcar_crew()
 			self.amcar_crew.categories = clone(self.amcar.categories)
 			self.amcar_crew.sounds.prefix = "amcar_npc"
@@ -2406,7 +2406,7 @@ local crew_wep_preset = {
 			self.amcar_crew.suppression = 2.2
 			self.amcar_crew.FIRE_MODE = "auto"
 		end
-		
+
 		function WeaponTweakData:_init_data_ak74_crew()
 			self.ak74_crew.categories = clone(self.ak74.categories)
 			self.ak74_crew.sounds.prefix = "ak74_npc"
@@ -2425,7 +2425,7 @@ local crew_wep_preset = {
 			self.ak74_secondary_crew = deep_clone(self.ak74_crew)
 			self.ak74_secondary_crew.use_data.selection_index = 1
 		end
-		
+
 		function WeaponTweakData:_init_data_m4_crew()
 			self.m4_crew.categories = clone(self.new_m4.categories)
 			self.m4_crew.sounds.prefix = "m4_npc"
@@ -2445,7 +2445,7 @@ local crew_wep_preset = {
 			self.m4_secondary_crew.use_data.selection_index = 1
 			self.ak47_ass_crew = deep_clone(self.m4_crew)
 		end
-		
+
 		function WeaponTweakData:_init_data_aug_crew()
 			self.aug_crew.categories = clone(self.aug.categories)
 			self.aug_crew.sounds.prefix = "aug_npc"
@@ -2464,7 +2464,7 @@ local crew_wep_preset = {
 			self.aug_secondary_crew = deep_clone(self.aug_crew)
 			self.aug_secondary_crew.use_data.selection_index = 1
 		end
-		
+
 		function WeaponTweakData:_init_data_akm_crew()
 			self.akm_crew.categories = clone(self.akm.categories)
 			self.akm_crew.sounds.prefix = "akm_npc"
@@ -2497,7 +2497,7 @@ local crew_wep_preset = {
 			self.tkb_crew.suppression = 2.2
 			self.tkb_crew.FIRE_MODE = "auto"
 		end
-		
+
 		function WeaponTweakData:_init_data_g36_crew()
 			self.g36_crew.categories = clone(self.g36.categories)
 			self.g36_crew.sounds.prefix = "g36_npc"
@@ -2514,7 +2514,7 @@ local crew_wep_preset = {
 			self.g36_crew.suppression = 2.2
 			self.g36_crew.FIRE_MODE = "auto"
 		end
-		
+
 		function WeaponTweakData:_init_data_ak5_crew()
 			self.ak5_crew.categories = clone(self.ak5.categories)
 			self.ak5_crew.sounds.prefix = "ak5_npc"
@@ -2531,7 +2531,7 @@ local crew_wep_preset = {
 			self.ak5_crew.suppression = 2.2
 			self.ak5_crew.FIRE_MODE = "auto"
 		end
-	
+
 		function WeaponTweakData:_init_data_m16_crew()
 			self.m16_crew.categories = clone(self.m16.categories)
 			self.m16_crew.sounds.prefix = "m16_npc"
@@ -2548,7 +2548,7 @@ local crew_wep_preset = {
 			self.m16_crew.pull_magazine_during_reload = "rifle"
 			self.m16_crew.FIRE_MODE = "auto"
 		end
-	
+
 		function WeaponTweakData:_init_data_s552_crew()
 			self.s552_crew.categories = clone(self.s552.categories)
 			self.s552_crew.sounds.prefix = "sig552_npc"
@@ -2567,7 +2567,7 @@ local crew_wep_preset = {
 			self.s552_secondary_crew = deep_clone(self.s552_crew)
 			self.s552_secondary_crew.use_data.selection_index = 1
 		end
-		
+
 		function WeaponTweakData:_init_data_scar_crew()
 			self.scar_crew.categories = clone(self.scar.categories)
 			self.scar_crew.sounds.prefix = "scar_npc"
@@ -2584,7 +2584,7 @@ local crew_wep_preset = {
 			self.scar_crew.suppression = 2.2
 			self.scar_crew.FIRE_MODE = "auto"
 		end
-		
+
 		function WeaponTweakData:_init_data_fal_crew()
 			self.fal_crew.categories = clone(self.fal.categories)
 			self.fal_crew.sounds.prefix = "fn_fal_npc"
@@ -2601,7 +2601,7 @@ local crew_wep_preset = {
 			self.fal_crew.suppression = 2.2
 			self.fal_crew.FIRE_MODE = "auto"
 		end
-	
+
 		function WeaponTweakData:_init_data_famas_crew()
 			self.famas_crew.categories = clone(self.famas.categories)
 			self.famas_crew.sounds.prefix = "famas_npc"
@@ -2618,7 +2618,7 @@ local crew_wep_preset = {
 			self.famas_crew.suppression = 2.2
 			self.famas_crew.FIRE_MODE = "auto"
 		end
-		
+
 		function WeaponTweakData:_init_data_galil_crew()
 			self.galil_crew.categories = clone(self.galil.categories)
 			self.galil_crew.sounds.prefix = "galil_npc"
@@ -2635,7 +2635,7 @@ local crew_wep_preset = {
 			self.galil_crew.suppression = 2.2
 			self.galil_crew.FIRE_MODE = "auto"
 		end
-		
+
 		function WeaponTweakData:_init_data_l85a2_crew()
 			self.l85a2_crew.categories = clone(self.l85a2.categories)
 			self.l85a2_crew.sounds.prefix = "l85_npc"
@@ -2654,7 +2654,7 @@ local crew_wep_preset = {
 			self.l85a2_crew.suppression = 2.2
 			self.l85a2_crew.FIRE_MODE = "auto"
 		end
-		
+
 		function WeaponTweakData:_init_data_vhs_crew()
 			self.vhs_crew.categories = clone(self.vhs.categories)
 			self.vhs_crew.sounds.prefix = "vhs_npc"
@@ -2672,7 +2672,7 @@ local crew_wep_preset = {
 			self.vhs_crew.suppression = 2.2
 			self.vhs_crew.FIRE_MODE = "auto"
 		end
-		
+
 		function WeaponTweakData:_init_data_asval_crew()
 			self.asval_crew.categories = clone(self.asval.categories)
 			self.asval_crew.sounds.prefix = "akm_npc"
@@ -2689,7 +2689,7 @@ local crew_wep_preset = {
 			self.asval_crew.suppression = 3.4
 			self.asval_crew.FIRE_MODE = "auto"
 		end
-		
+
 		function WeaponTweakData:_init_data_contraband_crew()
 			self.contraband_crew.categories = clone(self.contraband.categories)
 			self.contraband_crew.sounds.prefix = "contraband_npc"
@@ -2721,7 +2721,7 @@ local crew_wep_preset = {
 			self.contraband_m203_crew.suppression = 1
 			self.contraband_m203_crew.FIRE_MODE = "auto"
 		end
-	
+
 		function WeaponTweakData:_init_data_groza_crew()
 			self.groza_crew.categories = clone(self.groza.categories)
 			self.groza_crew.sounds.prefix = "groza_npc"
@@ -2756,7 +2756,7 @@ local crew_wep_preset = {
 			self.groza_underbarrel_crew.suppression = 1
 			self.groza_underbarrel_crew.FIRE_MODE = "auto"
 		end
-		
+
 		function WeaponTweakData:_init_data_flint_crew()
 			self.flint_crew.categories = clone(self.flint.categories)
 			self.flint_crew.sounds.prefix = "flint_npc"
@@ -2773,7 +2773,7 @@ local crew_wep_preset = {
 			self.flint_crew.suppression = 2.2
 			self.flint_crew.FIRE_MODE = "auto"
 		end
-		
+
 		function WeaponTweakData:_init_data_corgi_crew()
 			self.corgi_crew.categories = clone(self.corgi.categories)
 			self.corgi_crew.sounds.prefix = "corgi_npc"
@@ -2793,8 +2793,8 @@ local crew_wep_preset = {
 			self.corgi_crew.alert_size = 2500
 			self.corgi_crew.suppression = 2.2
 			self.corgi_crew.FIRE_MODE = "auto"
-		end		
-		
+		end
+
 		function WeaponTweakData:_init_data_komodo_crew()
 			self.komodo_crew.categories = clone(self.komodo.categories)
 			self.komodo_crew.sounds.prefix = "komodo_npc"
@@ -2814,8 +2814,8 @@ local crew_wep_preset = {
 			self.komodo_crew.alert_size = 2500
 			self.komodo_crew.suppression = 2.2
 			self.komodo_crew.FIRE_MODE = "auto"
-		end		
-	
+		end
+
 	--SHOTGUNS
 		function WeaponTweakData:_init_data_ben_crew()
 			self.ben_crew.categories = {"shotgun"}
@@ -2837,7 +2837,7 @@ local crew_wep_preset = {
 			self.ben_crew.FIRE_MODE = "single"
 			self.benelli_crew = deep_clone(self.ben_crew)
 		end
-		
+
 		function WeaponTweakData:_init_data_spas12_crew()
 			self.spas12_crew.categories = clone(self.spas12.categories)
 			self.spas12_crew.sounds.prefix = "spas_npc"
@@ -2856,7 +2856,7 @@ local crew_wep_preset = {
 			self.spas12_crew.is_shotgun = true
 			self.spas12_crew.FIRE_MODE = "single"
 		end
-		
+
 		function WeaponTweakData:_init_data_ultima_crew()
 			self.ultima_crew.categories = clone(self.ultima.categories)
 			self.ultima_crew.sounds.prefix = "ultima_npc"
@@ -2873,8 +2873,8 @@ local crew_wep_preset = {
 			self.ultima_crew.suppression = 3.4
 			self.ultima_crew.FIRE_MODE = "single"
 			self.ultima_crew.is_shotgun = true
-		end	
-	
+		end
+
 		function WeaponTweakData:_init_data_aa12_crew()
 			self.aa12_crew.categories = clone(self.aa12.categories)
 			self.aa12_crew.sounds.prefix = "aa12_npc"
@@ -2893,7 +2893,7 @@ local crew_wep_preset = {
 			self.aa12_crew.rays = 8
 			self.aa12_crew.FIRE_MODE = "auto"
 		end
-		
+
 		function WeaponTweakData:_init_data_sko12_crew()
 			self.sko12_crew.categories = clone(self.sko12.categories)
 			self.sko12_crew.sounds.prefix = "sko12_npc"
@@ -2912,7 +2912,7 @@ local crew_wep_preset = {
 			self.sko12_crew.rays = 8
 			self.sko12_crew.FIRE_MODE = "auto"
 		end
-		
+
 		function WeaponTweakData:_init_data_saiga_crew()
 			self.saiga_crew.categories = clone(self.saiga.categories)
 			self.saiga_crew.sounds.prefix = "saiga_npc"
@@ -2931,7 +2931,7 @@ local crew_wep_preset = {
 			self.saiga_crew.is_shotgun = true
 			self.saiga_crew.FIRE_MODE = "auto"
 		end
-		
+
 		function WeaponTweakData:_init_data_b682_crew()
 			self.b682_crew.categories = clone(self.b682.categories)
 			self.b682_crew.sounds.prefix = "b682_npc"
@@ -2950,7 +2950,7 @@ local crew_wep_preset = {
 			self.b682_crew.is_shotgun = true
 			self.b682_crew.FIRE_MODE = "single"
 		end
-		
+
 		function WeaponTweakData:_init_data_r870_crew()
 			self.r870_crew.categories = clone(self.r870.categories)
 			self.r870_crew.sounds.prefix = "remington_npc"
@@ -2967,9 +2967,9 @@ local crew_wep_preset = {
 			self.r870_crew.suppression = 3.4
 			self.r870_crew.is_shotgun = true
 			self.r870_crew.rays = 8
-			self.r870_crew.FIRE_MODE = "single"		
+			self.r870_crew.FIRE_MODE = "single"
 		end
-		
+
 		function WeaponTweakData:_init_data_ksg_crew()
 			self.ksg_crew.categories = clone(self.ksg.categories)
 			self.ksg_crew.sounds.prefix = "keltec_npc"
@@ -3007,7 +3007,7 @@ local crew_wep_preset = {
 			self.huntsman_crew.rays = 8
 			self.huntsman_crew.FIRE_MODE = "single"
 		end
-	
+
 		function WeaponTweakData:_init_data_boot_crew()
 			self.boot_crew.categories = clone(self.boot.categories)
 			self.boot_crew.sounds.prefix = "boot_npc"
@@ -3063,7 +3063,7 @@ local crew_wep_preset = {
 			self.m14_crew.suppression = 3.4
 			self.m14_crew.FIRE_MODE = "auto"
 		end
-		
+
 		function WeaponTweakData:_init_data_g3_crew()
 			self.g3_crew.categories = clone(self.g3.categories)
 			self.g3_crew.sounds.prefix = "g3_npc"
@@ -3100,7 +3100,7 @@ local crew_wep_preset = {
 			self.shak12_crew.suppression = 2.2
 			self.shak12_crew.FIRE_MODE = "auto"
 		end
-		
+
 		function WeaponTweakData:_init_data_ching_crew()
 			self.ching_crew.categories = clone(self.ching.categories)
 			self.ching_crew.sounds.prefix = "ching_npc"
@@ -3118,8 +3118,8 @@ local crew_wep_preset = {
 			self.ching_crew.alert_size = 2500
 			self.ching_crew.suppression = 3.4
 			self.ching_crew.FIRE_MODE = "single"
-		end		
-		
+		end
+
 		function WeaponTweakData:_init_data_tti_crew()
 			self.tti_crew.categories = clone(self.tti.categories)
 			self.tti_crew.sounds.prefix = "tti_npc"
@@ -3137,7 +3137,7 @@ local crew_wep_preset = {
 			self.tti_crew.suppression = 3.4
 			self.tti_crew.FIRE_MODE = "single"
 		end
-		
+
 		function WeaponTweakData:_init_data_qbu88_crew()
 			self.qbu88_crew.categories = clone(self.qbu88.categories)
 			self.qbu88_crew.sounds.prefix = "qbu88_npc"
@@ -3155,7 +3155,7 @@ local crew_wep_preset = {
 			self.qbu88_crew.suppression = 3.4
 			self.qbu88_crew.FIRE_MODE = "single"
 		end
-		
+
 		function WeaponTweakData:_init_data_wa2000_crew()
 			self.wa2000_crew.categories = clone(self.wa2000.categories)
 			self.wa2000_crew.sounds.prefix = "lakner_npc"
@@ -3173,7 +3173,7 @@ local crew_wep_preset = {
 			self.wa2000_crew.suppression = 3.4
 			self.wa2000_crew.FIRE_MODE = "single"
 		end
-		
+
 		function WeaponTweakData:_init_data_siltstone_crew()
 			self.siltstone_crew.categories = clone(self.siltstone.categories)
 			self.siltstone_crew.sounds.prefix = "siltstone_npc"
@@ -3209,7 +3209,7 @@ local crew_wep_preset = {
 			self.model70_secondary_crew = deep_clone(self.model70_crew)
 			self.model70_secondary_crew.use_data.selection_index = 1
 		end
-		
+
 		function WeaponTweakData:_init_data_msr_crew()
 			self.msr_crew.categories = clone(self.msr.categories)
 			self.msr_crew.sounds.prefix = "msr_npc"
@@ -3226,7 +3226,7 @@ local crew_wep_preset = {
 			self.msr_crew.suppression = 3.4
 			self.msr_crew.FIRE_MODE = "single"
 		end
-		
+
 		function WeaponTweakData:_init_data_r93_crew()
 			self.r93_crew.categories = clone(self.r93.categories)
 			self.r93_crew.sounds.prefix = "blazer_npc"
@@ -3243,7 +3243,7 @@ local crew_wep_preset = {
 			self.r93_crew.suppression = 3.4
 			self.r93_crew.FIRE_MODE = "single"
 		end
-		
+
 		function WeaponTweakData:_init_data_m95_crew()
 			self.m95_crew.categories = clone(self.m95.categories)
 			self.m95_crew.sounds.prefix = "barrett_npc"
@@ -3261,7 +3261,7 @@ local crew_wep_preset = {
 			self.m95_crew.suppression = 3.4
 			self.m95_crew.FIRE_MODE = "single"
 		end
-		
+
 		function WeaponTweakData:_init_data_mosin_crew()
 			self.mosin_crew.categories = clone(self.mosin.categories)
 			self.mosin_crew.sounds.prefix = "nagant_npc"
@@ -3279,7 +3279,7 @@ local crew_wep_preset = {
 			self.mosin_secondary_crew = deep_clone(self.mosin_crew)
 			self.mosin_secondary_crew.use_data.selection_index = 1
 		end
-		
+
 		--Flintlock (Crew)
 		function WeaponTweakData:_init_data_bessy_crew()
 			self.bessy_crew.categories = clone(self.bessy.categories)
@@ -3297,7 +3297,7 @@ local crew_wep_preset = {
 			self.bessy_crew.FIRE_MODE = "single"
 			self.bessy_secondary_crew = deep_clone(self.bessy_crew)
 			self.bessy_secondary_crew.use_data.selection_index = 1
-		end	
+		end
 
 		--Cash Blaster (Crew)
 		function WeaponTweakData:_init_data_money_crew()
@@ -3327,8 +3327,8 @@ local crew_wep_preset = {
 			self.money_crew.alert_size = 2500
 			self.money_crew.suppression = 0.45
 			self.money_crew.FIRE_MODE = "auto"
-		end		
-	
+		end
+
 		function WeaponTweakData:_init_data_winchester1874_crew()
 			self.winchester1874_crew.categories = clone(self.winchester1874.categories)
 			self.winchester1874_crew.sounds.prefix = "m1873_npc"
@@ -3347,7 +3347,7 @@ local crew_wep_preset = {
 			self.winchester1874_secondary_crew = deep_clone(self.winchester1874_crew)
 			self.winchester1874_secondary_crew.use_data.selection_index = 1
 		end
-		
+
 		function WeaponTweakData:_init_data_sbl_crew()
 			self.sbl_crew.categories = clone(self.sbl.categories)
 			self.sbl_crew.sounds.prefix = "sbl_npc"
@@ -3366,7 +3366,7 @@ local crew_wep_preset = {
 			self.sbl_secondary_crew = deep_clone(self.sbl_crew)
 			self.sbl_secondary_crew.use_data.selection_index = 1
 		end
-		
+
 		function WeaponTweakData:_init_data_desertfox_crew()
 			self.desertfox_crew.categories = clone(self.desertfox.categories)
 			self.desertfox_crew.sounds.prefix = "desertfox_npc"
@@ -3386,7 +3386,7 @@ local crew_wep_preset = {
 			self.desertfox_secondary_crew = deep_clone(self.desertfox_crew)
 			self.desertfox_secondary_crew.use_data.selection_index = 1
 		end
-		
+
 		function WeaponTweakData:_init_data_r700_crew()
 			self.r700_crew.categories = clone(self.r700.categories)
 			self.r700_crew.sounds.prefix = "r700_npc"
@@ -3437,7 +3437,7 @@ local crew_wep_preset = {
 			self.tecci_crew.suppression = 2.2
 			self.tecci_crew.FIRE_MODE = "auto"
 		end
-		
+
 		function WeaponTweakData:_init_data_par_crew()
 			self.par_crew.categories = clone(self.par.categories)
 			self.par_crew.sounds.prefix = "svinet_npc"
@@ -3456,7 +3456,7 @@ local crew_wep_preset = {
 			self.par_secondary_crew.use_data.selection_index = 1
 			self.par_secondary_crew.armor_piercing = true
 		end
-		
+
 		function WeaponTweakData:_init_data_rpk_crew()
 			self.rpk_crew.categories = clone(self.rpk.categories)
 			self.rpk_crew.sounds.prefix = "rpk_npc"
@@ -3472,7 +3472,7 @@ local crew_wep_preset = {
 			self.rpk_crew.suppression = 2
 			self.rpk_crew.FIRE_MODE = "auto"
 		end
-		
+
 		function WeaponTweakData:_init_data_m249_crew()
 			self.m249_crew.categories = clone(self.m249.categories)
 			self.m249_crew.sounds.prefix = "m249_npc"
@@ -3488,7 +3488,7 @@ local crew_wep_preset = {
 			self.m249_crew.suppression = 2
 			self.m249_crew.FIRE_MODE = "auto"
 		end
-		
+
 		function WeaponTweakData:_init_data_hk21_crew()
 			self.hk21_crew.categories = clone(self.hk21.categories)
 			self.hk21_crew.sounds.prefix = "hk23e_npc"
@@ -3520,7 +3520,7 @@ local crew_wep_preset = {
 			self.hcar_crew.suppression = 2.2
 			self.hcar_crew.FIRE_MODE = "auto"
 		end
-		
+
 		function WeaponTweakData:_init_data_hk51b_crew()
 			self.hk51b_crew.categories = clone(self.hk51b.categories)
 			self.hk51b_crew.sounds.prefix = "hk51b_npc"
@@ -3536,7 +3536,7 @@ local crew_wep_preset = {
 			self.hk51b_crew.suppression = 2
 			self.hk51b_crew.FIRE_MODE = "auto"
 		end
-		
+
 		function WeaponTweakData:_init_data_mg42_crew()
 			self.mg42_crew.categories = clone(self.mg42.categories)
 			self.mg42_crew.sounds.prefix = "mg42_npc"
@@ -3788,7 +3788,7 @@ function WeaponTweakData:_init_stats()
 		local k = math.lerp( 1.9, 0.8, i)
 		table.insert( self.stats.mobility, math.ceil(1/k*1000)/1000 )
 	end
-	
+
 	self.stats.extra_ammo = {}
 	for i = -100, 1500, 1 do
 		table.insert(self.stats.extra_ammo, clamp_near_zero(i))
@@ -3925,8 +3925,8 @@ function WeaponTweakData:_init_stats()
 					0.55 * self.stat_info.stance_recoil_mults.standing,
 					0.35 * self.stat_info.stance_recoil_mults.standing,
 					0.80 * -self.stat_info.stance_recoil_mults.standing,
-					0.00 * -self.stat_info.stance_recoil_mults.standing 
-					-- the funny logic here to have the kick values add up to 2 is that the last two recoil values 
+					0.00 * -self.stat_info.stance_recoil_mults.standing
+					-- the funny logic here to have the kick values add up to 2 is that the last two recoil values
 					-- are meant to be inverted to each other for left and right; since both go in the same direction for these recoil variants the logic is that the
 					-- kick value that'd normally be +0.3 is being offset by a -0.3 and I'm counting the -0.3 that's cancelling out the +0.3 as a part of the add-up to 2
 					-- I'm also full of shit :^)
@@ -4231,7 +4231,7 @@ function WeaponTweakData:_init_stats()
 			},
 
 		--Why the recoil is multiplied by x10 in playerturret vs just making the kick values 0.2 instead of 0.02 I will never understand
-			kick_m2 = { 
+			kick_m2 = {
 				standing = {
 					(0.85 * self.stat_info.stance_recoil_mults.standing) / 10,
 					(0.7 * self.stat_info.stance_recoil_mults.standing) / 10,
@@ -4866,7 +4866,7 @@ function WeaponTweakData:_init_stats()
 					},
 					min_h_recoil = 0.20
 				},
-				pattern_rd5 = { 
+				pattern_rd5 = {
 					standing = {
 						0.45 * -self.stat_info.stance_recoil_mults.standing,
 						0.30 * -self.stat_info.stance_recoil_mults.standing,
@@ -5040,7 +5040,7 @@ local sms_preset = {
 			damage = 50
 		}
 	end
-	
+
 	function WeaponTweakData:_init_money(weapon_data)
 		self.money = {
 			categories = {
@@ -5290,26 +5290,26 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 			}
 		end
 	end
-		
+
 	local faction = {
 		'p90','x_p90','mp7','lemming','olympic','x_olympic','m16','amcar','new_m4','ak5','s552','g36','aug','famas','l85a2','vhs','tecci','hajk','komodo','new_m14','scar','fal','galil','g3','msr','tti','scout','m134','shuno','par','hk21','hk51b','m249','par','m60','corgi','contraband','awp','kacchainsaw','victor'
-	}	
+	}
 	for i, wep_id in ipairs(faction) do
 		self[ wep_id ].nato = true
 	end
 	faction = {
 		'sr2','x_sr2','akmsu','akm','akm_gold','ak74','rpk','asval','x_akmsu','flint','mosin','siltstone','shak12','rsh12','groza','coal','stech','x_stech','type54','x_type54','qbu88','tkb'
-	}	
+	}
 	for i, wep_id in ipairs(faction) do
 		self[ wep_id ].warsaw = true
 	end
-		
-	local recat = { "g26", "jowi", "holt", "x_holt", "glock_18c", "x_g18c", "czech", "x_czech", "stech", "x_stech", "fmg9", "b92fs", "x_b92fs", "beer", "x_beer", "maxim9", "x_maxim9", "glock_17", "x_g17", "g22c", "x_g22c", "packrat", "x_packrat", "breech", "x_breech", "ppk", "x_ppk", "lemming", "hs2000", "x_hs2000", "p226", "x_p226", "sparrow", "x_sparrow", "legacy", "x_legacy", "pl14", "x_pl14"}	
+
+	local recat = { "g26", "jowi", "holt", "x_holt", "glock_18c", "x_g18c", "czech", "x_czech", "stech", "x_stech", "fmg9", "b92fs", "x_b92fs", "beer", "x_beer", "maxim9", "x_maxim9", "glock_17", "x_g17", "g22c", "x_g22c", "packrat", "x_packrat", "breech", "x_breech", "ppk", "x_ppk", "lemming", "hs2000", "x_hs2000", "p226", "x_p226", "sparrow", "x_sparrow", "legacy", "x_legacy", "pl14", "x_pl14"}
 	for i, wep_id in ipairs(recat) do
 		self[ wep_id ].recategorize = { "light_pis" }
 		self[ wep_id ].damage_type = "pistol"
-	end	
-	
+	end
+
 	recat = { "usp", "x_usp", "type54", "x_type54", "shrew", "x_shrew", "colt_1911", "x_1911", "m1911", "x_m1911", "c96", "sub2000" }
 	for i, wep_id in ipairs(recat) do
 		self[ wep_id ].recategorize = { "heavy_pis" }
@@ -5321,41 +5321,41 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 		self[ wep_id ].recategorize = { "heavy_pis", "handcannon" }
 		self[ wep_id ].damage_type = "handcannon"
 	end
-	
+
 	recat = { "saiga", "aa12", "benelli", "ultima", "spas12", "striker", "rota", "x_rota", "basset", "x_basset", "sko12", "x_sko12" }
 	for i, wep_id in ipairs(recat) do
 		self[ wep_id ].recategorize = { "light_shot" }
 		self[ wep_id ].damage_type = "shotgun"
 		self[ wep_id ].damage_type_single_ray = "sniper"
 	end
-	
+
 	recat = { "judge", "x_judge", "m1897", "m590", "r870", "ksg", "m37", "serbu", "supernova" }
 	for i, wep_id in ipairs(recat) do
 		self[ wep_id ].recategorize = { "heavy_shot" }
 		self[ wep_id ].damage_type = "shotgun_heavy"
 		self[ wep_id ].damage_type_single_ray = "sniper"
 	end
-	
+
 	recat = { "huntsman", "b682", "boot", "coach", "x_type54_underbarrel", "type54_underbarrel" }
 	for i, wep_id in ipairs(recat) do
 		self[ wep_id ].recategorize = { "break_shot" }
 		self[ wep_id ].damage_type = "shotgun_heavy"
 		self[ wep_id ].damage_type_single_ray = "sniper"
 	end
-	
+
 	recat = { "tec9", "x_tec9", "shepheard", "x_shepheard", "coal", "x_coal", "pm9", "x_pm9", "baka", "x_baka", "new_mp5", "x_mp5", "sr2", "x_sr2", "mp7", "x_mp7", "mp9", "x_mp9", "scorpion", "x_scorpion", "p90", "x_p90", "cobray", "x_cobray","hailstorm" }
 	for i, wep_id in ipairs(recat) do
 		self[ wep_id ].recategorize = { "light_smg" }
 		self[ wep_id ].damage_type = "machine_gun"
 	end
 	self.hailstorm.recategorize = { "wpn_special" }
-	
+
 	recat = { "uzi", "x_uzi", "schakal", "x_schakal", "vityaz", "x_vityaz", "polymer", "x_polymer", "m1928", "x_m1928", "mac10", "x_mac10", "m45", "x_m45", "erma", "x_erma", "sterling", "x_sterling" }
 	for i, wep_id in ipairs(recat) do
 		self[ wep_id ].recategorize = { "heavy_smg" }
 		self[ wep_id ].damage_type = "machine_gun"
 	end
-	
+
 	recat = { "amcar", "s552", "g36", "olympic", "x_olympic", "vhs", "famas" }
 	for i, wep_id in ipairs(recat) do
 		table.insert(self[ wep_id ].categories, "crb")
@@ -5368,7 +5368,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 		self[ wep_id ].recategorize = { "light_ar" }
 		self[ wep_id ].damage_type = "assault_rifle"
 	end
-	
+
 	recat = { "akmsu", "x_akmsu" }
 	for i, wep_id in ipairs(recat) do
 		self[ wep_id ].recategorize = { "heavy_ar" }
@@ -5379,7 +5379,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 		self[ wep_id ].recategorize = { "heavy_ar" }
 		self[ wep_id ].damage_type = "assault_rifle"
 	end
-	
+
 	recat = { "galil", "fal", "scar", "contraband", "asval" }
 	for i, wep_id in ipairs(recat) do
 		table.insert(self[ wep_id ].categories, "dmr_l")
@@ -5393,7 +5393,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 		self[ wep_id ].recategorize = { "dmr_ar" }
 		self[ wep_id ].damage_type = "sniper"
 	end
-	
+
 	recat = { "tecci" }
 	for i, wep_id in ipairs(recat) do
 		self[ wep_id ].recategorize = { "light_mg" }
@@ -5417,7 +5417,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 		self[ wep_id ].sms = sms_preset.lmg_60
 		self[ wep_id ].weapon_movement_penalty = sms_preset.lmg_60
 	end
-	
+
 	recat = { "mg42", "hk21" }
 	for i, wep_id in ipairs(recat) do
 		table.insert(self[ wep_id ].categories, "mmg")
@@ -5442,7 +5442,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 		self[ wep_id ].recategorize = { "heavy_mg" }
 		self[ wep_id ].damage_type = "anti_materiel"
 	end
-	
+
 	recat = { "shuno" }
 	for i, wep_id in ipairs(recat) do
 		self[ wep_id ].recategorize = { "miniguns" }
@@ -5458,13 +5458,13 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 		self[ wep_id ].sms = sms_preset.mini_60
 		self[ wep_id ].weapon_movement_penalty = sms_preset.mini_60
 	end
-	
+
 	recat = { "winchester1874", "qbu88", "msr", "r700", "tti", "scout", "victor", "awp" }
 	for i, wep_id in ipairs(recat) do
 		self[ wep_id ].recategorize = { "light_snp" }
 		self[ wep_id ].damage_type = "sniper"
 	end
-	
+
 	recat = { "siltstone", "r93", "desertfox", "sbl", "mosin", "model70", "wa2000", "contender", "bessy"}
 	for i, wep_id in ipairs(recat) do
 		self[ wep_id ].recategorize = { "heavy_snp" }
@@ -5680,7 +5680,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 	--[[     BASE WEAPONS     ]]--
 	--Sorted by "Primary Skill Use > Sub-category > Primary/Secondary"
 	--Akimbo weapons are sorted under their single-wielded secondary counterpart
-	
+
 		--[[     PISTOLS     ]]--
 
 			--[[     LIGHT PISTOLS     ]]
@@ -5690,7 +5690,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 					--CZ ACCUSHADOW BUT SOMEHOW FULL AUTO
 						self.czech.use_data.selection_index = 2 --The G18C exists, use that if you want lead-pisser pistol secondary
 						self.czech.has_description = true
-						self.czech.desc_id = "bm_czech_sc_desc"				
+						self.czech.desc_id = "bm_czech_sc_desc"
 						self.czech.CLIP_AMMO_MAX = 18
 						self.czech.AMMO_MAX = 90
 						self.czech.fire_mode_data.fire_rate = 0.06
@@ -5767,7 +5767,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 							reload = 20
 						}
 						self.fmg9.stats_modifiers = nil
-						self.fmg9.panic_suppression_chance = 0.05	
+						self.fmg9.panic_suppression_chance = 0.05
 						self.fmg9.swap_speed_multiplier = 0.45
 						self.fmg9.timers = {
 							reload_empty = 3.42,
@@ -5776,12 +5776,12 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 							reload_exit_not_empty = 0.8,
 							unequip = 1.7,
 							equip = 1.4
-						}	
+						}
 						self.fmg9.use_unequip_swap = true
 
 					--Beretta Auto (93R)
 						self.beer.has_description = true
-						self.beer.desc_id = "bm_beer_sc_desc"				
+						self.beer.desc_id = "bm_beer_sc_desc"
 						self.beer.use_data.selection_index = 2
 						self.beer.BURST_FIRE = {
 							count = 3,
@@ -5792,7 +5792,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 							burst_default = true
 						}
 						self.beer.CAN_TOGGLE_FIREMODE = false
-						self.beer.FIRE_MODE = "single"	
+						self.beer.FIRE_MODE = "single"
 						self.beer.AMMO_MAX = 120
 						self.beer.CLIP_AMMO_MAX = 15
 						self.beer.fire_mode_data.fire_rate = 0.0882352
@@ -5846,7 +5846,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 							"tranq"
 						}
 						self.maxim9.has_description = true
-						self.maxim9.desc_id = "bm_tranq_maxim_sc_desc"	
+						self.maxim9.desc_id = "bm_tranq_maxim_sc_desc"
 						self.maxim9.fire_mode_data.fire_rate = 0.08571428571
 						self.maxim9.single.fire_rate = 0.08571428571
 						self.maxim9.CLIP_AMMO_MAX = 17
@@ -5879,8 +5879,8 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 							reload = 20
 						}
 						self.maxim9.stats_modifiers = nil
-						self.maxim9.panic_suppression_chance = 0.05	
-						self.maxim9.no_auto_anims = true	
+						self.maxim9.panic_suppression_chance = 0.05
+						self.maxim9.no_auto_anims = true
 						self.maxim9.sounds.fire = "max9_fire"
 						self.maxim9.sounds.fire_single = "max9_fire"
 						self.maxim9.sounds.fire_auto = "max9_fire"
@@ -5895,7 +5895,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 							"tranq"
 						}
 						self.x_maxim9.has_description = true
-						self.x_maxim9.desc_id = "bm_tranq_x_maxim_sc_desc"	
+						self.x_maxim9.desc_id = "bm_tranq_x_maxim_sc_desc"
 						self.x_maxim9.fire_mode_data.fire_rate = 0.08571428571
 						self.x_maxim9.single.fire_rate = 0.08571428571
 						self.x_maxim9.CLIP_AMMO_MAX = 34
@@ -5934,7 +5934,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 
 					--5/7 AP (Five-seveN)
 						self.lemming.has_description = true
-						self.lemming.desc_id = "bm_lemming_sc_desc"			
+						self.lemming.desc_id = "bm_lemming_sc_desc"
 						self.lemming.categories = {
 							"pistol",
 							"pistol_pdw"
@@ -5981,7 +5981,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 						self.lemming.stats_modifiers = nil
 						self.lemming.timers.reload_exit_empty = 0.55
 						self.lemming.timers.reload_exit_not_empty = 0.45
-							
+
 						if self.x_lemming then
 							self.x_lemming.use_data.selection_index = 2
 							self.x_lemming.recategorize = {"light_pis"}
@@ -6119,11 +6119,11 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 						self.x_g18c.stats_modifiers = nil
 						self.x_g18c.panic_suppression_chance = 0.05
 						self.x_g18c.timers.reload_exit_empty = 0.55
-						self.x_g18c.timers.reload_exit_not_empty = 0.65	
+						self.x_g18c.timers.reload_exit_not_empty = 0.65
 
 					--Gruber Kurz (PPK)
 						self.ppk.has_description = true
-						self.ppk.desc_id = "bm_ppk_sc_desc"					
+						self.ppk.desc_id = "bm_ppk_sc_desc"
 						self.ppk.AMMO_MAX = 75
 						self.ppk.CLIP_AMMO_MAX = 7
 						self.ppk.fire_mode_data.fire_rate = 0.0821917
@@ -6163,7 +6163,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 						self.ppk.weapon_movement_penalty = 1.14
 					--Akimbo
 						self.x_ppk.has_description = true
-						self.x_ppk.desc_id = "bm_ppk_sc_desc"					
+						self.x_ppk.desc_id = "bm_ppk_sc_desc"
 						self.x_ppk.AMMO_MAX = 150
 						self.x_ppk.CLIP_AMMO_MAX = 14
 						self.x_ppk.fire_mode_data.fire_rate = 0.0821917
@@ -6202,7 +6202,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 
 					--Chimano Compact (Glock 26)
 						self.g26.has_description = true
-						self.g26.desc_id = "bm_jowi_sc_desc"				
+						self.g26.desc_id = "bm_jowi_sc_desc"
 						self.g26.CLIP_AMMO_MAX = 10
 						self.g26.AMMO_MAX = 75
 						self.g26.kick = self.stat_info.kick_tables.even_recoil
@@ -6280,7 +6280,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 
 					--Igor (APS)
 						self.stech.has_description = true
-						self.stech.desc_id = "bm_x_stech_sc_desc"						
+						self.stech.desc_id = "bm_x_stech_sc_desc"
 						self.stech.fire_mode_data.fire_rate = 0.08
 						self.stech.AMMO_MAX = 75
 						self.stech.kick = self.stat_info.kick_tables.moderate_kick
@@ -6436,7 +6436,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 
 					--Bernetti 9 (M92FS)
 						self.b92fs.has_description = true
-						self.b92fs.desc_id = "bm_b92fs_sc_desc"			
+						self.b92fs.desc_id = "bm_b92fs_sc_desc"
 						self.b92fs.CLIP_AMMO_MAX = 15
 						self.b92fs.AMMO_MAX = 75
 						self.b92fs.fire_mode_data.fire_rate = 0.0882352
@@ -6513,7 +6513,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 
 					--White Streak
 						self.pl14.has_description = true
-						self.pl14.desc_id = "bm_pl14_sc_desc"				
+						self.pl14.desc_id = "bm_pl14_sc_desc"
 						self.pl14.fire_mode_data.fire_rate = 0.0882352
 						self.pl14.CLIP_AMMO_MAX = 15
 						self.pl14.AMMO_MAX = 75
@@ -6552,7 +6552,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 						self.pl14.timers.reload_exit_not_empty = 0.65
 					--Akimbo
 						self.x_pl14.has_description = true
-						self.x_pl14.desc_id = "bm_pl14_sc_desc"				
+						self.x_pl14.desc_id = "bm_pl14_sc_desc"
 						self.x_pl14.fire_mode_data.fire_rate = 0.0882352
 						self.x_pl14.CLIP_AMMO_MAX = 30
 						self.x_pl14.AMMO_MAX = 150
@@ -6591,7 +6591,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 
 					--M13
 						self.legacy.has_description = true
-						self.legacy.desc_id = "bm_legacy_sc_desc"				
+						self.legacy.desc_id = "bm_legacy_sc_desc"
 						self.legacy.fire_mode_data.fire_rate = 0.0857142
 						self.legacy.CLIP_AMMO_MAX = 13
 						self.legacy.AMMO_MAX = 75
@@ -6629,7 +6629,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 							reload_empty = 2.12,
 							unequip = 0.5,
 							equip = 0.35
-						}		
+						}
 						self.legacy.panic_suppression_chance = 0.05
 						self.legacy.reload_speed_multiplier = 1.08
 						self.legacy.timers.reload_exit_empty = 0.5
@@ -6639,7 +6639,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 						end
 					--Akimbo
 						self.x_legacy.has_description = true
-						self.x_legacy.desc_id = "bm_legacy_sc_desc"				
+						self.x_legacy.desc_id = "bm_legacy_sc_desc"
 						self.x_legacy.fire_mode_data.fire_rate = 0.0857142
 						self.x_legacy.CLIP_AMMO_MAX = 13 * 2
 						self.x_legacy.AMMO_MAX = 75 * 2
@@ -6678,7 +6678,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 
 					--Holt 9mm (Hudson H9)
 						self.holt.has_description = true
-						self.holt.desc_id = "bm_holt_sc_desc"				
+						self.holt.desc_id = "bm_holt_sc_desc"
 						self.holt.fire_mode_data.fire_rate = 0.0882352
 						self.holt.CLIP_AMMO_MAX = 15
 						self.holt.AMMO_MAX = 75
@@ -6718,7 +6718,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 						self.holt.timers.reload_exit_not_empty = 0.65
 					--Akimbo
 						self.x_holt.has_description = true
-						self.x_holt.desc_id = "bm_x_holt_sc_desc"					
+						self.x_holt.desc_id = "bm_x_holt_sc_desc"
 						self.x_holt.fire_mode_data.fire_rate = 0.0882352
 						self.x_holt.CLIP_AMMO_MAX = 30
 						self.x_holt.AMMO_MAX = 150
@@ -6757,7 +6757,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 
 					--Contractor Pistol (P30L)
 						self.packrat.has_description = true
-						self.packrat.desc_id = "bm_packrat_sc_desc"			
+						self.packrat.desc_id = "bm_packrat_sc_desc"
 						self.packrat.AMMO_MAX = 75
 						self.packrat.CLIP_AMMO_MAX = 15
 						self.packrat.fire_mode_data.fire_rate = 0.0882352
@@ -6798,7 +6798,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 						self.packrat.timers.reload_exit_not_empty = 0.65
 					--Akimbo
 						self.x_packrat.has_description = true
-						self.x_packrat.desc_id = "bm_x_packrat_sc_desc"				
+						self.x_packrat.desc_id = "bm_x_packrat_sc_desc"
 						self.x_packrat.AMMO_MAX = 150
 						self.x_packrat.CLIP_AMMO_MAX = 30
 						self.x_packrat.fire_mode_data.fire_rate = 0.0882352
@@ -6837,7 +6837,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 
 					--Parabellum (Luger)
 						self.breech.has_description = true
-						self.breech.desc_id = "bm_breech_sc_desc"				
+						self.breech.desc_id = "bm_breech_sc_desc"
 						self.breech.AMMO_MAX = 60
 						self.breech.CLIP_AMMO_MAX = 8
 						self.breech.fire_mode_data.fire_rate = 0.0882352
@@ -6882,7 +6882,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 						}
 					--Akimbo
 						self.x_breech.has_description = true
-						self.x_breech.desc_id = "bm_breech_sc_desc"				
+						self.x_breech.desc_id = "bm_breech_sc_desc"
 						self.x_breech.AMMO_MAX = 120
 						self.x_breech.CLIP_AMMO_MAX = 16
 						self.x_breech.fire_mode_data.fire_rate = 0.0882352
@@ -6924,13 +6924,13 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 
 					--Chimano Custom (Glock 22)
 						self.g22c.has_description = true
-						self.g22c.desc_id = "bm_g22c_sc_desc"			
+						self.g22c.desc_id = "bm_g22c_sc_desc"
 						self.g22c.timers = {
 							reload_not_empty = 1.47,
 							reload_empty = 2.12,
 							unequip = 0.5,
 							equip = 0.35
-						}		
+						}
 						self.g22c.fire_mode_data.fire_rate = 0.09523809
 						self.g22c.AMMO_MAX = 60
 						self.g22c.kick = self.stat_info.kick_tables.left_recoil
@@ -6969,7 +6969,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 						self.g22c.timers.reload_exit_not_empty = 0.65
 					--Akimbo
 						self.x_g22c.has_description = true
-						self.x_g22c.desc_id = "bm_x_g22c_sc_desc"					
+						self.x_g22c.desc_id = "bm_x_g22c_sc_desc"
 						self.x_g22c.kick = self.stat_info.kick_tables.even_recoil
 						self.x_g22c.kick_pattern = {
 							{0, self.stat_info.kick_tables.left_kick},
@@ -7011,7 +7011,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 
 					--Signature .40 (P226)
 						self.p226.has_description = true
-						self.p226.desc_id = "bm_p226_sc_desc"					
+						self.p226.desc_id = "bm_p226_sc_desc"
 						self.p226.AMMO_MAX = 60
 						self.p226.CLIP_AMMO_MAX = 15
 						self.p226.fire_mode_data.fire_rate = 0.1
@@ -7090,7 +7090,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 
 					--Baby Deagle (941)
 						self.sparrow.has_description = true
-						self.sparrow.desc_id = "bm_sparrow_sc_desc"				
+						self.sparrow.desc_id = "bm_sparrow_sc_desc"
 						self.sparrow.CLIP_AMMO_MAX = 12
 						self.sparrow.AMMO_MAX = 60
 						self.sparrow.kick = {}
@@ -7128,7 +7128,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 						self.sparrow.timers.reload_exit_empty = 0.7
 						self.sparrow.timers.reload_exit_not_empty = 0.65
 					--Akimbo
-						self.x_sparrow.desc_id = "bm_sparrow_sc_desc"				
+						self.x_sparrow.desc_id = "bm_sparrow_sc_desc"
 						self.x_sparrow.CLIP_AMMO_MAX = 24
 						self.x_sparrow.AMMO_MAX = 120
 						self.x_sparrow.kick = {}
@@ -7167,7 +7167,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 
 					--Leo (HS2000)
 						self.hs2000.has_description = true
-						self.hs2000.desc_id = "bm_hs2000_sc_desc"						
+						self.hs2000.desc_id = "bm_hs2000_sc_desc"
 						self.hs2000.CLIP_AMMO_MAX = 16
 						self.hs2000.AMMO_MAX = 60
 						self.hs2000.FIRE_MODE = "single"
@@ -7213,13 +7213,13 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 
 					--Broomstick (C96)
 						--Moved to primary
-						self.c96.use_data.selection_index = 2	
+						self.c96.use_data.selection_index = 2
 						self.c96.sounds.fire = "c96_fire"
 						self.c96.sounds.fire_single = "c96_fire"
 						self.c96.sounds.dryfire = "secondary_dryfire"
 						self.c96.sounds.enter_steelsight = "pistol_steel_sight_enter"
 						self.c96.sounds.leave_steelsight = "pistol_steel_sight_exit"
-						self.c96.sounds.magazine_empty = "wp_pistol_slide_lock"		
+						self.c96.sounds.magazine_empty = "wp_pistol_slide_lock"
 						self.c96.has_description = true
 						self.c96.desc_id = "bm_c96_sc_desc"
 						self.c96.AMMO_MAX = 80
@@ -7269,7 +7269,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 
 					--Cavity 9mm
 						self.sub2000.has_description = true
-						self.sub2000.desc_id = "bm_sub2000_sc_desc"			
+						self.sub2000.desc_id = "bm_sub2000_sc_desc"
 						self.sub2000.categories = {"pistol"}
 						self.sub2000.CLIP_AMMO_MAX = 31
 						self.sub2000.AMMO_MAX = 80
@@ -7322,7 +7322,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 
 					--RUS-12 Angry Tiger
 						self.rsh12.has_description = true
-						self.rsh12.desc_id = "bm_rsh12_sc_desc"				
+						self.rsh12.desc_id = "bm_rsh12_sc_desc"
 						self.rsh12.fire_mode_data.fire_rate = 0.2
 						self.rsh12.AMMO_MAX = 40
 						self.rsh12.CLIP_AMMO_MAX = 5
@@ -7377,7 +7377,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 
 					--Model 54
 						self.type54.has_description = true
-						self.type54.desc_id = "bm_type54_sc_desc"					
+						self.type54.desc_id = "bm_type54_sc_desc"
 						self.type54.CLIP_AMMO_MAX = 9
 						self.type54.AMMO_MAX = 40
 						self.type54.FIRE_MODE = "single"
@@ -7410,13 +7410,13 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 							reload = 20
 						}
 						self.type54.stats_modifiers = nil
-						self.type54.panic_suppression_chance = 0.05	
+						self.type54.panic_suppression_chance = 0.05
 						self.type54.reload_speed_multiplier = 1.05
 						self.type54.timers.reload_exit_empty = 0.55
 						self.type54.timers.reload_exit_not_empty = 0.45
 					--Akimbo
 						self.x_type54.has_description = true
-						self.x_type54.desc_id = "bm_x_type54_sc_desc"			
+						self.x_type54.desc_id = "bm_x_type54_sc_desc"
 						self.x_type54.CLIP_AMMO_MAX = 18
 						self.x_type54.AMMO_MAX = 80
 						self.x_type54.FIRE_MODE = "single"
@@ -7451,7 +7451,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 						self.x_type54.stats_modifiers = nil
 						self.x_type54.panic_suppression_chance = 0.05
 						self.x_type54.timers.reload_exit_empty = 0.55
-						self.x_type54.timers.reload_exit_not_empty = 0.65		
+						self.x_type54.timers.reload_exit_not_empty = 0.65
 					--Model 54 Underbarrel
 						self.type54_underbarrel.categories = {
 							"shotgun",
@@ -7492,10 +7492,10 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 							reload = 20
 						}
 						self.type54_underbarrel.stats_modifiers = nil
-						self.type54_underbarrel.panic_suppression_chance = 0.05	
+						self.type54_underbarrel.panic_suppression_chance = 0.05
 						self.type54_underbarrel.ignore_crit_damage = false
 						self.type54_underbarrel.ignore_damage_multipliers = false
-						self.type54_underbarrel.ignore_damage_upgrades = false	
+						self.type54_underbarrel.ignore_damage_upgrades = false
 						self.type54_underbarrel.timers.reload_exit_empty = 0.35
 						self.type54_underbarrel.timers.reload_exit_not_empty = 0.35
 					--Akimbo
@@ -7542,16 +7542,16 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 							reload = 20
 						}
 						self.x_type54_underbarrel.stats_modifiers = nil
-						self.x_type54_underbarrel.panic_suppression_chance = 0.05	
+						self.x_type54_underbarrel.panic_suppression_chance = 0.05
 						self.x_type54_underbarrel.ignore_crit_damage = false
 						self.x_type54_underbarrel.ignore_damage_multipliers = false
-						self.x_type54_underbarrel.ignore_damage_upgrades = false	
+						self.x_type54_underbarrel.ignore_damage_upgrades = false
 						self.x_type54_underbarrel.timers.reload_exit_empty = 0.55
 						self.x_type54_underbarrel.timers.reload_exit_not_empty = 0.65
 
 					--Crosskill Guard
 						self.shrew.has_description = true
-						self.shrew.desc_id = "bm_shrew_sc_desc"			
+						self.shrew.desc_id = "bm_shrew_sc_desc"
 						self.shrew.fire_mode_data.fire_rate = 0.106194
 						self.shrew.CLIP_AMMO_MAX = 6
 						self.shrew.AMMO_MAX = 40
@@ -7589,7 +7589,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 						self.shrew.timers.reload_exit_not_empty = 0.65
 					--Akimbo
 						self.x_shrew.has_description = true
-						self.x_shrew.desc_id = "bm_x_shrew_sc_desc"				
+						self.x_shrew.desc_id = "bm_x_shrew_sc_desc"
 						self.x_shrew.fire_mode_data.fire_rate = 0.106194
 						self.x_shrew.CLIP_AMMO_MAX = 12
 						self.x_shrew.AMMO_MAX = 80
@@ -7671,7 +7671,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 						self.usp.timers.reload_exit_not_empty = 0.65
 					--Akimbo
 						self.x_usp.has_description = true
-						self.x_usp.desc_id = "bm_x_usp_sc_desc"					
+						self.x_usp.desc_id = "bm_x_usp_sc_desc"
 						self.x_usp.kick = self.stat_info.kick_tables.right_recoil
 						self.x_usp.kick_pattern = {
 							{0, self.stat_info.kick_tables.right_kick},
@@ -7747,7 +7747,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 						self.colt_1911.timers.reload_exit_not_empty = 0.65
 					--Akimbo
 						self.x_1911.has_description = true
-						self.x_1911.desc_id = "bm_x_1911_sc_desc"					
+						self.x_1911.desc_id = "bm_x_1911_sc_desc"
 						self.x_1911.CLIP_AMMO_MAX = 16
 						self.x_1911.AMMO_MAX = 80
 						self.x_1911.fire_mode_data.fire_rate = 0.1176470588
@@ -7863,7 +7863,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 
 					--Kahn .357
 						self.korth.has_description = true
-						self.korth.desc_id = "bm_ap_armor_50_weapon_sc_desc"	
+						self.korth.desc_id = "bm_ap_armor_50_weapon_sc_desc"
 						self.korth.fire_mode_data.fire_rate = 0.18181818
 						self.korth.CLIP_AMMO_MAX = 8
 						self.korth.AMMO_MAX = 30
@@ -7908,14 +7908,14 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 						--stupid garbage implementation; should proabably slap this into the actual timers table but IDGAF, it works
 						--Am I upset that this dogshit workaround is needed to make it look proper?
 						--Yes
-						--All of ONE weapon (this one, lol) needs this despite other revolvers doing 
+						--All of ONE weapon (this one, lol) needs this despite other revolvers doing
 						--the exact same fucking thing with their speed loaders WITHOUT the need for this stupid shit
 						self.korth.hide_reload_obj_start = 0
 						self.korth.show_reload_obj = 1.2
 						self.korth.hide_reload_obj_exit = 1.1
 					--Akimbo
 						self.x_korth.has_description = true
-						self.x_korth.desc_id = "bm_ap_armor_50_weapon_sc_desc"	
+						self.x_korth.desc_id = "bm_ap_armor_50_weapon_sc_desc"
 						self.x_korth.fire_mode_data.fire_rate = 0.18181818
 						self.x_korth.CLIP_AMMO_MAX = 16
 						self.x_korth.AMMO_MAX = 60
@@ -8047,7 +8047,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 
 					--Frenchman Model 87
 						self.model3.has_description = true
-						self.model3.desc_id = "bm_model3_sc_desc"			
+						self.model3.desc_id = "bm_model3_sc_desc"
 						self.model3.fire_mode_data.fire_rate = 0.1714285
 						self.model3.AMMO_MAX = 30
 						self.model3.kick = self.stat_info.kick_tables.moderate_kick
@@ -8088,7 +8088,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 						self.model3.panic_suppression_chance = 0.05
 					--Akimbo
 						self.x_model3.has_description = true
-						self.x_model3.desc_id = "bm_x_model3_sc_desc"			
+						self.x_model3.desc_id = "bm_x_model3_sc_desc"
 						self.x_model3.fire_mode_data.fire_rate = 0.1714285
 						self.x_model3.AMMO_MAX = 60
 						self.x_model3.kick = self.stat_info.kick_tables.moderate_kick
@@ -8128,7 +8128,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 						self.x_model3.timers.reload_empty = 3.1
 						self.x_model3.timers.reload_not_empty = 3.1
 						self.x_model3.timers.reload_exit_empty = 1.3
-						self.x_model3.timers.reload_exit_not_empty = 1.3		
+						self.x_model3.timers.reload_exit_not_empty = 1.3
 
 					--Bronco
 						self.new_raging_bull.has_description = true
@@ -8174,7 +8174,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 						self.new_raging_bull.panic_suppression_chance = 0.05
 					--Akimbo
 						self.x_rage.has_description = true
-						self.x_rage.desc_id = "bm_x_rage_sc_desc"					
+						self.x_rage.desc_id = "bm_x_rage_sc_desc"
 						self.x_rage.fire_mode_data.fire_rate = 0.2
 						self.x_rage.AMMO_MAX = 60
 						self.x_rage.kick = self.stat_info.kick_tables.vertical_kick
@@ -8250,7 +8250,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 							total_ammo_mod = 400,
 							value = 1,
 							reload = 20
-						}		
+						}
 						self.chinchilla.stats_modifiers = nil
 						self.chinchilla.armor_piercing_chance = 0.5
 						self.chinchilla.can_shoot_through_enemy = true
@@ -8263,7 +8263,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 						self.chinchilla.timers.reload_exit_not_empty = 1.1
 					--Akimbo
 						self.x_chinchilla.has_description = true
-						self.x_chinchilla.desc_id = "bm_x_chinchilla_sc_desc"				
+						self.x_chinchilla.desc_id = "bm_x_chinchilla_sc_desc"
 						self.x_chinchilla.panic_suppression_chance = 0.05
 						self.x_chinchilla.fire_mode_data.fire_rate = 0.1818181
 						self.x_chinchilla.AMMO_MAX = 60
@@ -8354,7 +8354,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 						self.deagle.timers.reload_exit_not_empty = 0.8
 					--Akimbo
 						self.x_deagle.has_description = true
-						self.x_deagle.desc_id = "bm_x_deagle_sc_desc"					
+						self.x_deagle.desc_id = "bm_x_deagle_sc_desc"
 						self.x_deagle.use_data.selection_index = 2
 						self.x_deagle.CLIP_AMMO_MAX = 14
 						self.x_deagle.AMMO_MAX = 40
@@ -8466,7 +8466,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 				--PRIMARIES
 
 					--Hailstorm Mk5
-						self.hailstorm.categories = { 
+						self.hailstorm.categories = {
 							"smg",
 							"typh"
 						}
@@ -8527,7 +8527,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 							total_ammo_mod = 400,
 							value = 9,
 							reload = 20
-						}		
+						}
 						self.hailstorm.recoil_values = {
 							{ 80, 60 },
 							5,
@@ -8545,7 +8545,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 
 					--Miyaka 10
 						--Moved to Primary slot
-						self.pm9.use_data.selection_index = 2	
+						self.pm9.use_data.selection_index = 2
 						self.pm9.CLIP_AMMO_MAX = 25
 						self.pm9.AMMO_MAX = 180
 						self.pm9.fire_mode_data.fire_rate = 0.05454545454
@@ -8721,7 +8721,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 							"pdw"
 						}
 						self.mp7.has_description = true
-						self.mp7.desc_id = "bm_mp7_sc_desc"	
+						self.mp7.desc_id = "bm_mp7_sc_desc"
 						self.mp7.AMMO_MAX = 90
 						self.mp7.fire_mode_data.fire_rate = 0.06315789473
 						self.mp7.CAN_TOGGLE_FIREMODE = true
@@ -8775,7 +8775,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 							"pdw"
 						}
 						self.p90.has_description = true
-						self.p90.desc_id = "bm_p90_sc_desc"	
+						self.p90.desc_id = "bm_p90_sc_desc"
 						self.p90.AMMO_MAX = 90
 						self.p90.fire_mode_data.fire_rate = 0.070588235
 						self.p90.armor_piercing_chance = 0.75
@@ -8825,7 +8825,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 							"pdw"
 						}
 						self.x_p90.has_description = true
-						self.x_p90.desc_id = "bm_p90_sc_desc"	
+						self.x_p90.desc_id = "bm_p90_sc_desc"
 						self.x_p90.AMMO_MAX = 180
 						self.x_p90.fire_mode_data.fire_rate = 0.070588235
 						self.x_p90.armor_piercing_chance = 0.75
@@ -8880,7 +8880,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 						self.tec9.CAN_TOGGLE_FIREMODE = true
 						self.tec9.auto = {}
 						self.tec9.has_description = true
-						self.tec9.desc_id = "bm_tec9_sc_desc"													
+						self.tec9.desc_id = "bm_tec9_sc_desc"
 						self.tec9.auto.fire_rate = 0.06
 						self.tec9.kick = self.stat_info.kick_tables.left_recoil
 						self.tec9.kick_pattern = {
@@ -9042,7 +9042,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 						self.mp9.panic_suppression_chance = 0.05
 						self.mp9.timers.reload_empty = 2.2
 						self.mp9.timers.reload_exit_empty = 1.1
-						self.mp9.timers.reload_exit_not_empty = 0.85	
+						self.mp9.timers.reload_exit_not_empty = 0.85
 
 					--Heather (SR2M)
 						self.sr2.categories = {
@@ -9236,7 +9236,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 							reload = 20
 						}
 						self.x_scorpion.stats_modifiers = nil
-						self.x_scorpion.panic_suppression_chance = 0.05	
+						self.x_scorpion.panic_suppression_chance = 0.05
 						self.x_scorpion.reload_speed_multiplier = 0.75
 						self.x_scorpion.timers.reload_not_empty = 2.1
 						self.x_scorpion.timers.reload_exit_not_empty = 1.5
@@ -9297,7 +9297,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 						self.x_mp5.fire_mode_data.fire_rate = 0.075
 						self.x_mp5.BURST_FIRE = false
 						self.x_mp5.FIRE_MODE = "auto"
-						self.x_mp5.ADAPTIVE_BURST_SIZE = false					
+						self.x_mp5.ADAPTIVE_BURST_SIZE = false
 						self.x_mp5.kick = self.stat_info.kick_tables.even_recoil
 						self.x_mp5.kick_pattern = {
 							{0, self.stat_info.kick_tables.moderate_right_kick},
@@ -9663,7 +9663,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 						self.m45.timers.reload_empty = 3.45
 						self.m45.timers.reload_exit_empty = 1.3
 						self.m45.timers.reload_not_empty = 2.55
-						self.m45.timers.reload_exit_not_empty = 0.9	
+						self.m45.timers.reload_exit_not_empty = 0.9
 						self.m45.panic_suppression_chance = 0.05
 
 					--Patchett
@@ -10410,7 +10410,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 							"mmg_moving"
 						}
 						self.hcar.has_description = true
-						self.hcar.desc_id = "bm_hcar_sc_desc"	
+						self.hcar.desc_id = "bm_hcar_sc_desc"
 						self.hcar.CLIP_AMMO_MAX = 20
 						self.hcar.AMMO_MAX = 120
 						self.hcar.fire_mode_data.fire_rate = 0.12
@@ -10452,7 +10452,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 
 					--M60
 						self.m60.has_description = true
-						self.m60.desc_id = "bm_m60_sc_desc"		
+						self.m60.desc_id = "bm_m60_sc_desc"
 						self.m60.categories = {
 							"lmg",
 							"smg",
@@ -10510,7 +10510,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 
 					--KSP 58
 						self.par.has_description = true
-						self.par.desc_id = "bm_par_sc_desc"				
+						self.par.desc_id = "bm_par_sc_desc"
 						self.par.categories = {
 							"lmg",
 							"smg",
@@ -10651,7 +10651,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 						total_ammo_mod = 400,
 						value = 9,
 						reload = 20
-					}		
+					}
 					self.shuno.stats_modifiers = nil
 					self.shuno.ads_spool = true
 					self.shuno.spin_up_anims = true
@@ -10670,7 +10670,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 						"smg"
 					}
 					self.m134.has_description = true
-					self.m134.desc_id = "bm_m134_sc_desc"	
+					self.m134.desc_id = "bm_m134_sc_desc"
 					self.m134.CLIP_AMMO_MAX = 400
 					self.m134.NR_CLIPS_MAX = 1
 					self.m134.AMMO_MAX = 400
@@ -10710,7 +10710,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 						alert_size = 2,
 						extra_ammo = 101,
 						total_ammo_mod = 400,
-						value = 9,	
+						value = 9,
 						reload = 20
 					}
 					self.m134.stats_modifiers = {}
@@ -10782,7 +10782,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 
 					--Commando 553
 						self.s552.desc_id = "bm_s552_sc_desc"
-						self.s552.has_description = true					
+						self.s552.has_description = true
 						self.s552.fire_mode_data.fire_rate = 0.08571428571
 						self.s552.auto.fire_rate = 0.08571428571
 						self.s552.BURST_FIRE = {
@@ -10791,7 +10791,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 							recoil_mult = 0.8,
 							last_recoil_mult = 1.05
 						}
-						self.s552.ADAPTIVE_BURST_SIZE = false															
+						self.s552.ADAPTIVE_BURST_SIZE = false
 						self.s552.kick = self.stat_info.kick_tables.moderate_kick
 						self.s552.kick_pattern = {
 							{0, self.stat_info.kick_tables.moderate_kick},
@@ -10830,7 +10830,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 							self.s552.reload_speed_multiplier = 1.46
 						else
 							self.s552.timers.reload_not_empty = 1.7
-							self.s552.timers.reload_empty = 2.35					
+							self.s552.timers.reload_empty = 2.35
 						end
 						self.s552.reload_speed_multiplier = self.s552.reload_speed_multiplier * 0.9
 						self.s552.timers.reload_exit_empty = 0.55
@@ -10839,14 +10839,14 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 
 					--JP36
 						self.g36.desc_id = "bm_g36_sc_desc"
-						self.g36.has_description = true				
+						self.g36.has_description = true
 						self.g36.BURST_FIRE = {
 							count = 3,
 							delay = 0.18,
 							recoil_mult = 0.75,
 							last_recoil_mult = 1.05
 						}
-						self.g36.ADAPTIVE_BURST_SIZE = false																	
+						self.g36.ADAPTIVE_BURST_SIZE = false
 						self.g36.auto.fire_rate = 0.08
 						self.g36.fire_mode_data.fire_rate = 0.08
 						self.g36.AMMO_MAX = 180
@@ -10891,7 +10891,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 
 					--Lion's Roar
 						self.vhs.desc_id = "bm_vhs_sc_desc"
-						self.vhs.has_description = true					
+						self.vhs.has_description = true
 						self.vhs.CLIP_AMMO_MAX = 30
 						self.vhs.AMMO_MAX = 180
 						self.vhs.fire_mode_data.fire_rate = 0.070588235
@@ -11031,7 +11031,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 
 					--Union 5.56
 						self.corgi.desc_id = "bm_corgi_sc_desc"
-						self.corgi.has_description = true			
+						self.corgi.has_description = true
 						self.corgi.CLIP_AMMO_MAX = 30
 						self.corgi.AMMO_MAX = 150
 						self.corgi.fire_mode_data.fire_rate = 0.07058823529
@@ -11076,7 +11076,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 
 					--UAR (AUG)
 						self.aug.desc_id = "bm_aug_sc_desc"
-						self.aug.has_description = true					
+						self.aug.has_description = true
 						self.aug.AMMO_MAX = 150
 						self.aug.CLIP_AMMO_MAX = 30
 						self.aug.fire_mode_data.fire_rate = 0.08333
@@ -11119,7 +11119,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 
 					--Ak17
 						self.flint.desc_id = "bm_flint_sc_desc"
-						self.flint.has_description = true				
+						self.flint.has_description = true
 						self.flint.AMMO_MAX = 150
 						self.flint.CLIP_AMMO_MAX = 30
 						self.flint.BURST_FIRE = {
@@ -11129,7 +11129,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 							recoil_mult = 0.4,
 							last_recoil_mult = 1.05
 						}
-						self.flint.ADAPTIVE_BURST_SIZE = false									
+						self.flint.ADAPTIVE_BURST_SIZE = false
 						self.flint.fire_mode_data.fire_rate = 0.08571428571
 						self.flint.kick = self.stat_info.kick_tables.moderate_right_kick
 						self.flint.kick_pattern = {
@@ -11170,7 +11170,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 
 					--AK
 						self.ak74.desc_id = "bm_ak74_sc_desc"
-						self.ak74.has_description = true					
+						self.ak74.has_description = true
 						self.ak74.AMMO_MAX = 150
 						self.ak74.fire_mode_data.fire_rate = 0.0923076923
 						self.ak74.kick = self.stat_info.kick_tables.right_recoil
@@ -11213,7 +11213,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 
 					--Para
 						self.olympic.desc_id = "bm_menu_sc_olympic_desc"
-						self.olympic.has_description = true		
+						self.olympic.has_description = true
 						self.olympic.categories = {
 							"assault_rifle"
 						}
@@ -11257,7 +11257,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 						self.olympic.timers.reload_exit_not_empty = 0.85
 					--Akimbo
 						self.x_olympic.desc_id = "bm_menu_sc_olympic_desc"
-						self.x_olympic.has_description = true		
+						self.x_olympic.has_description = true
 						self.x_olympic.categories = {
 							"akimbo",
 							"assault_rifle"
@@ -11308,7 +11308,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 
 					--Clarion (IS THAT A DEAGLE)
 						self.famas.desc_id = "bm_menu_sc_famas_desc"
-						self.famas.has_description = true					
+						self.famas.has_description = true
 						self.famas.use_data.selection_index = 1
 						self.famas.AMMO_MAX = 90
 						self.famas.CLIP_AMMO_MAX = 25
@@ -11399,7 +11399,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 							total_ammo_mod = 400,
 							value = 1,
 							reload = 20
-						}	
+						}
 						self.komodo.stats_modifiers = nil
 						self.komodo.timers.reload_empty = 2.66
 						self.komodo.timers.reload_exit_empty = 0.87
@@ -11409,7 +11409,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 
 					--CR 805
 						self.hajk.desc_id = "bm_menu_sc_hajk_desc"
-						self.hajk.has_description = true				
+						self.hajk.has_description = true
 						self.hajk.fire_mode_data.fire_rate = 0.085714285
 						self.hajk.AMMO_MAX = 75
 						self.hajk.BURST_FIRE = {
@@ -11417,7 +11417,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 							delay = 0.15,
 							recoil_mult = 0.75,
 							last_recoil_mult = 1.02
-						}					
+						}
 						self.hajk.kick = self.stat_info.kick_tables.moderate_kick
 						self.hajk.kick_pattern = {
 							{0, self.stat_info.kick_tables.moderate_kick},
@@ -11454,7 +11454,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 						self.hajk.stats_modifiers = nil
 						self.hajk.timers.reload_empty = 2.9
 						self.hajk.timers.reload_exit_empty = 0.98
-						self.hajk.timers.reload_not_empty = 1.9 
+						self.hajk.timers.reload_not_empty = 1.9
 						self.hajk.timers.reload_exit_not_empty = 0.65
 
 			--[[     HEAVY ARs     ]]
@@ -11527,14 +11527,14 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 							{12, self.stat_info.kick_tables.moderate_left_kick},
 							{15, self.stat_info.kick_tables.moderate_right_kick},
 							{21, self.stat_info.kick_tables.moderate_kick}
-						}		
+						}
 						self.l85a2.supported = true
 						self.l85a2.ads_speed = 0.400
 						self.l85a2.damage_falloff = {
 							start_dist = 2500,
 							end_dist = 7800,
 							min_mult = 0.4
-						}	
+						}
 						self.l85a2.stats = {
 							damage = 30,
 							spread = 91,
@@ -11611,7 +11611,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 							{12, self.stat_info.kick_tables.moderate_right_kick},
 							{18, self.stat_info.kick_tables.moderate_kick},
 							{22, self.stat_info.kick_tables.moderate_right_kick}
-						}			
+						}
 						self.akm_gold.AMMO_MAX = 120
 						self.akm_gold.fire_mode_data.fire_rate = 0.1
 						self.akm_gold.auto.fire_rate = 0.1
@@ -11709,7 +11709,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 							weapon = {
 								"clip_ammo_increase"
 							}
-						}		
+						}
 						self.groza_underbarrel.fire_mode_data.fire_rate = 1.2
 						self.groza_underbarrel.kick = self.stat_info.kick_tables.moderate_kick
 						self.groza_underbarrel.panic_suppression_chance = 0.05
@@ -11825,7 +11825,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 							{16, self.stat_info.kick_tables.moderate_kick},
 							{20, self.stat_info.kick_tables.moderate_left_kick},
 							{25, self.stat_info.kick_tables.moderate_right_kick}
-						}	
+						}
 						self.akmsu.supported = true
 						self.akmsu.ads_speed = 0.300
 						self.akmsu.damage_falloff = {
@@ -11850,7 +11850,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 						self.akmsu.stats_modifiers = nil
 						self.akmsu.timers.reload_empty = 3.2
 						self.akmsu.timers.reload_exit_empty = 1.25
-						self.akmsu.timers.reload_not_empty = 1.95 
+						self.akmsu.timers.reload_not_empty = 1.95
 						self.akmsu.timers.reload_exit_not_empty = 0.77
 						self.akmsu.reload_speed_multiplier = 1.18
 						self.akmsu.reload_not_empty_speed_multiplier = 0.95
@@ -11861,12 +11861,12 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 							"crb"
 						}
 						self.x_akmsu.desc_id = "bm_x_akmsu_sc_desc"
-						self.x_akmsu.has_description = true		
+						self.x_akmsu.has_description = true
 						self.x_akmsu.sounds.fire = "akm_fire_single"
 						self.x_akmsu.sounds.fire_single = "akm_fire_single"
 						self.x_akmsu.sounds.fire_auto = "akm_fire"
 						self.x_akmsu.sounds.stop_fire = "akm_stop"
-						self.x_akmsu.sounds.dryfire = "primary_dryfire"	
+						self.x_akmsu.sounds.dryfire = "primary_dryfire"
 						self.x_akmsu.AMMO_MAX = 120
 						self.x_akmsu.fire_mode_data.fire_rate = 0.0923076923
 						self.x_akmsu.panic_suppression_chance = 0.05
@@ -11877,7 +11877,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 							{16, self.stat_info.kick_tables.moderate_kick},
 							{20, self.stat_info.kick_tables.moderate_left_kick},
 							{25, self.stat_info.kick_tables.moderate_right_kick}
-						}	
+						}
 						self.x_akmsu.supported = true
 						self.x_akmsu.ads_speed = 0.300
 						self.x_akmsu.damage_falloff = {
@@ -11961,7 +11961,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 
 					--Eagle Heavy
 						self.scar.desc_id = "bm_scar_sc_desc"
-						self.scar.has_description = true		
+						self.scar.has_description = true
 						self.scar.AMMO_MAX = 80
 						self.scar.CLIP_AMMO_MAX = 20
 						self.scar.fire_mode_data.fire_rate = 0.1
@@ -11976,7 +11976,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 							{9, self.stat_info.kick_tables.vertical_kick},
 							{14, self.stat_info.kick_tables.moderate_kick},
 							{17, self.stat_info.kick_tables.moderate_right_kick}
-						}	
+						}
 						self.scar.muzzleflash = "effects/payday2/particles/weapons/big_762_auto_fps"
 						self.scar.supported = true
 						self.scar.ads_speed = 0.360
@@ -12127,7 +12127,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 							start_dist = 2000,
 							end_dist = 5000,
 							min_mult = 0.53333
-						}	
+						}
 						self.contraband.stats = {
 							damage = 45,
 							spread = 84,
@@ -12151,7 +12151,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 							weapon = {
 								"clip_ammo_increase"
 							}
-						}		
+						}
 						self.contraband_m203.fire_mode_data.fire_rate = 1.2
 						self.contraband_m203.kick = self.stat_info.kick_tables.vertical_kick
 						self.contraband_m203.panic_suppression_chance = 0.05
@@ -12230,7 +12230,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 						self.shak12.reload_speed_multiplier = 0.85
 						self.shak12.can_shoot_through_enemy = true
 						self.shak12.can_shoot_through_wall = false
-						self.shak12.panic_suppression_chance = 0.05	
+						self.shak12.panic_suppression_chance = 0.05
 						self.shak12.timers = deep_clone(self.corgi.timers)
 
 					--M308 (M1A SOCOM/M14)
@@ -12336,7 +12336,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 						self.g3.reload_speed_multiplier = 1.425
 
 					--Galant (M1 Garand)
-						self.ching.categories = { 
+						self.ching.categories = {
 							"assault_rifle",
 							"dmr_h"
 						}
@@ -12348,7 +12348,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 						self.ching.CLIP_AMMO_MAX = 8
 						self.ching.AMMO_MAX = 60
 						self.ching.CAN_TOGGLE_FIREMODE = false
-						self.ching.kick = self.stat_info.kick_tables.vertical_kick	
+						self.ching.kick = self.stat_info.kick_tables.vertical_kick
 						self.ching.kick_pattern = {
 							{0, self.stat_info.kick_tables.vertical_kick},
 							{3, self.stat_info.kick_tables.right_kick},
@@ -12377,7 +12377,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 							value = 9,
 							reload = 20
 						}
-						self.ching.stats_modifiers = nil	
+						self.ching.stats_modifiers = nil
 						self.ching.armor_piercing_chance = 0.75
 						self.ching.can_shoot_through_enemy = true
 						self.ching.can_shoot_through_enemy_unlim = true
@@ -12501,7 +12501,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 
 					--Repeater 1874
 						self.winchester1874.has_description = true
-						self.winchester1874.desc_id = "bm_winchester1874_sc_desc"			
+						self.winchester1874.desc_id = "bm_winchester1874_sc_desc"
 						self.winchester1874.upgrade_blocks = nil
 						self.winchester1874.AMMO_MAX = 40
 						self.winchester1874.CLIP_AMMO_MAX = 10
@@ -12559,7 +12559,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 
 					--Rattlesnake
 						self.msr.desc_id = "bm_msr_sc_desc"
-						self.msr.has_description = true					
+						self.msr.has_description = true
 						self.msr.upgrade_blocks = nil
 						self.msr.CLIP_AMMO_MAX = 10
 						self.msr.NR_CLIPS_MAX = 5
@@ -12599,7 +12599,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 
 					--Amaroq 900 (AWP)
 						self.awp.desc_id = "bm_awp_sc_desc"
-						self.awp.has_description = true			
+						self.awp.has_description = true
 						self.awp.upgrade_blocks = nil
 						self.awp.CLIP_AMMO_MAX = 5
 						self.awp.AMMO_MAX = 40
@@ -12640,7 +12640,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 
 					--R700
 						self.r700.desc_id = "bm_r700_sc_desc"
-						self.r700.has_description = true				
+						self.r700.has_description = true
 						self.r700.upgrade_blocks = nil
 						self.r700.CLIP_AMMO_MAX = 5
 						self.r700.AMMO_MAX = 40
@@ -12932,13 +12932,13 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 							total_ammo_mod = 400,
 							value = 9,
 							reload = 20
-						}	
+						}
 						self.sbl.stats_modifiers = nil
 						self.sbl.panic_suppression_chance = 0.05
 						self.sbl.timers.shotgun_reload_first_shell_offset = 0.25
 						self.sbl.timers.shotgun_reload_exit_empty = 1
 
-					--Nagant 
+					--Nagant
 						self.mosin.bmp = 1
 						self.mosin.has_description = true
 						self.mosin.desc_id = "bm_mosin_sc_desc"
@@ -13193,7 +13193,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 							total_ammo_mod = 400,
 							value = 9,
 							reload = 20
-						}	
+						}
 						self.contender.stats_modifiers = nil
 						self.contender.panic_suppression_chance = 0.05
 						self.contender.use_vapor_trail = true
@@ -13365,7 +13365,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 						self.system.shake.bypass_global_shake = true
 
 					--Cash Blaster
-						if self.money then			
+						if self.money then
 							self.money.fire_variant = "money"
 							self.money.categories = {
 								"flamethrower",
@@ -13422,7 +13422,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 							self.money.timers.reload_not_empty = 8.5
 							self.money.timers.reload_exit_empty = 1.5
 							self.money.timers.reload_exit_not_empty = 1.5
-							self.money.sounds.no_fix = true		
+							self.money.sounds.no_fix = true
 							self.money.shake.bypass_global_shake = true
 							self.money.unlock_func = nil
 						end
@@ -13433,7 +13433,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 
 					--Izhma 12G
 						self.saiga.desc_id = "bm_saiga_sc_desc"
-						self.saiga.has_description = true			
+						self.saiga.has_description = true
 						self.saiga.rays = 8
 						self.saiga.muzzleflash = "effects/payday2/particles/weapons/big_51b_auto_fps" --"effects/particles/shotgun/shotgun_gen"
 						self.saiga.CLIP_AMMO_MAX = 5
@@ -13490,7 +13490,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 							{13, self.stat_info.kick_tables.moderate_kick}
 						}
 						self.sko12.muzzleflash = "effects/payday2/particles/weapons/big_51b_auto_fps" --"effects/particles/shotgun/shotgun_gen"
-						self.sko12.FIRE_MODE = "single"				
+						self.sko12.FIRE_MODE = "single"
 						self.sko12.CAN_TOGGLE_FIREMODE = false
 						self.sko12.supported = true
 						self.sko12.ads_speed = 0.420
@@ -13537,7 +13537,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 							{10, self.stat_info.kick_tables.left_kick},
 							{12, self.stat_info.kick_tables.moderate_kick}
 						}
-						self.aa12.FIRE_MODE = "auto"				
+						self.aa12.FIRE_MODE = "auto"
 						self.aa12.CAN_TOGGLE_FIREMODE = false
 						self.aa12.supported = true
 						self.aa12.ads_speed = 0.380
@@ -13573,7 +13573,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 
 					--Argos III (Ultima)
 						self.ultima.desc_id = "bm_ultima_sc_desc"
-						self.ultima.has_description = true					
+						self.ultima.has_description = true
 						self.ultima.rays = 8
 						self.ultima.muzzleflash = "effects/payday2/particles/weapons/big_51b_auto_fps" --"effects/particles/shotgun/shotgun_gen"
 						self.ultima.CLIP_AMMO_MAX = 7
@@ -13606,9 +13606,9 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 							total_ammo_mod = 400,
 							value = 1,
 							reload = 20
-						}	
+						}
 						self.ultima.stats_modifiers = nil
-						self.ultima.panic_suppression_chance = 0.05	
+						self.ultima.panic_suppression_chance = 0.05
 						self.ultima.reload_speed_multiplier = 0.68
 						self.ultima.timers.shotgun_reload.not_empty = {
 							reload_enter = 0.4666666666666667,
@@ -13622,7 +13622,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 
 					--Predator 12G
 						self.spas12.desc_id = "bm_spas12_sc_desc"
-						self.spas12.has_description = true					
+						self.spas12.has_description = true
 						self.spas12.rays = 8
 						self.spas12.muzzleflash = "effects/payday2/particles/weapons/big_51b_auto_fps" --"effects/particles/shotgun/shotgun_gen"
 						self.spas12.AMMO_MAX = 60
@@ -13676,7 +13676,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 
 					--M1014
 						self.benelli.desc_id = "bm_benelli_sc_desc"
-						self.benelli.has_description = true					
+						self.benelli.has_description = true
 						self.benelli.AMMO_MAX = 60
 						self.benelli.CLIP_AMMO_MAX = 5
 						self.benelli.rays = 8
@@ -13757,7 +13757,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 							reload = 20,
 							suppression = 9,
 							concealment = 26
-						}		
+						}
 						self.basset.stats_modifiers = nil
 						self.basset.reload_speed_multiplier = 0.925
 						self.basset.sounds.fire_single = "basset_x_fire_single"
@@ -13801,7 +13801,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 							reload = 20,
 							suppression = 9,
 							concealment = 21
-						}		
+						}
 						self.x_basset.stats_modifiers = nil
 						self.x_basset.reload_speed_multiplier = 0.6
 						self.x_basset.always_hipfire = true
@@ -13922,7 +13922,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 							total_ammo_mod = 400,
 							value = 1,
 							reload = 20
-						}		
+						}
 						self.m590.stats_modifiers = nil
 						self.m590.panic_suppression_chance = 0.05
 						self.m590.timers.shotgun_reload_enter = 0.3
@@ -13981,7 +13981,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 							total_ammo_mod = 400,
 							value = 1,
 							reload = 20
-						}		
+						}
 						self.supernova.stats_modifiers = nil
 						self.supernova.panic_suppression_chance = 0.05
 						self.supernova.timers = {
@@ -14025,7 +14025,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 							total_ammo_mod = 400,
 							value = 1,
 							reload = 20
-						}		
+						}
 						self.r870.stats_modifiers = nil
 						self.r870.panic_suppression_chance = 0.05
 						self.r870.reload_speed_multiplier = 0.97
@@ -14037,14 +14037,14 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 
 					--Raven (KSG)
 						self.ksg.desc_id = "bm_menu_sc_ksg_desc"
-						self.ksg.has_description = true			
+						self.ksg.has_description = true
 						self.ksg.rays = 8
 						self.ksg.muzzleflash = "effects/payday2/particles/weapons/big_51b_auto_fps" --"effects/particles/shotgun/shotgun_gen"
 						self.ksg.AMMO_MAX = 40
 						self.ksg.CLIP_AMMO_MAX = 14
 						self.ksg.fire_mode_data.fire_rate = 0.5
 						self.ksg.fire_rate_multiplier = 0.775
-						self.ksg.kick = self.stat_info.kick_tables.vertical_kick		
+						self.ksg.kick = self.stat_info.kick_tables.vertical_kick
 						self.ksg.supported = true
 						self.ksg.ads_speed = 0.340
 						self.ksg.damage_falloff = {
@@ -14077,7 +14077,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 
 					--Reinfeld 88 (WHY IS THIS UNDER THE REMINGTON LABEL)
 						self.m1897.desc_id = "bm_menu_sc_m1897_desc"
-						self.m1897.has_description = true				
+						self.m1897.has_description = true
 						self.m1897.muzzleflash = "effects/payday2/particles/weapons/big_51b_auto_fps" --"effects/particles/shotgun/shotgun_gen"
 						self.m1897.rays = 8
 						self.m1897.CLIP_AMMO_MAX = 5
@@ -14122,7 +14122,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 							total_ammo_mod = 400,
 							value = 1,
 							reload = 20
-						}		
+						}
 						self.m1897.stats_modifiers = nil
 						self.m1897.panic_suppression_chance = 0.05
 						self.m1897.timers.shotgun_reload_exit_not_empty = 0.9
@@ -14172,7 +14172,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 
 					--GSPS (Ithaca Model 37)
 						self.m37.desc_id = "bm_slamfire_generic_desc"
-						self.m37.has_description = true				
+						self.m37.has_description = true
 						self.m37.rays = 8
 						self.m37.muzzleflash = "effects/payday2/particles/weapons/big_51b_auto_fps" --"effects/particles/shotgun/shotgun_gen"
 						self.m37.CLIP_AMMO_MAX = 5
@@ -14267,7 +14267,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 						self.judge.panic_suppression_chance = 0.05
 					--Akimbo
 						self.x_judge.desc_id = "bm_x_judge_sc_desc"
-						self.x_judge.has_description = true							
+						self.x_judge.has_description = true
 						self.x_judge.categories = {
 							"akimbo",
 							"shotgun",
@@ -14330,7 +14330,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 
 					--Joceline O/U 12G (Beretta 682 Hybrid)
 						self.b682.desc_id = "bm_b682_sc_desc"
-						self.b682.has_description = true						
+						self.b682.has_description = true
 						self.b682.rays = 8
 						self.b682.muzzleflash = "effects/payday2/particles/weapons/big_51b_auto_fps" --"effects/particles/shotgun/shotgun_gen"
 						self.b682.AMMO_MAX = 30
@@ -14338,7 +14338,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 						self.b682.CAN_TOGGLE_FIREMODE = false
 						self.b682.fire_mode_data.fire_rate = 0.2727272
 						self.b682.sounds.fire_single = "b682_fire"
-						self.b682.sounds.fire_auto = "b682_fire"		
+						self.b682.sounds.fire_auto = "b682_fire"
 						self.b682.kick = self.stat_info.kick_tables.vertical_kick
 						self.b682.kick_pattern = {
 							{0, self.stat_info.kick_tables.pattern_r2},
@@ -14542,7 +14542,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 							weapon = {
 								"clip_ammo_increase"
 							}
-						}		
+						}
 						self.ecp.damage_type = "sniper"
 						self.ecp.has_description = true
 						self.ecp.desc_id = "bm_airbow_sc_desc"
@@ -14619,7 +14619,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 							weapon = {
 								"clip_ammo_increase"
 							}
-						}			
+						}
 						self.arblast.damage_type = "anti_materiel"
 						self.arblast.has_description = true
 						self.arblast.desc_id = "bm_xbow_sc_desc"
@@ -14654,7 +14654,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 							weapon = {
 								"clip_ammo_increase"
 							}
-						}		
+						}
 						self.plainsrider.damage_type = "sniper"
 						self.plainsrider.has_description = true
 						self.plainsrider.desc_id = "bm_bow_sc_desc"
@@ -14741,7 +14741,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 							reload_empty = 1.5,
 							unequip = 0.85,
 							equip = 0.85
-						}		
+						}
 						self.elastic.kick = self.stat_info.kick_tables.none
 						self.elastic.charge_data.max_t = 0.5
 						self.elastic.not_allowed_in_bleedout = false
@@ -14788,7 +14788,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 							weapon = {
 								"clip_ammo_increase"
 							}
-						}		
+						}
 						self.hunter.damage_type = "sniper"
 						self.hunter.has_description = true
 						self.hunter.desc_id = "bm_xbow_sc_desc"
@@ -14827,7 +14827,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 							weapon = {
 								"clip_ammo_increase"
 							}
-						}		
+						}
 						self.gre_m79.desc_id = "bm_w_gre_m79_sc_desc"
 						self.gre_m79.has_description = true
 						self.gre_m79.fire_mode_data.fire_rate = 1.2
@@ -14869,7 +14869,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 							weapon = {
 								"clip_ammo_increase"
 							}
-						}				
+						}
 						self.m32.kick = self.stat_info.kick_tables.right_kick
 						self.m32.has_description = true
 						self.m32.desc_id = "bm_m32_sc_desc"
@@ -14914,7 +14914,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 							weapon = {
 								"clip_ammo_increase"
 							}
-						}			
+						}
 						self.ray.use_data.selection_index = 2
 						self.ray.has_description = true
 						self.ray.desc_id = "bm_ray_sc_desc"
@@ -14964,7 +14964,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 							weapon = {
 								"clip_ammo_increase"
 							}
-						}		
+						}
 						self.ms3gl.desc_id = "bm_ms3gl_sc_desc"
 						self.ms3gl.has_description = true
 						--self.ms3gl.green_display = true
@@ -15021,7 +15021,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 							weapon = {
 								"clip_ammo_increase"
 							}
-						}		
+						}
 						self.arbiter.fire_mode_data.fire_rate = 0.5
 						self.arbiter.CLIP_AMMO_MAX = 5
 						self.arbiter.AMMO_MAX = 6
@@ -15062,7 +15062,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 							weapon = {
 								"clip_ammo_increase"
 							}
-						}			
+						}
 						self.slap.desc_id = "bm_40mm_weapon_sc_desc"
 						self.slap.has_description = false
 						self.slap.fire_mode_data.fire_rate = 1.2
@@ -15104,7 +15104,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 							weapon = {
 								"clip_ammo_increase"
 							}
-						}		
+						}
 						self.china.desc_id = "bm_w_china_sc_desc"
 						self.china.has_description = true
 						self.china.fire_mode_data.fire_rate = 1.3
@@ -15148,7 +15148,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 							weapon = {
 								"clip_ammo_increase"
 							}
-						}		
+						}
 						self.rpg7.kick = self.stat_info.kick_tables.vertical_kick
 						self.rpg7.has_description = true
 						self.rpg7.rays = 1
@@ -15243,7 +15243,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 					self.saw_secondary.reload_speed_multiplier = 1.1
 					self.saw_secondary.panic_suppression_chance = 0.05
 					self.saw_secondary.timers = deep_clone(self.saw.timers)
-		
+
 	--[[     RESMOD WEAPONS     ]]--
 
 		--Phoenix .500
@@ -15252,7 +15252,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 			self.shatters_fury.recategorize = { "heavy_pis", "handcannon" }
 			self.shatters_fury.damage_type = "handcannon"
 			self.shatters_fury.fire_mode_data.fire_rate = 0.2142857
-			self.shatters_fury.muzzleflash = "effects/payday2/particles/weapons/big_51b_auto_fps"	
+			self.shatters_fury.muzzleflash = "effects/payday2/particles/weapons/big_51b_auto_fps"
 			--if restoration.Options:GetValue("OTHER/ComboSounds") then
 				self.shatters_fury.sounds.fire_single = "pmkr45_fire"
 				self.shatters_fury.sounds.stop_fire = "b682_fire" --"hajk_x_fire_single
@@ -15311,7 +15311,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 			self.osipr.damage_type = "assault_rifle"
 			self.osipr.is_bullpup = true
 			self.osipr.nato = true
-			self.osipr.tactical_reload = 1		
+			self.osipr.tactical_reload = 1
 			self.osipr.AMMO_MAX = 120
 			self.osipr.CLIP_AMMO_MAX = 30
 			self.osipr.fire_mode_data.fire_rate = 0.075
@@ -15389,10 +15389,10 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 			self.osipr_gl.stats_modifiers = {damage = 10}
 			self.osipr_gl.timers.reload_not_empty = 3.34
 			self.osipr_gl.timers.reload_exit_not_empty = 0.8
-			self.osipr_gl.timers.reload_empty = 4.5		
+			self.osipr_gl.timers.reload_empty = 4.5
 			self.osipr_gl.timers.reload_exit_empty = 0.6
 			self.osipr_gl.panic_suppression_chance = 0.05
-			self.osipr_gl.custom = false	--Temp fix for BeardLib sync 
+			self.osipr_gl.custom = false	--Temp fix for BeardLib sync
 			self.osipr_gl_npc.sounds.prefix = "contrabandm203_npc"
 			self.osipr_gl_npc.use_data.selection_index = 2
 			self.osipr_gl_npc.DAMAGE = 2
@@ -15411,14 +15411,14 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 		--Anubis .45
 		if self.socom then
 			self.socom.recategorize = { "heavy_pis" }
-			self.socom.damage_type = "heavy_pistol"	
+			self.socom.damage_type = "heavy_pistol"
 			self.socom.timers = {
 				reload_not_empty = 1.5435,
 				reload_empty = 2.226,
 				unequip = 0.5,
 				equip = 0.35
-			}	
-			self.socom.tactical_reload = 1	
+			}
+			self.socom.tactical_reload = 1
 			self.socom.fire_mode_data.fire_rate = 0.117647058
 			self.socom.CLIP_AMMO_MAX = 12
 			self.socom.AMMO_MAX = 40
@@ -15502,7 +15502,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 			self.x_socom.timers.reload_exit_empty = 0.55
 			self.x_socom.timers.reload_exit_not_empty = 0.65
 		end
-	
+
 	--[[     CUSTOM BEARDLIB WEAPONS     ]]--
 
 		--[[     GAMBYT'S MODS     ]]--
@@ -15553,10 +15553,9 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 				self.toy1911.desc_id = "bm_w_toy1911_sc_desc"
 				self.toy1911.ads_speed = 0.100
 				self.toy1911.fire_mode_data.fire_rate = 0.04
-				self.toy1911.BURST_FIRE = 1
-				self.toy1911.BURST_TYPE = "rapid"
-				self.toy1911.BURST_DELAY = 0.04
-				self.toy1911.AUTO_BURST = true
+				self.toy1911.no_auto_anims = true
+				self.toy1911.CAN_TOGGLE_FIREMODE = true
+				self.toy1911.FIRE_MODE = "auto"
 				self.toy1911.damage_falloff = {
 					start_dist = 250,
 					end_dist = 1500,
@@ -15582,11 +15581,12 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 					fire_steelsight_multiplier = 0.01,
 					bypass_global_shake = true
 				}
-				self.toy1911.timers.reload_exit_empty = 0.5
-				self.toy1911.timers.reload_exit_not_empty = 0.65	
+				self.toy1911.sounds.fire_single = "toy1911_fire"
+				self.toy1911.sounds.fire_auto = "toy1911_fire"
+				self.toy1911.timers = deep_clone(self.packrat.timers)
 			end
 
-			if self.hpb then --Gambyt's Browning HP	
+			if self.hpb then --Gambyt's Browning HP
 				self.hpb.recategorize = {"light_pis"}
 				self.hpb.has_description = false
 				self.hpb.tactical_reload = 1
@@ -15625,13 +15625,13 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 				self.hpb.panic_suppression_chance = 0.05
 				self.hpb.timers.reload_exit_empty = 0.5
 				self.hpb.timers.reload_exit_not_empty = 0.65
-			end	
+			end
 
 			--Vanilla Mod Pack
 				if self.lebman then --Gambyt's Vendetta 38 Pistol
 					self.lebman.recategorize = {"light_pis"}
 					self.lebman.desc_id = nil
-					self.lebman.tactical_reload = 1		
+					self.lebman.tactical_reload = 1
 					self.lebman.use_data.selection_index = 2
 					self.lebman.CLIP_AMMO_MAX = 11
 					self.lebman.AMMO_MAX = 120
@@ -15673,12 +15673,12 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 					self.x_lebman.use_data.selection_index = 5
 					self.x_lebman.supported = true
 				end
-			
+
 				if self.ak5s then --Gambyt's Automat-5/AK5 SMG
 					self.ak5s.recategorize = { "light_smg" }
 					self.ak5s.desc_id = nil
 					self.ak5s.categories = {"smg"}
-					self.ak5s.tactical_reload = 1		
+					self.ak5s.tactical_reload = 1
 					self.ak5s.use_data.selection_index = 2
 					self.ak5s.CLIP_AMMO_MAX = 30
 					self.ak5s.AMMO_MAX = 150
@@ -15720,8 +15720,8 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 					self.ak5s.timers.reload_not_empty = 2.52
 					self.ak5s.timers.reload_exit_not_empty = 0.7
 					self.ak5s.reload_speed_multiplier = 1.05
-				end	
-			
+				end
+
 				if self.car9 then --Gambyt's ACAR 9
 					self.car9.recategorize = { "light_smg" }
 					self.car9.damage_type = "machine_gun"
@@ -15765,22 +15765,22 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 					self.car9.timers.reload_not_empty = self.new_m4.timers.reload_not_empty
 					self.car9.timers.reload_empty = self.new_m4.timers.reload_empty
 					self.car9.timers.reload_exit_empty = self.new_m4.timers.reload_exit_empty
-					self.car9.timers.reload_exit_not_empty = self.new_m4.timers.reload_exit_not_empty	
+					self.car9.timers.reload_exit_not_empty = self.new_m4.timers.reload_exit_not_empty
 					self.car9.panic_suppression_chance = 0.05
 					self.car9.stats_modifiers = nil
 				end
-					
+
 				if self.amr12 then --Gambyt's AMR 12G Shotgun
-					self.amr12.recategorize = { "light_shot" }	
+					self.amr12.recategorize = { "light_shot" }
 					self.amr12.damage_type = "shotgun"
 					self.amr12.damage_type_single_ray = "sniper"
 					self.amr12.rays = 8
 					self.amr12.muzzleflash = "effects/payday2/particles/weapons/big_51b_auto_fps" --"effects/particles/shotgun/shotgun_gen"
 					self.amr12.AMMO_MAX = 60
-					self.amr12.tactical_reload = 1		
+					self.amr12.tactical_reload = 1
 					self.amr12.CLIP_AMMO_MAX = 5
 					self.amr12.fire_mode_data.fire_rate = 0.17142857
-					self.amr12.FIRE_MODE = "single"		
+					self.amr12.FIRE_MODE = "single"
 					self.amr12.CAN_TOGGLE_FIREMODE = false
 					self.amr12.BURST_FIRE = false
 					self.amr12.kick = self.stat_info.kick_tables.vertical_kick
@@ -15814,7 +15814,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 					self.amr12.sounds.stop_fire = "contraband_fire_single"
 					self.amr12.timers = deep_clone(self.olympic.timers)
 				end
-			
+
 				if self.minibeck then --Reinbeck Auto
 					self.minibeck.recategorize = { "light_shot" }
 					self.minibeck.damage_type = "shotgun"
@@ -15861,7 +15861,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 					self.minibeck.timers.shotgun_reload_exit_not_empty = 0.2
 					self.minibeck.timers.shotgun_reload_exit_empty = 1.5
 				end
-				
+
 				if self.beck then --Gambyt's Reinbeck M1 Shotgun
 					self.beck.recategorize = { "heavy_shot" }
 					self.beck.damage_type = "shotgun_heavy"
@@ -15905,7 +15905,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 					self.beck.timers.shotgun_reload_exit_not_empty = 0.3
 					self.beck.timers.shotgun_reload_exit_empty = 0.7
 				end
-			
+
 				if self.bs23 then --Hammer 23
 					self.bs23.categories = { "shotgun" }
 					self.bs23.recategorize = { "break_shot" }
@@ -15950,13 +15950,13 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 					self.bs23.timers.shotgun_reload_exit_empty = 1.4
 					self.bs23.timers.shotgun_reload_exit_not_empty = 0.7
 				end
-			
+
 				if self.sg416 then --Gambyt's SG416
 					self.sg416.nato = true
 					self.sg416.recategorize = { "light_ar" }
 					self.sg416.damage_type = "assault_rifle"
-					self.sg416.has_description = false						
-					self.sg416.tactical_reload = 1		
+					self.sg416.has_description = false
+					self.sg416.tactical_reload = 1
 					self.sg416.AMMO_MAX = 150
 					self.sg416.sounds.fire = "m16_fire_single"
 					self.sg416.sounds.fire_single = "m16_fire_single"
@@ -15998,14 +15998,14 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 					self.sg416.timers = deep_clone(self.new_m4.timers)
 					self.sg416.panic_suppression_chance = 0.05
 				end
-			
+
 				if self.aknato then --Gambyt's Mamba 5.56 / Ak-101
 					self.aknato.nato = true
 					self.aknato.recategorize = {"light_ar"}
 					self.aknato.tactical_reload = 1
 					self.aknato.CLIP_AMMO_MAX = 30
 					self.aknato.AMMO_MAX = 150
-					self.aknato.FIRE_MODE = "auto"				
+					self.aknato.FIRE_MODE = "auto"
 					self.aknato.BURST_FIRE = false
 					self.aknato.CAN_TOGGLE_FIREMODE = true
 					self.aknato.sounds.fire = "m4_olympic_fire_single"
@@ -16044,8 +16044,8 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 					self.aknato.stats_modifiers = nil
 					self.aknato.panic_suppression_chance = 0.05
 					self.aknato.timers = deep_clone(self.akm.timers)
-				end	
-			
+				end
+
 				if self.smolak then --Gambyt's AK Dragon 5.45 Pistol
 					self.smolak.warsaw = true
 					self.smolak.categories = {"assault_rifle"}
@@ -16055,7 +16055,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 					self.smolak.fire_mode_data.fire_rate = 0.08
 					self.smolak.AMMO_MAX = 150
 					self.smolak.CAN_TOGGLE_FIREMODE = true
-					self.smolak.kick = self.stat_info.kick_tables.right_kick	
+					self.smolak.kick = self.stat_info.kick_tables.right_kick
 					self.smolak.kick_pattern = {
 						{0, self.stat_info.kick_tables.right_kick},
 						{2, self.stat_info.kick_tables.pattern_r4},
@@ -16089,17 +16089,17 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 					self.smolak.panic_suppression_chance = 0.05
 					self.smolak.reload_speed_multiplier = 1.2
 					self.smolak.timers = deep_clone(self.asval.timers)
-				end	
-			
+				end
+
 				if self.spike then --Gambyt's Spike Rifle
 					self.spike.warsaw = true
 					self.spike.recategorize = { "heavy_ar" }
 					self.spike.is_bullpup = true
-					self.spike.has_description = false						
-					self.spike.tactical_reload = 1		
+					self.spike.has_description = false
+					self.spike.tactical_reload = 1
 					self.spike.AMMO_MAX = 120
 					self.spike.fire_mode_data.fire_rate = 0.1
-					self.spike.kick = self.stat_info.kick_tables.right_kick	
+					self.spike.kick = self.stat_info.kick_tables.right_kick
 					self.spike.kick_pattern = {
 						{0, self.stat_info.kick_tables.vertical_kick},
 						{6, self.stat_info.kick_tables.right_kick},
@@ -16107,7 +16107,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 						{10, self.stat_info.kick_tables.pattern_l1},
 						{12, self.stat_info.kick_tables.vertical_kick},
 						{18, self.stat_info.kick_tables.moderate_left_kick}
-					}	
+					}
 					self.spike.supported = true
 					self.spike.ads_speed = 0.280
 					self.spike.damage_falloff = {
@@ -16134,12 +16134,12 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 					self.spike.timers = deep_clone(self.basset.timers)
 					self.spike.panic_suppression_chance = 0.05
 				end
-			
+
 				if self.bdgr then --Hornet .300
 					--Making it a secondary
 					self.bdgr.recategorize = { "heavy_ar" }
 					self.bdgr.damage_type = "assault_rifle"
-					self.bdgr.use_data.selection_index = 1				
+					self.bdgr.use_data.selection_index = 1
 					self.bdgr.fire_mode_data.fire_rate = 0.075
 					self.bdgr.tactical_reload = 1
 					self.bdgr.AMMO_MAX = 60
@@ -16178,8 +16178,8 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 					self.bdgr.timers.reload_not_empty = 2.6
 					self.bdgr.timers.reload_exit_not_empty = 0.65
 				end
-			
-				if self.sgs then --Gambyt's Guerilla .308	
+
+				if self.sgs then --Gambyt's Guerilla .308
 					self.sgs.nato = true
 					self.sgs.categories = {
 						"snp",
@@ -16232,7 +16232,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 					self.sgs.stats_modifiers = nil
 					self.sgs.panic_suppression_chance = 0.05
 					self.sgs.timers = deep_clone(self.shepheard.timers)
-				end	
+				end
 
 			--Quake Weapon Pack
 				if self.qrl then
@@ -16241,7 +16241,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 						weapon = {
 							"clip_ammo_increase"
 						}
-					}		
+					}
 					self.qrl.supported = true
 					self.qrl.ads_speed = 0.320
 					self.qrl.damage_falloff = {
@@ -16278,7 +16278,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 					self.qsho.damage_type_single_ray = "anti_materiel"
 					self.qsho.should_reload_immediately = true
 					self.qsho.has_description = true
-					self.qsho.no_auto_anims = true	
+					self.qsho.no_auto_anims = true
 					self.qsho.desc_id = "bm_quake_shotgun_sc_desc"
 					self.qsho.AMMO_MAX = 15
 					self.qsho.kick = self.stat_info.kick_tables.vertical_kick
@@ -16313,7 +16313,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 		--[[     CARL'S MODS     ]]--
 
 			if self.l1a1 then
-				self.l1a1.categories = { 
+				self.l1a1.categories = {
 					"assault_rifle",
 					"dmr_l",
 				}
@@ -16365,7 +16365,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 
 			if self.limafive then -- Deagle L5
 				self.limafive.recategorize = {"heavy_pis"}
-				self.limafive.damage_type = "handcannon"			
+				self.limafive.damage_type = "handcannon"
 				self.limafive.fire_mode_data.fire_rate = 0.1428
 				self.limafive.CLIP_AMMO_MAX = 9
 				self.limafive.AMMO_MAX = 30
@@ -16399,7 +16399,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 				self.limafive.stats_modifiers = nil
 				self.limafive.panic_suppression_chance = 0.05
 				self.limafive.has_description = true
-				self.limafive.desc_id = "bm_ap_armor_50_weapon_sc_desc"	
+				self.limafive.desc_id = "bm_ap_armor_50_weapon_sc_desc"
 				self.limafive.can_shoot_through_enemy = true
 				self.limafive.armor_piercing_chance = 0.5
 				self.limafive.reload_speed_multiplier = 1.12
@@ -16458,7 +16458,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 
 			if self.tilt then --Carl's AN 92
 				self.tilt.warsaw = true
-				self.tilt.recategorize = { "light_ar" }	
+				self.tilt.recategorize = { "light_ar" }
 				self.tilt.damage_type = "assault_rifle"
 				self.tilt.has_description = true
 				self.tilt.desc_id = "bm_tilt_sc_desc"
@@ -16513,8 +16513,8 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 			end
 
 			if self.czevo then --Carl's Scorpion EVO
-				self.czevo.recategorize = { "light_smg" }					
-				self.czevo.has_description = false					
+				self.czevo.recategorize = { "light_smg" }
+				self.czevo.has_description = false
 				self.czevo.use_data.selection_index = 2
 				self.czevo.tactical_reload = 1
 				self.czevo.categories = {
@@ -16557,7 +16557,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 				self.czevo.timers.reload_exit_empty = 0.4
 				self.czevo.timers.reload_not_empty = 2.08
 				self.czevo.timers.reload_exit_not_empty = 0.4
-				self.x_czevo.use_data.selection_index = 5 
+				self.x_czevo.use_data.selection_index = 5
 			end
 
 			if self.lapd then --Carl's M2019 Blaster
@@ -16602,10 +16602,10 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 				self.lapd.can_shoot_through_enemy_unlim = true
 				self.lapd.sounds.fire2 = "rbull_fire"
 				self.lapd.timers = deep_clone(self.new_raging_bull.timers)
-				
+
 				self.x_lapd.use_data.selection_index = 5
 			end
-			
+
 			if self.pdr then
 				self.pdr.supported = true
 				self.pdr.categories = {"assault_rifle"}
@@ -16614,7 +16614,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 				self.pdr.fire_mode_data.fire_rate = 0.08
 				self.pdr.tactical_reload = 1
 				self.pdr.CLIP_AMMO_MAX = 30
-				self.pdr.AMMO_MAX = 75				
+				self.pdr.AMMO_MAX = 75
 				self.pdr.kick = self.stat_info.kick_tables.moderate_kick
 				self.aug.kick_pattern = {
 					{0, self.stat_info.kick_tables.vertical_kick},
@@ -16947,7 +16947,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 				self.acwr.recategorize = { "light_ar" }
 				self.acwr.damage_type = "assault_rifle"
 				self.acwr.tactical_reload = 1
-				self.acwr.nato = true			
+				self.acwr.nato = true
 				self.acwr.BURST_FIRE = false
 				self.acwr.ADAPTIVE_BURST_SIZE = false
 				self.acwr.FIRE_MODE = "auto"
@@ -17037,7 +17037,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 				self.acwr2.timers = deep_clone(self.new_m4.timers)
 			end
 
-			if self.mr96 then 
+			if self.mr96 then
 				self.mr96.recategorize = {"heavy_pis", "handcannon"}
 				self.mr96.has_description = true
 				self.mr96.desc_id = "bm_ap_armor_50_weapon_sc_desc"
@@ -17134,7 +17134,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 					{12, self.stat_info.kick_tables.moderate_right_kick},
 					{18, self.stat_info.kick_tables.moderate_kick},
 					{22, self.stat_info.kick_tables.moderate_right_kick}
-				}	
+				}
 				self.akm_nomag.supported = true
 				self.akm_nomag.ads_speed = 0.240
 				self.akm_nomag.damage_falloff = {
@@ -17166,7 +17166,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 			if self.tingledingle then --Zdanns's TBP
 				table.insert(self.tingledingle.categories, "crb")
 				self.tingledingle.bmp = 999999
-				self.tingledingle.no_auto_anims = true		
+				self.tingledingle.no_auto_anims = true
 				self.tingledingle.recategorize = { "light_ar" }
 				self.tingledingle.damage_type = "assault_rifle"
 				self.tingledingle.tactical_reload = 1
@@ -17192,7 +17192,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 					start_dist = 690,
 					end_dist = 6900,
 					min_mult = 0.05
-				}	
+				}
 				self.tingledingle.stats = {
 					damage = 18,
 					spread = 71,
@@ -17217,7 +17217,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 					"snp",
 					"semi_snp"
 				}
-				self.hmcar.recategorize = { "heavy_snp" }	
+				self.hmcar.recategorize = { "heavy_snp" }
 				self.hmcar.damage_type = "sniper"
 				self.hmcar.has_description = true
 				self.hmcar.desc_id = "bm_hmcar_sc_desc"
@@ -17266,7 +17266,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 					start_dist = 6900,
 					end_dist = 9600,
 					min_mult = 0.5
-				}	
+				}
 				self.hmcar.stats = {
 					damage = 90,
 					spread = 91,
@@ -17315,7 +17315,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 					{6, self.stat_info.kick_tables.moderate_right_kick},
 					{12, self.stat_info.kick_tables.moderate_kick},
 					{18, self.stat_info.kick_tables.moderate_right_kick}
-				}	
+				}
 				self.nckuro.ads_speed = 0.300
 				self.nckuro.supported = true
 				self.nckuro.stats = {
@@ -17526,7 +17526,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 			end
 
 			if self.obrez then
-				self.obrez.categories = { 
+				self.obrez.categories = {
 					"snp",
 					"gl_pistol"
 				}
@@ -17873,7 +17873,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 					reload_empty = 2.12,
 					unequip = 0.5,
 					equip = 0.35
-				}		
+				}
 				self.p99.panic_suppression_chance = 0.05
 				self.p99.timers.reload_exit_empty = 0.5
 				self.p99.timers.reload_exit_not_empty = 0.65
@@ -18213,7 +18213,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 				self.aug9mm.CAN_TOGGLE_FIREMODE = true
 				self.aug9mm.CLIP_AMMO_MAX = 25
 				self.aug9mm.AMMO_MAX = 75
-				self.aug9mm.tactical_reload = 1	
+				self.aug9mm.tactical_reload = 1
 				self.aug9mm.kick = self.stat_info.kick_tables.moderate_kick
 				self.aug.kick_pattern = {
 					{0, self.stat_info.kick_tables.vertical_kick},
@@ -18404,7 +18404,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 				self.wmtx.timers.reload_not_empty = 2.82
 				self.wmtx.timers.reload_exit_not_empty = 0.5
 			end
-			
+
 			if self.jackhammer then --Pawcio's Jackhammer
 				self.jackhammer.recategorize = { "heavy_shot" } --it's effectively semi auto
 				self.jackhammer.damage_type = "shotgun"
@@ -18477,7 +18477,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 					rof_mult = 5
 				}
 				self.quadbarrel.CAN_TOGGLE_FIREMODE = false
-				self.quadbarrel.ADAPTIVE_BURST_SIZE = false		
+				self.quadbarrel.ADAPTIVE_BURST_SIZE = false
 				self.quadbarrel.fire_mode_data = {}
 				self.quadbarrel.fire_mode_data.fire_rate = 0.171428
 				self.quadbarrel.supported = true
@@ -18523,7 +18523,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 				self.ks23.fire_mode_data.fire_rate = 1.3
 				self.ks23.rays = 8
 				self.ks23.AMMO_MAX = 30
-				self.ks23.CLIP_AMMO_MAX = 3		
+				self.ks23.CLIP_AMMO_MAX = 3
 				self.ks23.kick = self.stat_info.kick_tables.vertical_kick
 				self.ks23.supported = true
 				self.ks23.ads_speed = 0.440
@@ -18554,11 +18554,11 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 				self.ks23.timers.shotgun_reload_first_shell_offset = 0.45
 				self.ks23.timers.shotgun_reload_exit_empty = 1.4
 				self.ks23.timers.shotgun_reload_exit_not_empty = 0.7
-			end	
+			end
 
 			if self.super then --Pawcio's DOOM Super Shotgun
 				table.insert(self.super.categories, "shotgun_super")
-				self.super.recategorize = { "break_shot" }	
+				self.super.recategorize = { "break_shot" }
 				self.super.damage_type = "shotgun_heavy"
 				self.super.damage_type_single_ray = "anti_materiel"
 				self.super.should_reload_immediately = true
@@ -18573,7 +18573,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 				}
 				self.super.CLIP_AMMO_MAX = 1
 				self.super.AMMO_MAX = 18
-				self.super.CAN_TOGGLE_FIREMODE = false							
+				self.super.CAN_TOGGLE_FIREMODE = false
 				self.super.BURST_FIRE = false
 				self.super.fire_mode_data.fire_rate = 0.5
 				self.super.supported = true
@@ -18765,7 +18765,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 				self.ar18.recategorize = { "light_ar" }
 				self.ar18.damage_type = "assault_rifle"
 				self.ar18.tactical_reload = 1
-				self.ar18.nato = true			
+				self.ar18.nato = true
 				self.ar18.BURST_FIRE = false
 				self.ar18.ADAPTIVE_BURST_SIZE = false
 				self.ar18.fire_mode_data.fire_rate = 0.08
@@ -18818,8 +18818,8 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 					rof_mult = 1.6666,
 					recoil_mult = 0.75,
 					last_recoil_mult = 1.05
-				}		
-				self.ak12.ADAPTIVE_BURST_SIZE = false									
+				}
+				self.ak12.ADAPTIVE_BURST_SIZE = false
 				self.ak12.fire_mode_data.fire_rate = 0.1
 				self.ak12.kick = self.stat_info.kick_tables.moderate_right_kick
 				self.ak12.kick_pattern = {
@@ -18868,7 +18868,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 				self.galilace.nato = true
 				self.galilace.AMMO_MAX = 150
 				self.galilace.CLIP_AMMO_MAX = 35
-				self.galilace.BURST_FIRE = false						
+				self.galilace.BURST_FIRE = false
 				self.galilace.fire_mode_data.fire_rate = 0.07692307
 				self.galilace.kick = self.stat_info.kick_tables.moderate_kick
 				self.galilace.kick_pattern = {
@@ -18930,14 +18930,14 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 					{13, self.stat_info.kick_tables.moderate_right_kick},
 					{19, self.stat_info.kick_tables.moderate_left_kick},
 					{22, self.stat_info.kick_tables.moderate_kick}
-				}	
+				}
 				self.scarl.supported = true
 				self.scarl.ads_speed = 0.300
 				self.scarl.damage_falloff = {
 					start_dist = 2800,
 					end_dist = 6500,
 					min_mult = 0.4
-				}	
+				}
 				self.scarl.stats = {
 					damage = 30,
 					spread = 86,
@@ -18975,7 +18975,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 					delay = 0.25,
 					recoil_mult = 0.75,
 					last_recoil_mult = 1.05
-				}		
+				}
 				self.xeno.kick = self.stat_info.kick_tables.moderate_kick
 				self.xeno.kick_pattern = {
 					{0, self.stat_info.kick_tables.vertical_kick},
@@ -18993,7 +18993,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 					start_dist = 1600,
 					end_dist = 5100,
 					min_mult = 0.53333
-				}	
+				}
 				self.xeno.stats = {
 					damage = 45,
 					spread = 71,
@@ -19018,10 +19018,10 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 				--since it overrides the tec9's soundbank
 				self.tec9.sounds.fire = "mp9_fire_single"
 				self.tec9.sounds.fire_single = "mp9_fire_single"
-			end	
+			end
 
 			if self.sks then
-				self.sks.categories = { 
+				self.sks.categories = {
 					"assault_rifle",
 					"dmr_l"
 				}
@@ -19044,7 +19044,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 					{7, self.stat_info.kick_tables.left_recoil},
 					{12, self.stat_info.kick_tables.moderate_right_kick},
 					{16, self.stat_info.kick_tables.right_recoil},
-				}	
+				}
 				self.sks.supported = true
 				self.sks.ads_speed = 0.280
 				self.sks.damage_falloff = {
@@ -19087,7 +19087,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 			end
 
 			if self.skspug then
-				self.skspug.categories = { 
+				self.skspug.categories = {
 					"assault_rifle",
 					"dmr_l"
 				}
@@ -19107,7 +19107,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 					{7, self.stat_info.kick_tables.right_kick},
 					{14, self.stat_info.kick_tables.moderate_left_kick},
 					{16, self.stat_info.kick_tables.moderate_right_kick},
-				}	
+				}
 				self.skspug.rays = nil
 				self.skspug.supported = true
 				self.skspug.ads_speed = 0.260
@@ -19139,7 +19139,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 			end
 
 			if self.vss then
-				self.vss.categories = { 
+				self.vss.categories = {
 					"assault_rifle",
 					"dmr_h",
 				}
@@ -19199,7 +19199,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 			end
 
 			if self.g3hk79 then
-				self.g3hk79.categories = { 
+				self.g3hk79.categories = {
 					"assault_rifle",
 					"dmr_h",
 				}
@@ -19259,7 +19259,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 			end
 
 			if self.m2 then
-				self.m2.categories = { 
+				self.m2.categories = {
 					"assault_rifle",
 				}
 				self.m2.recategorize = {"heavy_ar"}
@@ -19311,7 +19311,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 			end
 
 			if self.m1a1 then
-				self.m1a1.categories = { 
+				self.m1a1.categories = {
 					"assault_rifle",
 					"dmr_l"
 				}
@@ -19364,7 +19364,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 				self.m1a1.timers.reload_exit_empty = 0.9
 				self.m1a1.timers.reload_exit_not_empty = 0.59
 			end
-						
+
 			if self.moss464spx then --Pawcio's SPX Centerfire
 				self.moss464spx.recategorize = {"light_snp"}
 				self.moss464spx.damage_type = "sniper"
@@ -19374,7 +19374,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 				self.moss464spx.sounds.stop_fire = "saiga_stop"
 				self.moss464spx.desc_id = "bm_ap_weapon_sc_desc"
 				self.moss464spx.AMMO_MAX = 40
-				self.moss464spx.tactical_reload = 1					
+				self.moss464spx.tactical_reload = 1
 				self.moss464spx.FIRE_MODE = "single"
 				self.moss464spx.fire_mode_data = {}
 				self.moss464spx.fire_mode_data.fire_rate = 0.857142857
@@ -19406,17 +19406,17 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 					value = 9,
 					reload = 20
 				}
-				self.moss464spx.timers = deep_clone(self.sbl.timers)	
+				self.moss464spx.timers = deep_clone(self.sbl.timers)
 				self.moss464spx.stats_modifiers = nil
 				self.moss464spx.panic_suppression_chance = 0.05
 				self.moss464spx.weapon_hold = "sbl"
-			end	
+			end
 
 			if self.winchester1894 then --Pawcio's Winchester 1894
 				self.winchester1894.recategorize = {"light_snp"}
 				self.winchester1894.damage_type = "sniper"
-				self.winchester1894.always_play_anims = true					
-				self.winchester1894.tactical_reload = 1						
+				self.winchester1894.always_play_anims = true
+				self.winchester1894.tactical_reload = 1
 				self.winchester1894.has_description = true
 				self.winchester1894.desc_id = "bm_ap_weapon_sc_desc"
 				self.winchester1894.sounds.stop_fire = "saiga_stop"
@@ -19452,17 +19452,17 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 					value = 9,
 					reload = 20
 				}
-				self.winchester1894.timers = deep_clone(self.sbl.timers)	
+				self.winchester1894.timers = deep_clone(self.sbl.timers)
 				self.winchester1894.stats_modifiers = nil
 				self.winchester1894.panic_suppression_chance = 0.05
 				self.winchester1894.weapon_hold = "sbl"
-			end		
+			end
 
 			if self.m1894 then --Pawcio's Marlin 1894
 				self.m1894.recategorize = {"light_snp"}
 				self.m1894.damage_type = "sniper"
 				self.m1894.always_play_anims = true
-				self.m1894.tactical_reload = 1						
+				self.m1894.tactical_reload = 1
 				self.m1894.has_description = true
 				self.m1894.desc_id = "bm_ap_weapon_sc_desc"
 				self.m1894.AMMO_MAX = 20
@@ -19954,7 +19954,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 				self.cs5.armor_piercing_chance = 1
 				self.cs5.timers = deep_clone(self.msr.timers)
 			end
-			
+
 			if self.arisaka38 then
 				self.arisaka38.categories = {
 					"snp"
@@ -20069,7 +20069,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 				self.as24.weapon_movement_penalty = 0.8
 			end
 
-			if self.rhino then 
+			if self.rhino then
 				self.rhino.recategorize = {"heavy_pis", "handcannon"}
 				self.rhino.has_description = true
 				self.rhino.desc_id = "bm_ap_armor_50_weapon_sc_desc"
@@ -20111,7 +20111,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 				self.rhino.timers = deep_clone(self.chinchilla.timers)
 			end
 
-			if self.sw27 then 
+			if self.sw27 then
 				self.sw27.recategorize = {"heavy_pis", "handcannon"}
 				self.sw27.has_description = true
 				self.sw27.desc_id = "bm_ap_armor_50_weapon_sc_desc"
@@ -20153,7 +20153,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 				self.sw27.timers = deep_clone(self.chinchilla.timers)
 			end
 
-			if self.sw642 then 
+			if self.sw642 then
 				self.sw642.recategorize = {"heavy_pis", "handcannon"}
 				self.sw642.has_description = true
 				self.sw642.desc_id = "bm_ap_armor_50_weapon_sc_desc"
@@ -20196,7 +20196,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 				self.sw642.timers = deep_clone(self.chinchilla.timers)
 			end
 
-			if self.x_sw642 then 
+			if self.x_sw642 then
 				self.x_sw642.recategorize = {"heavy_pis", "handcannon"}
 				self.x_sw642.has_description = true
 				self.x_sw642.desc_id = "bm_ap_armor_50_weapon_sc_desc"
@@ -20238,8 +20238,8 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 				self.x_sw642.can_shoot_through_enemy = true
 				self.x_sw642.timers = deep_clone(self.x_chinchilla.timers)
 			end
-			
-			if self.unica6 then 
+
+			if self.unica6 then
 				self.unica6.recategorize = {"heavy_pis", "handcannon"}
 				self.unica6.has_description = true
 				self.unica6.desc_id = "bm_ap_armor_50_weapon_sc_desc"
@@ -20281,7 +20281,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 				self.unica6.timers = deep_clone(self.new_raging_bull.timers)
 			end
 
-			if self.m1895 then 
+			if self.m1895 then
 				self.m1895.recategorize = {"heavy_pis", "handcannon"}
 				self.m1895.has_description = true
 				self.m1895.desc_id = "bm_m1895_sc_desc"
@@ -20344,7 +20344,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 				self.m1895.swap_speed_multiplier = 0.8
 			end
 
-			if self.deckard then 
+			if self.deckard then
 				self.deckard.recategorize = {"heavy_pis", "handcannon"}
 				self.deckard.has_description = true
 				self.deckard.desc_id = "bm_ap_armor_50_weapon_sc_desc"
@@ -20386,7 +20386,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 				self.deckard.timers = deep_clone(self.new_raging_bull.timers)
 				self.deckard.panic_suppression_chance = 0.05
 			end
-			
+
 			if self.einhander then
 				self.einhander.recategorize = { "light_smg" }
 				self.einhander.damage_type = "machine_gun"
@@ -20489,7 +20489,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 				self.m60e4.timers = deep_clone(self.m60.timers)
 				self.m60e4.panic_suppression_chance = 0.05
 			end
-			
+
 			if self.m1919a6 then
 				self.m1919a6.categories = {
 					"lmg",
@@ -20583,7 +20583,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 					start_dist = 1600,
 					end_dist = 5400,
 					min_mult = 0.4166
-				}	
+				}
 				self.ultimax.stats = {
 					damage = 24,
 					spread = 61,
@@ -20644,7 +20644,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 					start_dist = 2000,
 					end_dist = 5000,
 					min_mult = 0.4166
-				}	
+				}
 				self.lsat.stats = {
 					damage = 24,
 					spread = 60,
@@ -20704,7 +20704,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 					start_dist = 2400,
 					end_dist = 7000,
 					min_mult = 0.5
-				}	
+				}
 				self.mg4.stats = {
 					damage = 24,
 					spread = 65,
@@ -20737,7 +20737,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 				self.mg3.damage_type = "machine_gun"
 				self.mg3.nato = true
 				self.mg3.has_description = true
-				self.mg3.desc_id = "bm_mg3_sc_desc"		
+				self.mg3.desc_id = "bm_mg3_sc_desc"
 				self.mg3.sms = sms_preset.lmg_60
 				self.mg3.weapon_movement_penalty = sms_preset.lmg_60
 				self.mg3.CLIP_AMMO_MAX = 50
@@ -20859,10 +20859,10 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 				self.a545.panic_suppression_chance = 0.05
 				self.a545.timers = deep_clone(self.galil.timers)
 			end
-			
+
 			if self.aku94 then
 				self.aku94.warsaw = true
-				self.aku94.recategorize = { "heavy_ar" }	
+				self.aku94.recategorize = { "heavy_ar" }
 				self.aku94.damage_type = "assault_rifle"
 				self.aku94.CLIP_AMMO_MAX = 30
 				self.aku94.tactical_reload = 1
@@ -20907,7 +20907,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 
 			if self.sr3m then
 				self.sr3m.warsaw = true
-				self.sr3m.recategorize = { "dmr_ar" }	
+				self.sr3m.recategorize = { "dmr_ar" }
 				self.sr3m.damage_type = "assault_rifle"
 				self.sr3m.CLIP_AMMO_MAX = 30
 				self.sr3m.tactical_reload = 1
@@ -20986,7 +20986,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 					start_dist = 1800,
 					end_dist = 5500,
 					min_mult = 0.5
-				}	
+				}
 				self.zweihander.stats = {
 					damage = 20,
 					spread = 58,
@@ -21011,8 +21011,8 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 					weapon = {
 						"clip_ammo_increase"
 					}
-				}		
-				self.air16.recategorize = { "wpn_special" }	
+				}
+				self.air16.recategorize = { "wpn_special" }
 				self.air16.damage_type = "sniper"
 				self.air16.has_description = true
 				self.air16.desc_id = "bm_airbow_sc_desc"
@@ -21103,7 +21103,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 				end
 			end
 
-			if self.x_toz66 then 
+			if self.x_toz66 then
 				self.x_toz66.recategorize = { "break_shot" }
 				self.x_toz66.categories = { "akimbo", "shotgun" }
 				self.x_toz66.damage_type = "shotgun"
@@ -21125,7 +21125,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 					last_recoil_mult = 1.25
 				}
 				self.x_toz66.CAN_TOGGLE_FIREMODE = false
-				self.x_toz66.FIRE_MODE = "single"				
+				self.x_toz66.FIRE_MODE = "single"
 				self.x_toz66.AMMO_MAX = 30
 				self.x_toz66.supported = true
 				self.x_toz66.ads_speed = 0.360
@@ -21302,7 +21302,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 
 			if self.rk62 then
 				self.rk62.warsaw = true
-				self.rk62.recategorize = { "heavy_ar" }	
+				self.rk62.recategorize = { "heavy_ar" }
 				self.rk62.damage_type = "assault_rifle"
 				self.rk62.CLIP_AMMO_MAX = 30
 				self.rk62.tactical_reload = 1
@@ -21389,7 +21389,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 					total_ammo_mod = 400,
 					value = 1,
 					reload = 20
-				}	
+				}
 				self.m1912.stats_modifiers = {damage = 1}
 				self.m1912.panic_suppression_chance = 0.05
 				self.m1912.timers = deep_clone(self.m1897.timers)
@@ -21448,7 +21448,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 				self.fnar.stats_modifiers = nil
 				self.fnar.panic_suppression_chance = 0.05
 				self.fnar.timers = deep_clone(self.siltstone.timers)
-			end	
+			end
 
 			if self.mk12 then
 				self.mk12.categories = {
@@ -21509,7 +21509,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 
 			if self.ak12_2014 then
 				self.ak12_2014.warsaw = true
-				self.ak12_2014.recategorize = { "heavy_ar" }	
+				self.ak12_2014.recategorize = { "heavy_ar" }
 				self.ak12_2014.damage_type = "assault_rifle"
 				self.ak12_2014.CLIP_AMMO_MAX = 30
 				self.ak12_2014.tactical_reload = 1
@@ -21519,7 +21519,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 					rof_mult = 1.6666,
 					recoil_mult = 0.75,
 					last_recoil_mult = 1.05
-				}		
+				}
 				self.ak12_2014.ADAPTIVE_BURST_SIZE = false
 				self.ak12_2014.fire_mode_data.fire_rate = 0.0923076923076923
 				self.ak12_2014.auto.fire_rate = 0.0923076923076923
@@ -21566,23 +21566,14 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 				self.triad.CLIP_AMMO_MAX = 6
 				self.triad.AMMO_MAX = 60
 				self.triad.fire_mode_data.fire_rate = 0.2
-				self.triad.fire_mode_data.volley = {}
-				self.triad.fire_mode_data.volley.spread_mul = 1.25
-				self.triad.fire_mode_data.volley.damage_mul = 1
-				self.triad.fire_mode_data.volley.ammo_usage = 3
-				self.triad.fire_mode_data.volley.rays = 3
-				self.triad.fire_mode_data.volley.can_shoot_through_wall = true
-				self.triad.fire_mode_data.volley.can_shoot_through_shield = true
-				self.triad.fire_mode_data.volley.can_shoot_through_enemy = true
-				self.triad.fire_mode_data.volley.can_shoot_through_enemy_unlim = true
-				self.triad.fire_mode_data.volley.armor_piercing_chance = 1
-				self.triad.fire_mode_data.volley.muzzleflash = "effects/payday2/particles/weapons/50cal_auto_fps"
-				self.triad.fire_mode_data.volley.trail_effect = "effects/particles/weapons/sniper_trail_sc"
-				self.triad.fire_mode_data.toggable = {
-					"volley",
-					"auto"
+				self.triad.BURST_FIRE = {
+					count = 3,
+					delay = 1,
+					rof_mult = 20,
+					recoil_mult = 0,
+					spread_mult = 1.5,
+					last_recoil_mult = 3
 				}
-				self.triad.no_charge_anims = true
 				self.triad.kick = self.stat_info.kick_tables.moderate_kick
 				self.triad.kick_pattern = {
 					{0, self.stat_info.kick_tables.right_kick},
@@ -21593,8 +21584,8 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 				self.triad.ads_speed = 0.200
 				self.triad.weapon_hold = "model3"
 				self.triad.damage_falloff = {
-					start_dist = 1800,
-					end_dist = 4000,
+					start_dist = 1500,
+					end_dist = 5000,
 					min_mult = 0.3333
 				}
 				self.triad.stats = {
@@ -21613,12 +21604,211 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 				}
 				self.triad.stats_modifiers = nil
 				self.triad.panic_suppression_chance = 0.05
-				self.triad.armor_piercing_chance = 0.5
+				self.triad.armor_piercing_chance = 1
 				self.triad.can_shoot_through_enemy = true
 				self.triad.can_shoot_through_enemy_unlim = true
+				self.triad.can_shoot_through_shield = true
+				self.triad.can_shoot_through_wall = true
 				self.triad.timers = deep_clone(self.chinchilla.timers)
 
 				self.x_triad.use_data.selection_index = 5
+			end
+
+			if self.hk45c then
+				self.hk45c.recategorize = { "heavy_pis" }
+				self.hk45c.damage_type = "heavy_pistol"
+				self.hk45c.fire_mode_data.fire_rate = 0.1176470588
+				self.hk45c.CLIP_AMMO_MAX = 10
+				self.hk45c.AMMO_MAX = 40
+				self.hk45c.kick = self.stat_info.kick_tables.right_recoil
+				self.hk45c.kick_pattern = {
+					{0, self.stat_info.kick_tables.vertical_kick},
+					{3, self.stat_info.kick_tables.right_kick},
+					{6, self.stat_info.kick_tables.right_recoil}
+				}
+				self.hk45c.supported = true
+				self.hk45c.ads_speed = 0.180
+				self.hk45c.damage_falloff = {
+					start_dist = 1000,
+					end_dist = 3200,
+					min_mult = 0.2
+				}
+				self.hk45c.stats = {
+					damage = 45,
+					spread = 53,
+					recoil = 75,
+					spread_moving = 5,
+					zoom = 1,
+					concealment = 29,
+					suppression = 9,
+					alert_size = 2,
+					extra_ammo = 101,
+					total_ammo_mod = 400,
+					value = 1,
+					reload = 20
+				}
+				self.hk45c.stats_modifiers = nil
+				self.hk45c.reload_speed_multiplier = 1.05
+				self.hk45c.panic_suppression_chance = 0.05
+				self.hk45c.timers = deep_clone(self.packrat.timers)
+			end
+
+			if self.x_hk45c then
+				self.x_hk45c.recategorize = { "heavy_pis" }
+				self.x_hk45c.damage_type = "heavy_pistol"
+				self.x_hk45c.fire_mode_data.fire_rate =  0.1176470588
+				self.x_hk45c.BURST_FIRE = {
+					count = 2,
+					delay = 0.15,
+					rof_mult = 4,
+					recoil_mult = 0.25,
+					last_recoil_mult = 1.05,
+				}
+				self.x_hk45c.AMMO_MAX = 80
+				self.x_hk45c.CLIP_AMMO_MAX = 20
+				self.x_hk45c.tactical_reload = 2
+				self.x_hk45c.lock_slide = true
+				self.x_hk45c.kick = self.stat_info.kick_tables.right_recoil
+				self.hk45c.kick_pattern = {
+					{0, self.stat_info.kick_tables.vertical_kick},
+					{3, self.stat_info.kick_tables.right_kick},
+					{6, self.stat_info.kick_tables.right_recoil}
+				}
+				self.x_hk45c.supported = true
+				self.x_hk45c.ads_speed = 0.180
+				self.x_hk45c.damage_falloff = {
+					start_dist = 1000,
+					end_dist = 3200,
+					min_mult = 0.2
+				}
+				self.x_hk45c.stats = {
+					damage = 45,
+					spread = 53,
+					recoil = 75,
+					spread_moving = 5,
+					zoom = 1,
+					concealment = 29,
+					suppression = 9,
+					alert_size = 2,
+					extra_ammo = 101,
+					total_ammo_mod = 400,
+					value = 1,
+					reload = 20
+				}
+				self.x_hk45c.stats_modifiers = nil
+				self.x_hk45c.panic_suppression_chance = 0.05
+				self.x_hk45c.timers = deep_clone(self.x_b92fs.timers)
+			end
+
+			if self.rpd then
+				self.rpd.categories = {
+					"lmg",
+					"smg"
+				}
+				self.rpd.recategorize = { "light_mg" }
+				self.rpd.damage_type = "machine_gun"
+				self.rpd.sms = sms_preset.lmg_60
+				self.rpd.weapon_movement_penalty = sms_preset.lmg_60
+				self.rpd.CLIP_AMMO_MAX = 100
+				self.rpd.AMMO_MAX = 240
+				self.rpd.FIRE_MODE = "auto"
+				self.rpd.fire_mode_data.fire_rate = 0.0923076923
+				self.rpd.CAN_TOGGLE_FIREMODE = false
+				self.rpd.BURST_FIRE = false
+				self.rpd.kick = {}
+				self.rpd.kick = self.stat_info.kick_tables.random_recoil
+				self.rpd.kick_pattern = {
+					{0, self.stat_info.kick_tables.right_kick},
+					{3, self.stat_info.kick_tables.random_recoil},
+					{11, self.stat_info.kick_tables.right_kick},
+					{17, self.stat_info.kick_tables.random_recoil},
+					{28, self.stat_info.kick_tables.right_recoil}
+				}
+				self.rpd.muzzleflash = "effects/payday2/particles/weapons/big_762_auto_fps"
+				self.rpd.supported = true
+				self.rpd.ads_speed = 0.460
+				self.rpd.damage_falloff = {
+					start_dist = 2100,
+					end_dist = 5000,
+					min_mult = 0.6
+				}
+				self.rpd.stats = {
+					damage = 30,
+					spread = 65,
+					recoil = 69,
+					spread_moving = 5,
+					zoom = 1,
+					concealment = 15,
+					suppression = 7,
+					alert_size = 2,
+					extra_ammo = 101,
+					total_ammo_mod = 400,
+					value = 9,
+					reload = 20
+				}
+				self.rpd.stats_modifiers = nil
+				self.rpd.panic_suppression_chance = 0.05
+				self.rpd.can_shoot_through_enemy = false
+				self.rpd.can_shoot_through_wall = false
+				self.rpd.can_shoot_through_shield = false
+				self.rpd.sounds.spin_start = "wp_m249_lever_release"
+				self.rpd.spin_up_shoot = true
+				self.rpd.spin_up_t = 0.09
+				self.rpd.spin_down_t = 0.00000001
+				self.rpd.timers = deep_clone(self.par.timers)
+			end
+
+			if self.cbjms then
+				self.cbjms.use_data.selection_index = 2
+				self.cbjms.categories = {
+					"smg",
+					"pdw"
+				}
+				self.cbjms.recategorize = { "light_smg" }
+				self.cbjms.damage_type = "machine_gun"
+				self.cbjms.has_description = true
+				self.cbjms.desc_id = "bm_ap_armor_75_weapon_sc_desc"
+				self.cbjms.fire_mode_data.fire_rate = 0.08571428
+				self.cbjms.CAN_TOGGLE_FIREMODE = true
+				self.cbjms.tactical_reload = 1
+				self.cbjms.CLIP_AMMO_MAX = 30
+				self.cbjms.AMMO_MAX = 180
+				self.cbjms.kick = self.stat_info.kick_tables.even_recoil
+				self.cbjms.kick_pattern = {
+					{0, self.stat_info.kick_tables.even_recoil},
+					{3, self.stat_info.kick_tables.moderate_right_kick},
+					{9, self.stat_info.kick_tables.moderate_kick},
+					{14, self.stat_info.kick_tables.moderate_right_kick}
+				}
+				self.cbjms.supported = true
+				self.cbjms.ads_speed = 0.220
+				self.cbjms.damage_falloff = {
+					start_dist = 600,
+					end_dist = 3500,
+					min_mult = 0.3
+				}
+				self.cbjms.stats = {
+					damage = 20,
+					spread = 65,
+					recoil = 83,
+					spread_moving = 8,
+					zoom = 1,
+					concealment = 28,
+					suppression = 11,
+					alert_size = 2,
+					extra_ammo = 101,
+					total_ammo_mod = 400,
+					value = 1,
+					reload = 20
+				}
+				self.cbjms.armor_piercing_chance = 0.75
+				self.cbjms.can_shoot_through_enemy = false
+				self.cbjms.can_shoot_through_shield = false
+				self.cbjms.can_shoot_through_wall = false
+				self.cbjms.hs_mult = 1.2
+				self.cbjms.stats_modifiers = nil
+				self.cbjms.panic_suppression_chance = 0.05
+				self.cbjms.timers = deep_clone(self.mp9.timers)
 			end
 
 			--Pawcio's GTAV Pack
@@ -21641,7 +21831,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 						start_dist = 5000,
 						end_dist = 9000,
 						min_mult = 0.5
-					}	
+					}
 					self.duskrifle.stats = {
 						damage = 120,
 						spread = 100,
@@ -21684,7 +21874,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 						start_dist = 3000,
 						end_dist = 7500,
 						min_mult = 0.3333
-					}	
+					}
 					self.duskmg.stats = {
 						damage = 30,
 						spread = 77,
@@ -21773,7 +21963,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 					self.riviter.turret_instakill = true
 					self.riviter.panic_suppression_chance = 0.05
 				end
-		
+
 		--[[     MIRA'S MODS     ]]--
 			if self.rusglock then
 				self.rusglock.categories = {"pistol"}
@@ -21934,7 +22124,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 				self.tommy.fire_mode_data.fire_rate = 0.085714285
 				self.tommy.AMMO_MAX = 120
 				self.tommy.CLIP_AMMO_MAX = 20
-				self.tommy.BURST_FIRE = false									
+				self.tommy.BURST_FIRE = false
 				self.tommy.kick = self.stat_info.kick_tables.even_recoil
 				self.tommy.kick_pattern = {
 					{0, self.stat_info.kick_tables.even_recoil},
@@ -21988,7 +22178,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 					recoil_mult = 0.85,
 					last_recoil_mult = 1.05
 				}
-				self.smg45.ADAPTIVE_BURST_SIZE = false											
+				self.smg45.ADAPTIVE_BURST_SIZE = false
 				self.smg45.kick = self.stat_info.kick_tables.moderate_left_kick
 				self.smg45.kick_pattern = {
 					{0, self.stat_info.kick_tables.even_recoil},
@@ -22038,7 +22228,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 				self.fang45.AMMO_MAX = 120
 				self.fang45.CLIP_AMMO_MAX = 40
 				self.fang45.BURST_FIRE = false
-				self.fang45.ADAPTIVE_BURST_SIZE = false											
+				self.fang45.ADAPTIVE_BURST_SIZE = false
 				self.fang45.kick = self.stat_info.kick_tables.even_recoil
 				self.fang45.kick_pattern = {
 					{0, self.stat_info.kick_tables.even_recoil},
@@ -22080,7 +22270,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 				self.fang45.sounds.stop_fire = "mp5_stop"
 				self.fang45.timers = deep_clone(self.new_m4.timers)
 			end
-			
+
 			if self.troglodyte then --Leon and Mira's AWM-F
 				self.troglodyte.recategorize = { "heavy_snp" }
 				self.troglodyte.use_data.selection_index = 2
@@ -22125,6 +22315,51 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 				self.troglodyte.timers.reload_not_empty = 2.55
 				self.troglodyte.timers.reload_exit_empty = 0.7
 				self.troglodyte.timers.reload_exit_not_empty = 0.75
+			end
+
+			if self.dvl10 then
+				self.dvl10.categories = {
+					"snp"
+				}
+				self.dvl10.recategorize = { "light_snp" }
+				self.dvl10.damage_type = "sniper"
+				self.dvl10.always_play_anims = true
+				self.dvl10.has_description = true
+				self.dvl10.desc_id = "bm_ap_weapon_sc_desc"
+				self.dvl10.upgrade_blocks = nil
+				self.dvl10.CLIP_AMMO_MAX = 10
+				self.dvl10.AMMO_MAX = 40
+				self.dvl10.tactical_reload = 1
+				self.dvl10.fire_mode_data.fire_rate = 1.09090909
+				self.dvl10.fire_rate_multiplier = 1.181818181818
+				self.dvl10.kick = self.stat_info.kick_tables.vertical_kick
+				self.dvl10.muzzleflash = "effects/payday2/particles/weapons/awp_muzzle"
+				self.dvl10.supported = true
+				self.dvl10.ads_speed = 0.360
+				self.dvl10.damage_falloff = {
+					start_dist = 3800,
+					end_dist = 7500,
+					min_mult = 0.5
+				}
+				self.dvl10.stats = {
+					damage = 90,
+					spread = 95,
+					recoil = 59,
+					spread_moving = 8,
+					zoom = 1,
+					concealment = 24,
+					suppression = 6,
+					alert_size = 2,
+					extra_ammo = 101,
+					total_ammo_mod = 400,
+					value = 9,
+					reload = 20
+				}
+				self.dvl10.stats_modifiers = nil
+				self.dvl10.panic_suppression_chance = 0.05
+				self.dvl10.reload_speed_multiplier = 0.9
+				self.dvl10.armor_piercing_chance = 1
+				self.dvl10.timers = deep_clone(self.msr.timers)
 			end
 
 			if self.dokkasho then
@@ -22362,7 +22597,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 
 			if self.fakedefy then
 				self.fakedefy.warsaw = true
-				self.fakedefy.recategorize = { "heavy_ar" }	
+				self.fakedefy.recategorize = { "heavy_ar" }
 				self.fakedefy.damage_type = "assault_rifle"
 				self.fakedefy.CLIP_AMMO_MAX = 30
 				self.fakedefy.tactical_reload = 1
@@ -22433,7 +22668,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 					start_dist = 1800,
 					end_dist = 5500,
 					min_mult = 0.4
-				}	
+				}
 				self.lvoac.stats = {
 					damage = 30,
 					spread = 72,
@@ -22469,12 +22704,12 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 				self.fsbcustom.use_data.selection_index = 1
 				self.fsbcustom.warsaw = true
 				self.fsbcustom.is_bullpup = true
-				self.fsbcustom.has_description = false						
-				self.fsbcustom.tactical_reload = 1	
+				self.fsbcustom.has_description = false
+				self.fsbcustom.tactical_reload = 1
 				self.fsbcustom.CLIP_AMMO_MAX = 30
 				self.fsbcustom.AMMO_MAX = 60
 				self.fsbcustom.fire_mode_data.fire_rate = 0.0923076923
-				self.fsbcustom.kick = self.stat_info.kick_tables.right_kick	
+				self.fsbcustom.kick = self.stat_info.kick_tables.right_kick
 				self.fsbcustom.kick_pattern = {
 					{0, self.stat_info.kick_tables.vertical_kick},
 					{6, self.stat_info.kick_tables.right_kick},
@@ -22482,7 +22717,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 					{10, self.stat_info.kick_tables.pattern_l1},
 					{12, self.stat_info.kick_tables.vertical_kick},
 					{18, self.stat_info.kick_tables.moderate_left_kick}
-				}	
+				}
 				self.fsbcustom.supported = true
 				self.fsbcustom.ads_speed = 0.240
 				self.fsbcustom.damage_falloff = {
@@ -22644,7 +22879,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 				self.vp70.sounds.enter_steelsight = "pistol_steel_sight_enter"
 				self.vp70.sounds.leave_steelsight = "pistol_steel_sight_exit"
 				self.vp70.timers = deep_clone(self.ppk.timers)
-				
+
 				self.x_vp70.recategorize = {"light_pis"}
 				self.x_vp70.damage_type = "pistol"
 				self.x_vp70.lock_slide = true
@@ -22702,7 +22937,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 				self.kurisumasu.recategorize = { "light_ar" }
 				self.kurisumasu.damage_type = "assault_rifle"
 				self.kurisumasu.tactical_reload = 1
-				self.kurisumasu.nato = true			
+				self.kurisumasu.nato = true
 				self.kurisumasu.BURST_FIRE = false
 				self.kurisumasu.ADAPTIVE_BURST_SIZE = false
 				self.kurisumasu.CLIP_AMMO_MAX = 30
@@ -22793,7 +23028,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 				self.enfieldl22.damage_type = "assault_rifle"
 				self.enfieldl22.fire_mode_data.fire_rate = 0.08
 				self.enfieldl22.CLIP_AMMO_MAX = 30
-				self.enfieldl22.AMMO_MAX = 75				
+				self.enfieldl22.AMMO_MAX = 75
 				self.enfieldl22.kick = self.stat_info.kick_tables.moderate_kick
 				self.enfieldl22.kick_pattern = {
 					{0, self.stat_info.kick_tables.vertical_kick},
@@ -23088,7 +23323,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 					{10, self.stat_info.kick_tables.right_recoil}
 				}
 				self.thorhammer.muzzleflash = "effects/payday2/particles/weapons/big_51b_auto_fps" --"effects/particles/shotgun/shotgun_gen"
-				self.thorhammer.FIRE_MODE = "single"				
+				self.thorhammer.FIRE_MODE = "single"
 				self.thorhammer.CAN_TOGGLE_FIREMODE = false
 				self.thorhammer.rays = 8
 				self.thorhammer.supported = true
@@ -23318,7 +23553,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 			end
 
 			if self.madsen_lar then
-				self.madsen_lar.categories = { 
+				self.madsen_lar.categories = {
 					"assault_rifle",
 					"dmr_h",
 				}
@@ -23340,7 +23575,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 					{7, self.stat_info.kick_tables.moderate_kick},
 					{10, self.stat_info.kick_tables.moderate_left_kick},
 					{16, self.stat_info.kick_tables.moderate_kick}
-				}		
+				}
 				self.madsen_lar.supported = true
 				self.madsen_lar.ads_speed = 0.380
 				self.madsen_lar.damage_falloff = {
@@ -23373,7 +23608,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 			end
 
 			if self.tti_2011 then --TTI 1911's
-				self.tti_2011.recategorize = { "light_pis" }		
+				self.tti_2011.recategorize = { "light_pis" }
 				self.tti_2011.damage_type = "light_pistol"
 				self.tti_2011.kick = self.stat_info.kick_tables.vertical_kick
 				self.tti_2011.kick_pattern = {
@@ -23422,7 +23657,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 			end
 
 			if self.tti_viper then
-				self.tti_viper.recategorize = { "light_pis" }		
+				self.tti_viper.recategorize = { "light_pis" }
 				self.tti_viper.damage_type = "light_pistol"
 				self.tti_viper.kick = self.stat_info.kick_tables.vertical_kick
 				self.tti_viper.kick_pattern = {
@@ -23473,7 +23708,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 			end
 
 			if self.papa320 then --RJC9000 and PlayBONK's MW2019 P320
-				self.papa320.recategorize = { "light_pis" }		
+				self.papa320.recategorize = { "light_pis" }
 				self.papa320.damage_type = "light_pistol"
 				self.papa320.kick = self.stat_info.kick_tables.vertical_kick
 				self.papa320.kick_pattern = {
@@ -23522,7 +23757,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 				self.papa320.panic_suppression_chance = 0.05
 			end
 			if self.x_papa320 then
-				self.x_papa320.recategorize = { "light_pis" }		
+				self.x_papa320.recategorize = { "light_pis" }
 				self.x_papa320.damage_type = "light_pistol"
 				self.x_papa320.kick = self.stat_info.kick_tables.vertical_kick
 				self.x_papa320.kick_pattern = {
@@ -23571,7 +23806,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 
 			if self.m6d then --RJC9000 and Offyerrocker's M6D
 				table.insert(self.m6d.categories, "no_shake")
-				self.m6d.recategorize = { "heavy_pis", "handcannon" }		
+				self.m6d.recategorize = { "heavy_pis", "handcannon" }
 				self.m6d.damage_type = "handcannon"
 				self.m6d.has_description = true
 				self.m6d.kick = self.stat_info.kick_tables.vertical_kick
@@ -23618,7 +23853,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 
 			if self.m7caseless then --RJC9000, PlayBONK, and Offyerocker's M7 SMG
 				table.insert(self.m7caseless.categories, "no_shake")
-				self.m7caseless.recategorize = { "light_smg" }		
+				self.m7caseless.recategorize = { "light_smg" }
 				self.m7caseless.damage_type = "machine_gun"
 				self.m7caseless.has_description = true
 				self.m7caseless.kick = self.stat_info.kick_tables.vertical_kick
@@ -23662,7 +23897,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 
 			if self.x_m7caseless then
 				table.insert(self.x_m7caseless.categories, "no_shake")
-				self.x_m7caseless.recategorize = { "light_smg" }		
+				self.x_m7caseless.recategorize = { "light_smg" }
 				self.x_m7caseless.damage_type = "machine_gun"
 				self.x_m7caseless.has_description = true
 				self.x_m7caseless.kick = self.stat_info.kick_tables.vertical_kick
@@ -23715,8 +23950,8 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 				self.alpha57_prim.categories = {
 					"smg",
 					"pdw"
-				}	
-				self.alpha57_prim.recategorize = { "light_smg" }		
+				}
+				self.alpha57_prim.recategorize = { "light_smg" }
 				self.alpha57_prim.damage_type = "machine_gun"
 				self.alpha57_prim.has_description = true
 				self.alpha57_prim.muzzleflash = "_dmc/effects/heavy_muzzle"
@@ -23806,7 +24041,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 					start_dist = 3600,
 					end_dist = 5300,
 					min_mult = 0.3
-				}	
+				}
 				self.stango44.stats = {
 					damage = 30,
 					spread = 81,
@@ -23856,7 +24091,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 					start_dist = 2400,
 					end_dist = 5800,
 					min_mult = 0.5
-				}	
+				}
 				self.acr_2012.stats = {
 					damage = 24,
 					spread = 83,
@@ -23911,7 +24146,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 					start_dist = 4000,
 					end_dist = 4001,
 					min_mult = 0.5
-				}	
+				}
 				self.nova4.stats = {
 					damage = 24,
 					spread = 86,
@@ -23962,7 +24197,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 					start_dist = 1700,
 					end_dist = 6000,
 					min_mult = 0.4
-				}	
+				}
 				self.m4_usasoc.stats = {
 					damage = 30,
 					spread = 81,
@@ -24174,7 +24409,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 					start_dist = 2500,
 					end_dist = 7000,
 					min_mult = 0.4
-				}	
+				}
 				self.t9british.stats = {
 					damage = 45,
 					spread = 86,
@@ -24239,7 +24474,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 					start_dist = 2200,
 					end_dist = 7000,
 					min_mult = 0.3333
-				}	
+				}
 				self.t9fastburst.stats = {
 					damage = 30,
 					spread = 83,
@@ -24419,9 +24654,9 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 					recoil_mult = 0.35,
 					last_recoil_mult = 1.1
 				}
-				self.rc_auto9.ADAPTIVE_BURST_SIZE = false		
+				self.rc_auto9.ADAPTIVE_BURST_SIZE = false
 				self.rc_auto9.CAN_TOGGLE_FIREMODE = false
-				self.rc_auto9.FIRE_MODE = "auto"	
+				self.rc_auto9.FIRE_MODE = "auto"
 				self.rc_auto9.fire_mode_data.fire_rate = 0.085714
 				self.rc_auto9.AMMO_MAX = 120
 				self.rc_auto9.CLIP_AMMO_MAX = 50
@@ -24528,7 +24763,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 
 			if self.cp2077_guts then
 				table.insert(self.cp2077_guts.categories, "shotgun_smasher")
-				self.cp2077_guts.recategorize = { "break_shot" }	
+				self.cp2077_guts.recategorize = { "break_shot" }
 				self.cp2077_guts.damage_type = "shotgun_heavy"
 				self.cp2077_guts.damage_type_single_ray = "anti_materiel"
 				self.cp2077_guts.desc_id = "bm_w_rebecca_desc"
@@ -24539,7 +24774,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 				self.cp2077_guts.kick = self.stat_info.kick_tables.vertical_kick
 				self.cp2077_guts.CLIP_AMMO_MAX = 6
 				self.cp2077_guts.AMMO_MAX = 18
-				self.cp2077_guts.CAN_TOGGLE_FIREMODE = false							
+				self.cp2077_guts.CAN_TOGGLE_FIREMODE = false
 				self.cp2077_guts.BURST_FIRE = false
 				self.cp2077_guts.fire_mode_data.fire_rate = 1
 				self.cp2077_guts.fire_rate_multiplier = 1.25
@@ -24579,7 +24814,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 			end
 
 			if self.tti_dracarys then
-				self.tti_dracarys.recategorize = { "light_shot" }	
+				self.tti_dracarys.recategorize = { "light_shot" }
 				self.tti_dracarys.damage_type = "shotgun"
 				self.tti_dracarys.damage_type_single_ray = "sniper"
 				self.tti_dracarys.muzzleflash = "effects/payday2/particles/weapons/big_51b_auto_fps" --"effects/particles/shotgun/shotgun_gen"
@@ -24595,7 +24830,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 				self.tti_dracarys.tactical_reload = 1
 				self.tti_dracarys.CLIP_AMMO_MAX = 10
 				self.tti_dracarys.AMMO_MAX = 60
-				self.tti_dracarys.CAN_TOGGLE_FIREMODE = true							
+				self.tti_dracarys.CAN_TOGGLE_FIREMODE = true
 				self.tti_dracarys.BURST_FIRE = false
 				self.tti_dracarys.fire_mode_data.fire_rate = 0.1
 				self.tti_dracarys.lock_slide = true
@@ -24754,7 +24989,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 					start_dist = 2200,
 					end_dist = 5500,
 					min_mult = 0.6
-				}	
+				}
 				self.malima.stats = {
 					damage = 30,
 					spread = 81,
@@ -24807,7 +25042,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 					start_dist = 1600,
 					end_dist = 5000,
 					min_mult = 0.6
-				}	
+				}
 				self.hk_g56.stats = {
 					damage = 30,
 					spread = 73,
@@ -24899,7 +25134,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 					{8, self.stat_info.kick_tables.right_recoil}
 				}
 				self.uncle12.muzzleflash = "effects/payday2/particles/weapons/big_51b_auto_fps" --"effects/particles/shotgun/shotgun_gen"
-				self.uncle12.FIRE_MODE = "auto"				
+				self.uncle12.FIRE_MODE = "auto"
 				self.uncle12.CAN_TOGGLE_FIREMODE = true
 				self.uncle12.rays = 8
 				self.uncle12.supported = true
@@ -24986,7 +25221,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 			end
 
 			if self.rmary2 then --BO6 Goblin Mk2 (leaving this in its pre-rework state prior to the BO6 FAL/TR2 effectively taking its old stats while it got new stats to become the spammy semi-auto)
-				self.rmary2.categories = { 
+				self.rmary2.categories = {
 					"assault_rifle",
 					"dmr_h"
 				}
@@ -25000,7 +25235,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 				self.rmary2.CLIP_AMMO_MAX = 20
 				self.rmary2.AMMO_MAX = 60
 				self.rmary2.fire_mode_data.fire_rate = 0.129870129
-				self.rmary2.FIRE_MODE = "single"		
+				self.rmary2.FIRE_MODE = "single"
 				self.rmary2.CAN_TOGGLE_FIREMODE = false
 				self.rmary2.BURST_FIRE = false
 				self.rmary2.kick = deep_clone(self.stat_info.kick_tables.vertical_kick)
@@ -25011,7 +25246,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 					{6, self.stat_info.kick_tables.left_recoil},
 					{9, self.stat_info.kick_tables.moderate_left_kick},
 					{12, self.stat_info.kick_tables.vertical_kick}
-				}			
+				}
 				self.rmary2.supported = true
 				self.rmary2.ads_speed = 0.260
 				self.rmary2.damage_falloff = {
@@ -25044,7 +25279,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 				self.rmary2.timers.reload_exit_not_empty = 0.6
 			end
 
-			if self.pkilo then 
+			if self.pkilo then
 				self.pkilo.categories = {
 					"lmg",
 					"smg",
@@ -25277,7 +25512,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 					self.akilo_2022.tactical_reload = 1
 					self.akilo_2022.AMMO_MAX = 120
 					self.akilo_2022.fire_mode_data.fire_rate = 0.1
-					self.akilo_2022.kick = self.stat_info.kick_tables.moderate_right_kick	
+					self.akilo_2022.kick = self.stat_info.kick_tables.moderate_right_kick
 					self.akilo_2022.supported = true
 					self.akilo_2022.ads_speed = 0.280
 					self.akilo_2022.damage_falloff = {
@@ -25325,7 +25560,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 						{15, self.stat_info.kick_tables.horizontal_right_recoil},
 						{17, self.stat_info.kick_tables.pattern_r5},
 						{18, self.stat_info.kick_tables.horizontal_right_recoil}
-					}	
+					}
 					self.akilo105_2022.supported = true
 					self.akilo105_2022.ads_speed = 0.260
 					self.akilo105_2022.damage_falloff = {
@@ -25356,8 +25591,8 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 			if self.mcbravo then --RJC9000 and PlayBONK's Honey Badger
 				self.mcbravo.recategorize = { "heavy_ar" }
 				self.mcbravo.has_description = true
-				self.mcbravo.desc_id = "bm_w_mcbravo_desc"	
-				self.mcbravo.damage_type = "assault_rifle"	
+				self.mcbravo.desc_id = "bm_w_mcbravo_desc"
+				self.mcbravo.damage_type = "assault_rifle"
 				self.mcbravo.fire_mode_data.fire_rate = 0.075
 				self.mcbravo.tactical_reload = 1
 				self.mcbravo.AMMO_MAX = 120
@@ -25395,7 +25630,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 			end
 
 			if self.mcx_spear then --RJC9000 and PlayBONK's SIG MCX Spear
-				self.mcx_spear.categories = { 
+				self.mcx_spear.categories = {
 					"assault_rifle",
 					"dmr_l"
 				}
@@ -25426,7 +25661,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 					start_dist = 2200,
 					end_dist = 6500,
 					min_mult = 0.53333
-				}	
+				}
 				self.mcx_spear.stats = {
 					damage = 45,
 					spread = 83,
@@ -25485,7 +25720,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 					start_dist = 2300,
 					end_dist = 6600,
 					min_mult = 0.66667
-				}	
+				}
 				self.sig_xm250.stats = {
 					damage = 30,
 					spread = 67,
@@ -25517,7 +25752,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 			end
 
 			if self.ngsierra then --RJC9000, PlayBONK and Captain Hamerica's MW2022 RM77
-				self.ngsierra.categories = { 
+				self.ngsierra.categories = {
 					"assault_rifle",
 					"dmr_l"
 				}
@@ -25545,7 +25780,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 					start_dist = 2000,
 					end_dist = 5800,
 					min_mult = 0.53333
-				}	
+				}
 				self.ngsierra.stats = {
 					damage = 45,
 					spread = 85,
@@ -25596,7 +25831,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 				self.vecho.FIRE_MODE = "single"
 				self.vecho.fire_mode_data.fire_rate = 0.2803738
 				self.vecho.kick = self.stat_info.kick_tables.vertical_kick
-				self.vecho.kick_pattern = { 
+				self.vecho.kick_pattern = {
 					{0, self.stat_info.kick_tables.vertical_kick},
 					{3, self.stat_info.kick_tables.pattern_r1},
 					{4, self.stat_info.kick_tables.right_kick},
@@ -25635,7 +25870,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 
 			--MW2023 CZ Brens
 			if self.bromeo805 then --MTZ-556
-				self.bromeo805.categories = { 
+				self.bromeo805.categories = {
 					"assault_rifle"
 				}
 				self.bromeo805.recategorize = { "light_ar" }
@@ -25661,7 +25896,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 					start_dist = 2000,
 					end_dist = 5800,
 					min_mult = 0.53333
-				}	
+				}
 				self.bromeo805.stats = {
 					damage = 24,
 					spread = 85,
@@ -25680,7 +25915,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 				self.bromeo805.panic_suppression_chance = 0.05
 			end
 			if self.bromeo2m then --MTZ-762 JAK
-				self.bromeo2m.categories = { 
+				self.bromeo2m.categories = {
 					"assault_rifle"
 				}
 				self.bromeo2m.recategorize = { "heavy_ar" }
@@ -25708,7 +25943,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 					start_dist = 2000,
 					end_dist = 5800,
 					min_mult = 0.53333
-				}	
+				}
 				self.bromeo2m.stats = {
 					damage = 30,
 					spread = 85,
@@ -25727,7 +25962,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 				self.bromeo2m.panic_suppression_chance = 0.05
 			end
 			if self.bromeo2 then --MTZ-762
-				self.bromeo2.categories = { 
+				self.bromeo2.categories = {
 					"assault_rifle",
 					"dmr_l"
 				}
@@ -25753,7 +25988,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 					start_dist = 2000,
 					end_dist = 5800,
 					min_mult = 0.53333
-				}	
+				}
 				self.bromeo2.stats = {
 					damage = 45,
 					spread = 85,
@@ -25772,7 +26007,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 				self.bromeo2.panic_suppression_chance = 0.05
 			end
 			if self.bromeop then --MTZ Interceptor
-				self.bromeop.categories = { 
+				self.bromeop.categories = {
 					"snp",
 					"semi_snp"
 				}
@@ -25798,7 +26033,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 					start_dist = 2200,
 					end_dist = 5300,
 					min_mult = 0.53333
-				}	
+				}
 				self.bromeop.stats = {
 					damage = 30,
 					spread = 85,
@@ -25929,9 +26164,9 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 			end
 
 			if self.owd_m1a then --RJC9000's OTWD M1A
-				self.owd_m1a.categories = { 
+				self.owd_m1a.categories = {
 					"assault_rifle",
-					"dmr_h" 
+					"dmr_h"
 				}
 				self.owd_m1a.recategorize = { "dmr_ar" }
 				self.owd_m1a.damage_type = "sniper"
@@ -25958,7 +26193,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 					start_dist = 3200,
 					end_dist = 7200,
 					min_mult = 0.4
-				}	
+				}
 				self.owd_m1a.stats = {
 					damage = 60,
 					spread = 91,
@@ -25989,8 +26224,8 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 				self.owd_m1a.sounds.stop_fire = "m14_stop"
 			end
 
-			if self.ma40 then 
-				self.ma40.categories = { 
+			if self.ma40 then
+				self.ma40.categories = {
 					"assault_rifle",
 					"no_shake"
 				}
@@ -26019,7 +26254,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 					start_dist = 1200,
 					end_dist = 3400,
 					min_mult = 0.8
-				}	
+				}
 				self.ma40.stats = {
 					damage = 30,
 					spread = 71,
@@ -26044,7 +26279,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 			end
 
 			if self.vk78_commando then --RJC9000 and PlayBONK's Halo Infinite VK78 Commando
-				self.vk78_commando.categories = { 
+				self.vk78_commando.categories = {
 					"assault_rifle",
 					"dmr_h",
 					"no_shake"
@@ -26073,7 +26308,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 					start_dist = 2700,
 					end_dist = 7800,
 					min_mult = 0.4
-				}	
+				}
 				self.vk78_commando.stats = {
 					damage = 60,
 					spread = 81,
@@ -26155,7 +26390,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 				self.br55.AMMO_MAX = 90
 				self.br55.fire_mode_data.fire_rate = 0.171428
 				self.br55.fire_mode_data.burst_cooldown = nil
-				self.br55.FIRE_MODE = "single"		
+				self.br55.FIRE_MODE = "single"
 				self.br55.CAN_TOGGLE_FIREMODE = false
 				self.br55.BURST_COUNT = nil
 				self.br55.burst = nil
@@ -26390,7 +26625,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 				self.zip22.jam_time = 2
 				self.zip22.CLIP_AMMO_MAX = 10
 				self.zip22.AMMO_MAX = 210
-				self.zip22.kick = self.stat_info.kick_tables.vertical_kick	
+				self.zip22.kick = self.stat_info.kick_tables.vertical_kick
 				self.zip22.always_play_anims = true
 				self.zip22.supported = true
 				self.zip22.ads_speed = 0.100
@@ -26483,8 +26718,8 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 				self.m416d.nato = true
 				self.m416d.recategorize = { "light_ar" }
 				self.m416d.damage_type = "assault_rifle"
-				self.m416d.has_description = false						
-				self.m416d.tactical_reload = 1		
+				self.m416d.has_description = false
+				self.m416d.tactical_reload = 1
 				self.m416d.AMMO_MAX = 150
 				self.m416d.fire_mode_data.fire_rate = 0.08571428571
 				self.m416d.kick = self.stat_info.kick_tables.moderate_kick
@@ -26569,18 +26804,18 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 				self.korth_prs.panic_suppression_chance = 0.05
 				self.korth_prs.timers = deep_clone(self.sparrow.timers)
 			end
-		
+
 		--[[     TANGERINE'S MODS     ]]--
 			if self.ar47 then --Tangerine's AR-47
-				self.ar47.recategorize = { "heavy_ar" }	
+				self.ar47.recategorize = { "heavy_ar" }
 				self.ar47.damage_type = "assault_rifle"
 				self.ar47.lock_slide = true
 				self.ar47.sounds.magazine_empty = "wp_rifle_slide_lock"
 				self.ar47.AMMO_MAX = 120
-				self.ar47.tactical_reload = 1		
+				self.ar47.tactical_reload = 1
 				self.ar47.CLIP_AMMO_MAX = 30
 				self.ar47.fire_mode_data.fire_rate = 0.1
-				self.ar47.FIRE_MODE = "auto"		
+				self.ar47.FIRE_MODE = "auto"
 				self.ar47.CAN_TOGGLE_FIREMODE = true
 				self.ar47.BURST_FIRE = false
 				self.ar47.kick = self.stat_info.kick_tables.moderate_right_kick
@@ -26613,7 +26848,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 			end
 
 			if self.omni then --Tangerine's .410 AR
-				self.omni.categories = { 
+				self.omni.categories = {
 					"shotgun",
 					"shotgun_auto"
 				 }
@@ -26623,10 +26858,10 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 				self.omni.rays = 6
 				self.omni.muzzleflash = "effects/payday2/particles/weapons/big_51b_auto_fps" --"effects/particles/shotgun/shotgun_gen"
 				self.omni.AMMO_MAX = 40
-				self.omni.tactical_reload = 1		
+				self.omni.tactical_reload = 1
 				self.omni.CLIP_AMMO_MAX = 10
 				self.omni.fire_mode_data.fire_rate = 0.15
-				self.omni.FIRE_MODE = "auto"		
+				self.omni.FIRE_MODE = "auto"
 				self.omni.CAN_TOGGLE_FIREMODE = true
 				self.omni.BURST_FIRE = false
 				self.omni.kick = self.stat_info.kick_tables.moderate_kick
@@ -26898,7 +27133,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 				}
 				self.polar9.stats = {
 					damage = 24,
-					spread = 57,
+					spread = 61,
 					recoil = 79,
 					spread_moving = 9,
 					zoom = 1,
@@ -26944,7 +27179,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 					}
 					self.x_polar9.stats = {
 						damage = 24,
-						spread = 47,
+						spread = 51,
 						recoil = 69,
 						spread_moving = 9,
 						zoom = 1,
@@ -27003,13 +27238,13 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 				self.baller.timers.reload_exit_empty = 0.5
 				self.baller.timers.reload_exit_not_empty = 0.65
 			end
-		
+
 		--[[     HYLIE'S MODS     ]]--
 
 			if self.m1918 then --RAID WW2 BAR
-				self.m1918.categories = { 
+				self.m1918.categories = {
 					"assault_rifle",
-					"dmr_h" 
+					"dmr_h"
 				}
 				self.m1918.recategorize = { "dmr_ar" }
 				self.m1918.damage_type = "sniper"
@@ -27036,7 +27271,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 					start_dist = 4000,
 					end_dist = 9000,
 					min_mult = 0.5
-				}	
+				}
 				self.m1918.stats = {
 					damage = 60,
 					spread = 71,
@@ -27070,7 +27305,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 				self.modl.recategorize = { "heavy_ar" }
 				self.modl.damage_type = "assault_rifle"
 				self.modl.tactical_reload = 1
-				self.modl.nato = true			
+				self.modl.nato = true
 				self.modl.BURST_FIRE = false
 				self.modl.ADAPTIVE_BURST_SIZE = false
 				self.modl.fire_mode_data.fire_rate = 0.1
@@ -27137,14 +27372,14 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 					{13, self.stat_info.kick_tables.moderate_right_kick},
 					{19, self.stat_info.kick_tables.moderate_left_kick},
 					{22, self.stat_info.kick_tables.moderate_kick}
-				}	
+				}
 				self.grayhound.supported = true
 				self.grayhound.ads_speed = 0.320
 				self.grayhound.damage_falloff = {
 					start_dist = 2800,
 					end_dist = 6500,
 					min_mult = 0.4
-				}	
+				}
 				self.grayhound.stats = {
 					damage = 30,
 					spread = 84,
@@ -27212,7 +27447,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 			end
 
 			if self.riveter then --MW2023 Riveter
-				self.riveter.categories = { 
+				self.riveter.categories = {
 					"shotgun",
 					"shotgun_auto"
 				 }
@@ -27222,10 +27457,10 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 				self.riveter.rays = 6
 				self.riveter.muzzleflash = "effects/payday2/particles/weapons/big_51b_auto_fps" --"effects/particles/shotgun/shotgun_gen"
 				self.riveter.AMMO_MAX = 80
-				self.riveter.tactical_reload = 1		
+				self.riveter.tactical_reload = 1
 				self.riveter.CLIP_AMMO_MAX = 15
 				self.riveter.fire_mode_data.fire_rate = 0.15
-				self.riveter.FIRE_MODE = "auto"		
+				self.riveter.FIRE_MODE = "auto"
 				self.riveter.CAN_TOGGLE_FIREMODE = true
 				self.riveter.BURST_FIRE = false
 				self.riveter.kick = self.stat_info.kick_tables.right_recoil
@@ -27267,7 +27502,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 			end
 
 			if self.soa then --MW2023 SOA Subverter
-				self.soa.categories = { 
+				self.soa.categories = {
 					"assault_rifle",
 					"dmr_l",
 				}
@@ -27335,7 +27570,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 				self.toz81.muzzleflash = "effects/payday2/particles/weapons/big_51b_auto_fps" --"effects/particles/shotgun/shotgun_gen"
 				self.toz81.BURST_FIRE = false
 				self.toz81.CAN_TOGGLE_FIREMODE = false
-				self.toz81.FIRE_MODE = "single"				
+				self.toz81.FIRE_MODE = "single"
 				self.toz81.AMMO_MAX = 20
 				self.toz81.supported = true
 				self.toz81.ads_speed = 0.260
@@ -27387,7 +27622,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 					last_recoil_mult = 1.1,
 				}
 				self.x_toz81.CAN_TOGGLE_FIREMODE = false
-				self.x_toz81.FIRE_MODE = "single"				
+				self.x_toz81.FIRE_MODE = "single"
 				self.x_toz81.AMMO_MAX = 40
 				self.x_toz81.supported = true
 				self.x_toz81.ads_speed = 0.260
@@ -27444,7 +27679,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 					{12, self.stat_info.kick_tables.vertical_kick}
 				}
 				self.bp12.muzzleflash = "effects/payday2/particles/weapons/big_51b_auto_fps" --"effects/particles/shotgun/shotgun_gen"
-				self.bp12.FIRE_MODE = "single"				
+				self.bp12.FIRE_MODE = "single"
 				self.bp12.rays = 8
 				self.bp12.supported = true
 				self.bp12.ads_speed = 0.340
@@ -27495,7 +27730,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 					{22, self.stat_info.kick_tables.right_recoil}
 				}
 				self.or12.muzzleflash = "effects/payday2/particles/weapons/big_51b_auto_fps" --"effects/particles/shotgun/shotgun_gen"
-				self.or12.FIRE_MODE = "single"				
+				self.or12.FIRE_MODE = "single"
 				self.or12.CAN_TOGGLE_FIREMODE = false
 				self.or12.rays = 8
 				self.or12.supported = true
@@ -27584,7 +27819,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 				self.bk500.timers.reload_not_empty = 2.05
 				self.bk500.timers.reload_exit_not_empty = 1.38
 			end
-			
+
 			if self.haymaker then
 				self.haymaker.categories = { "shotgun" }
 				self.haymaker.recategorize = { "light_shot" }
@@ -27603,7 +27838,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 					{12, self.stat_info.kick_tables.even_recoil}
 				}
 				self.haymaker.muzzleflash = "effects/payday2/particles/weapons/big_51b_auto_fps" --"effects/particles/shotgun/shotgun_gen"
-				self.haymaker.FIRE_MODE = "single"				
+				self.haymaker.FIRE_MODE = "single"
 				self.haymaker.CAN_TOGGLE_FIREMODE = false
 				self.haymaker.rays = 8
 				self.haymaker.supported = true
@@ -27683,7 +27918,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 			end
 
 			if self.fik22 then
-				self.fik22.categories = { 
+				self.fik22.categories = {
 					"assault_rifle"
 				}
 				self.fik22.recategorize = {"light_ar"}
@@ -27725,7 +27960,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 			end
 
 			if self.ar2 then
-				self.ar2.categories = { 
+				self.ar2.categories = {
 					"assault_rifle"
 				}
 				self.ar2.recategorize = {"light_ar"}
@@ -27810,7 +28045,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 					start_dist = 2000,
 					end_dist = 7000,
 					min_mult = 0.4166
-				}	
+				}
 				self.mx63.stats = {
 					damage = 24,
 					spread = 65,
@@ -27839,7 +28074,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 			end
 
 			if self.g7 then
-				self.g7.categories = { 
+				self.g7.categories = {
 					"assault_rifle",
 					"dmr_h"
 				}
@@ -27874,7 +28109,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 					reload = 20
 				}
 				self.g7.stats_modifiers = nil
-				self.g7.panic_suppression_chance = 0.05	
+				self.g7.panic_suppression_chance = 0.05
 				self.g7.timers.reload_not_empty = 1.65
 				self.g7.timers.reload_exit_not_empty = 0.58
 				self.g7.timers.reload_empty = 2.35
@@ -27882,7 +28117,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 			end
 
 			if self.ar23 then
-				self.ar23.categories = { 
+				self.ar23.categories = {
 					"assault_rifle",
 					"sweet_liberty"
 				}
@@ -27935,7 +28170,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 			end
 
 			if self.sta52 then
-				self.sta52.categories = { 
+				self.sta52.categories = {
 					"assault_rifle",
 					"sweet_liberty"
 				}
@@ -27982,7 +28217,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 			end
 
 			if self.br14 then
-				self.br14.categories = { 
+				self.br14.categories = {
 					"assault_rifle",
 					"dmr_h",
 					"sweet_liberty"
@@ -28032,7 +28267,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 			end
 
 			if self.reprimand then
-				self.reprimand.categories = { 
+				self.reprimand.categories = {
 					"smg",
 					"sweet_liberty"
 				}
@@ -28087,7 +28322,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 			end
 
 			if self.sta11 then
-				self.sta11.categories = { 
+				self.sta11.categories = {
 					"smg",
 					"sweet_liberty"
 				}
@@ -28135,7 +28370,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 			end
 
 			if self.sickle then
-				self.sickle.categories = { 
+				self.sickle.categories = {
 					"assault_rifle",
 					"battery"
 				}
@@ -28202,7 +28437,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 			end
 
 			if self.r6 then
-				self.r6.categories = { 
+				self.r6.categories = {
 					"snp",
 					"sweet_liberty"
 				}
@@ -28253,7 +28488,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 			end
 
 			if self.bulldog then --valorant gun
-				self.bulldog.categories = { 
+				self.bulldog.categories = {
 					"assault_rifle"
 				}
 				self.bulldog.use_data.selection_index = 2
@@ -28314,7 +28549,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 			end
 
 			if self.holoar then --WE LIKE FORTNITE
-				self.holoar.categories = { 
+				self.holoar.categories = {
 					"assault_rifle"
 				}
 				self.holoar.recategorize = {"light_ar"}
@@ -28354,7 +28589,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 				self.holoar.timers.reload_not_empty = 2.2
 				self.holoar.timers.reload_exit_not_empty = 0.75
 			end
-			
+
 		--[[     SILENT ENFORCER'S MODS     ]]--
 
 			if self.qbz95 then --RJC9000 and PlayBONK's PAYDAY "THE SERVERS ARE DOWN! CAN'T PLAY, IDIOT" 3 QBZ-191
@@ -28588,6 +28823,45 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 				self.toz194.timers.shotgun_reload_exit_empty = 0.7
 			end
 
+			if self.mossberg590 then
+				self.mossberg590.recategorize = { "heavy_shot" }
+				self.mossberg590.damage_type = "shotgun_heavy"
+				self.mossberg590.damage_type_single_ray = "sniper"
+				self.mossberg590.has_description = false
+				self.mossberg590.tactical_reload = 1
+				self.mossberg590.rays = 8
+				self.mossberg590.CLIP_AMMO_MAX = 8
+				self.mossberg590.muzzleflash = "effects/payday2/particles/weapons/big_51b_auto_fps" --"effects/particles/shotgun/shotgun_gen"
+				self.mossberg590.kick = self.stat_info.kick_tables.left_kick
+				self.mossberg590.fire_mode_data.fire_rate = 0.6
+				self.mossberg590.fire_rate_multiplier = 1.08
+				self.mossberg590.AMMO_MAX = 40
+				self.mossberg590.supported = true
+				self.mossberg590.ads_speed = 0.320
+				self.mossberg590.damage_falloff = {
+					start_dist = 800,
+					end_dist = 2800,
+					min_mult = 0.1333
+				}
+				self.mossberg590.stats = {
+					damage = 180,
+					spread = 64,
+					recoil = 41,
+					spread_moving = 6,
+					zoom = 1,
+					concealment = 22,
+					suppression = 7,
+					alert_size = 2,
+					extra_ammo = 101,
+					total_ammo_mod = 400,
+					value = 1,
+					reload = 20
+				}
+				self.mossberg590.stats_modifiers = {damage = 1}
+				self.mossberg590.panic_suppression_chance = 0.05
+				self.mossberg590.timers = deep_clone(self.m1897.timers)
+			end
+
 			if self.welrod then
 				self.welrod.recategorize = {"light_pis"}
 				self.welrod.damage_type = "pistol"
@@ -28755,7 +29029,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 					unequip = 0.001,
 					equip = 0.001
 				}
-			end	
+			end
 			if self.nothing2 then
 				self.nothing2.recategorize = { "wpn_special" }
 				self.nothing2.fire_mode_data.fire_rate = 0.8695652
@@ -28791,8 +29065,8 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 					unequip = 0.001,
 					equip = 0.001
 				}
-			end	
-			
+			end
+
 			if self.mg34 then --Silent Enforcer's MG34
 				self.mg34.recategorize = { "heavy_mg" }
 				self.mg34.categories = {
@@ -28850,7 +29124,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 				self.mg34.reload_speed_multiplier = 1
 				self.mg34.timers.reload_exit_empty = 1.65
 				self.mg34.timers.reload_exit_not_empty = 1.65
-			end	
+			end
 
 			if self.sasha then -- Silent Enforcer's TF2 Minigun
 				self.sasha.recategorize = { "miniguns" }
@@ -28867,7 +29141,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 				self.sasha.kick = self.stat_info.kick_tables.vertical_kick
 				self.sasha.muzzleflash = "effects/payday2/particles/weapons/big_762_auto_fps"
 				self.sasha.supported = true
-				self.sasha.sprintout_anim_time = 0.8 
+				self.sasha.sprintout_anim_time = 0.8
 				self.sasha.ads_speed = 0.400
 				self.sasha.damage_falloff = {
 					ignore_rays = true,
@@ -28910,7 +29184,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 
 		--Predator Pack
 			if self.owlfbullpup then
-				self.owlfbullpup.categories = { 
+				self.owlfbullpup.categories = {
 					"assault_rifle",
 					"dmr_l",
 				}
@@ -28963,7 +29237,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 			end
 
 			if self.plasmaproto then
-				self.plasmaproto.categories = { 
+				self.plasmaproto.categories = {
 					"assault_rifle",
 					"dmr_h",
 				}
@@ -28982,7 +29256,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 					{4, self.stat_info.kick_tables.moderate_right_kick},
 					{10, self.stat_info.kick_tables.vertical_kick},
 					{14, self.stat_info.kick_tables.moderate_right_kick}
-				}	
+				}
 				self.plasmaproto.supported = true
 				self.plasmaproto.ads_speed = 0.400
 				self.plasmaproto.damage_falloff = {
@@ -29049,7 +29323,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 				self.hhpc.timers.reload_exit_not_empty = 0.5
 			end
 
-			if self.predator_spear_crossbow then 
+			if self.predator_spear_crossbow then
 				self.predator_spear_crossbow.use_data.selection_index = 2
 				self.predator_spear_crossbow.upgrade_blocks = {
 					weapon = {
@@ -29191,10 +29465,10 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 					total_ammo_mod = 400,
 					value = 9,
 					reload = 20
-				}		
+				}
 				self.xm214a.stats_modifiers = nil
 				self.xm214a.ads_spool = true
-				self.xm214a.sprintout_anim_time = 0.8 
+				self.xm214a.sprintout_anim_time = 0.8
 				self.xm214a.spin_up_anims = true
 				self.xm214a.spin_up_t = 0.25
 				self.xm214a.spin_down_t = 0.5
@@ -29296,8 +29570,8 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 		end
 
 		if self.amt then --Matthelzor, Gambyt, >:3, and Alcat's Automag .44
-			self.amt.recategorize = { "heavy_pis", "handcannon" }		
-			self.amt.damage_type = "handcannon"			
+			self.amt.recategorize = { "heavy_pis", "handcannon" }
+			self.amt.damage_type = "handcannon"
 			self.amt.tactical_reload = 1
 			self.amt.use_data.selection_index = 2
 			self.amt.has_description = true
@@ -29339,10 +29613,10 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 			self.amt.panic_suppression_chance = 0.05
 			self.amt.reload_speed_multiplier = 1.02
 			self.amt.timers = deep_clone(self.deagle.timers)
-		end	
+		end
 
 		if self.xr2 then --KillerKrayola + Pawcio + splish's BO3 XR-2
-			self.xr2.categories = { 
+			self.xr2.categories = {
 				"assault_rifle",
 				"dmr_l"
 			}
@@ -29402,7 +29676,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 		end
 
 		if self.crysis3_typhoon then
-			self.crysis3_typhoon.categories = { 
+			self.crysis3_typhoon.categories = {
 				"smg",
 				"typh"
 			}
@@ -29473,7 +29747,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 				total_ammo_mod = 400,
 				value = 9,
 				reload = 20
-			}		
+			}
 			self.crysis3_typhoon.recoil_values = {
 				{ 80, 60 },
 				5,
@@ -29554,7 +29828,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 			self.iuhTTIPlus.stats_modifiers = nil
 			self.iuhTTIPlus.panic_suppression_chance = 0.05
 			self.iuhTTIPlus.timers = deep_clone(self.contraband.timers)
-		end	
+		end
 
 		if self.rsass then --youngrich99 and FrenchyAU's Remington RSASS
 			self.rsass.recategorize = { "light_snp" }
@@ -29611,7 +29885,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 		end
 
 		if self.fg42 then --Killerwolf's FG42
-			self.fg42.categories = { 
+			self.fg42.categories = {
 				"assault_rifle",
 				"dmr_h"
 			}
@@ -29759,7 +30033,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 			self.pb.hs_mult = 2.5
 			self.pb.timers = deep_clone(self.lemming.timers)
 		end
-		
+
 		if self.hshdm then
 			self.hshdm.recategorize = {"light_pis"}
 			self.hshdm.damage_type = "pistol"
@@ -29803,7 +30077,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 			self.hshdm.weapon_movement_penalty = 1.08
 			self.hshdm.hs_mult = 3
 			self.hshdm.timers = deep_clone(self.breech.timers)
-		
+
 				self.x_hshdm.recategorize = {"light_pis"}
 				self.x_hshdm.damage_type = "pistol"
 				self.x_hshdm.AMMO_MAX = 120
@@ -29935,7 +30209,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 			self.enfield_no5i.panic_suppression_chance = 0.05
 			self.enfield_no5i.armor_piercing_chance = 1
 			self.enfield_no5i.timers = deep_clone(self.model70.timers)
-			
+
 			self.enfield_no4i.use_data.selection_index = 5
 		end
 
@@ -30124,7 +30398,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 				self.x_cz75b.stats_modifiers = nil
 				self.x_cz75b.panic_suppression_chance = 0.05
 				self.x_cz75b.timers = deep_clone(self.x_b92fs.timers)
-		end	
+		end
 
 
 		if self.abzats then
@@ -30180,7 +30454,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 			self.abzats.always_play_anims = true
 			self.abzats.weapon_movement_penalty = nil
 			self.abzats.sms = nil
-		end	
+		end
 
 		if self.ashot then
 			self.ashot.recategorize = { "break_shot" }
@@ -30238,7 +30512,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 				{7, self.stat_info.kick_tables.moderate_left_kick}
 			}
 			self.spas15.muzzleflash = "effects/payday2/particles/weapons/big_51b_auto_fps" --"effects/particles/shotgun/shotgun_gen"
-			self.spas15.FIRE_MODE = "single"				
+			self.spas15.FIRE_MODE = "single"
 			self.spas15.CAN_TOGGLE_FIREMODE = false
 			self.spas15.rays = 8
 			self.spas15.supported = true
@@ -30267,8 +30541,8 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 			self.spas15.reload_speed_multiplier = 1.1
 			self.spas15.reload_not_empty_speed_multiplier = 1.1
 			self.spas15.timers = deep_clone(self.g36.timers)
-		end	
-		
+		end
+
 		if self.k5 then
 			self.k5.recategorize = { "light_pis" }
 			self.k5.damage_type = "light_pistol"
@@ -30314,7 +30588,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 			self.k2.recategorize = { "light_ar" }
 			self.k2.damage_type = "assault_rifle"
 			self.k2.tactical_reload = 1
-			self.k2.nato = true			
+			self.k2.nato = true
 			self.k2.BURST_FIRE = {
 				count = 3,
 				delay = 0.18,
@@ -30360,7 +30634,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 		end
 
 		if self.mdr_308 then --H.H. Hartmann's MDRX
-			self.mdr_308.categories = { 
+			self.mdr_308.categories = {
 				"assault_rifle",
 				"dmr_l",
 			}
@@ -30413,7 +30687,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 		end
 
 		if self.mdr_308_underbarrel then
-			self.mdr_308_underbarrel.categories = { 
+			self.mdr_308_underbarrel.categories = {
 				"rocket_launcher",
 				"grenade_launcher"
 			}
@@ -30489,8 +30763,8 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 			self.degfifty.always_play_anims = true
 			self.degfifty.can_shoot_through_enemy = true
 			self.degfifty.can_shoot_through_enemy_unlim = true
-			self.degfifty.can_shoot_through_shield = true 
-			self.degfifty.can_shoot_through_titan_shield = true 
+			self.degfifty.can_shoot_through_shield = true
+			self.degfifty.can_shoot_through_titan_shield = true
 			self.degfifty.use_vapor_trail = true
 			self.degfifty.hs_mult = 2
 			self.degfifty.lock_slide = true
@@ -30505,7 +30779,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 
 		if self.glockson then --Masavik's Glockson
 			--Moved to primary
-			self.glockson.use_data.selection_index = 2	
+			self.glockson.use_data.selection_index = 2
 			self.glockson.categories = {"smg"}
 			self.glockson.recategorize = {"light_smg"}
 			self.glockson.damage_type = "machine_gun"
@@ -30550,7 +30824,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 		end
 
 		--Akimbo Bubble Daryls
-		if self.x_huntsman then 
+		if self.x_huntsman then
 			self.x_huntsman.recategorize = { "break_shot" }
 			self.x_huntsman.categories = { "akimbo", "shotgun" }
 			self.x_huntsman.damage_type = "shotgun"
@@ -30572,7 +30846,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 				last_recoil_mult = 1.25
 			}
 			self.x_huntsman.CAN_TOGGLE_FIREMODE = false
-			self.x_huntsman.FIRE_MODE = "single"				
+			self.x_huntsman.FIRE_MODE = "single"
 			self.x_huntsman.AMMO_MAX = 30
 			self.x_huntsman.supported = true
 			self.x_huntsman.ads_speed = 0.380
@@ -30630,7 +30904,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 				last_recoil_mult = 1.25
 			}
 			self.x_coach.CAN_TOGGLE_FIREMODE = false
-			self.x_coach.FIRE_MODE = "single"				
+			self.x_coach.FIRE_MODE = "single"
 			self.x_coach.AMMO_MAX = 30
 			self.x_coach.supported = true
 			self.x_coach.ads_speed = 0.380
@@ -30703,32 +30977,32 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 		end
 
 
-	--[[     CAP/WEAPONLIB REQUIRING THINGS     ]]	
+	--[[     CAP/WEAPONLIB REQUIRING THINGS     ]]
 		-- Currently low priority. If it REQUIRES Weaponlib (some Weaponlib weapons just need CAP's functionality, those are fine) then it's a no-go for now
-		
+
 		if self.x_car9 then --disabled vmp akimbos
 			self.x_car9.use_data.selection_index = 5
 			self.x_car9.supported = true
-		end	
+		end
 
 		if self.x_smolak then --disabled vmp akimbos
 			self.x_smolak.use_data.selection_index = 5
 			self.x_smolak.supported = true
-		end	
+		end
 
 		if self.x_ak5s then --disabled vmp akimbos
 			self.x_ak5s.use_data.selection_index = 5
 			self.x_ak5s.supported = true
-		end	
+		end
 
 		if self.x_cold then --disabled vmp akimbos
 			self.x_cold.use_data.selection_index = 5
 			self.x_cold.supported = true
-		end		
+		end
 
 		if self.cold then --Gambyt's VMP Crosskill Protector
 			self.cold.use_data.selection_index = 5
-			self.cold.tactical_reload = 1											
+			self.cold.tactical_reload = 1
 			self.cold.fire_mode_data.fire_rate = 0.08571428571
 			self.cold.single.fire_rate = 0.08571428571
 			self.cold.CLIP_AMMO_MAX = 8
@@ -30754,82 +31028,82 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 		end
 
 	--[[     DISABLED     ]]--
-	
+
 		--Akimbo CZ ACCUSHADOW
 		--DISABLED - ALREADY A PRIMARY
 			self.x_czech.use_data.selection_index = 5
-		--Akimbo VD-12 
+		--Akimbo VD-12
 		--DISABLED - ALREADY A PRIMARY
 			self.x_sko12.use_data.selection_index = 5
 
 		--Akimbo MP40
 		--DISABLED - ALREADY A PRIMARY
-			self.x_erma.use_data.selection_index = 5			
-	
+			self.x_erma.use_data.selection_index = 5
+
 		--Akimbo CR805
 		--DISABLED - LOL NO
 			self.x_hajk.use_data.selection_index = 5
-	
+
 		--Akimbo Kross Vertex
 		--DISABLED - ALREADY A PRIMARY
 			self.x_polymer.use_data.selection_index = 5
-	
+
 		--Akimbo Jackal
 		--DISABLED - ALREADY A PRIMARY
 			self.x_schakal.use_data.selection_index = 5
-	
+
 		--Akimbo Chicago typewriter
 		--DISABLED-- - LOL NO
 			self.x_m1928.use_data.selection_index = 5
-	
+
 		--Akimbo Tatonka
 		--DISABLED - ALREADY A PRIMARY
 			self.x_coal.use_data.selection_index = 5
-	
+
 		--Akimbo Spec Ops (Akimbo MP7)
 		--DISABLED
 			self.x_mp7.use_data.selection_index = 5
-					
+
 		--Akimbo Goliath 12g
 		--DISABLED
 			self.x_rota.use_data.selection_index = 5
-	
+
 		--Akimbo CMP
 		--DISABLED
 			self.x_mp9.use_data.selection_index = 5
-	
+
 		--Akimbo Patchett
 		--DISABLED
 			self.x_sterling.use_data.selection_index = 5
-	
+
 		--Akimbo Blaster 9mm
 		--DISABLED
 			self.x_tec9.use_data.selection_index = 5
-	
+
 		--akimbo Broomstick
 		--DISABLED - ALREADY A PRIMARY
 			self.x_c96.use_data.selection_index = 5
-	
+
 		--Akimbo Leo
 		--DISABLED
 			self.x_hs2000.use_data.selection_index = 5
-	
+
 		--Akimbo Swedish K
 		--DISABLED
 			self.x_m45.use_data.selection_index = 5
-	
+
 		--Akimbo Beretta Auto
 		--DISABLED - ALREADY A PRIMARY
 			self.x_beer.use_data.selection_index = 5
-	
+
 		--Akimbo AK Gen 21 Tactical
 		--DISABLED - ALREADY A PRIMARY
 			self.x_vityaz.use_data.selection_index = 5
-		
+
 		--Akimbo Miyaka 10
 		--DISABLED - ALREADY A PRIMARY
-			self.x_pm9.use_data.selection_index = 5	
-					
+			self.x_pm9.use_data.selection_index = 5
+
 	--Automatically generate reasonableish stats for custom weapons.
 	--Someone please help me fix this for the new stat indexes -DMC
 	for id, weap in pairs(self) do
@@ -30837,7 +31111,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 		if weap.categories and weap.stats then
 			if not weap.supported then
 				weap.always_play_anims = true
-				self:generate_custom_weapon_stats(weap)	
+				self:generate_custom_weapon_stats(weap)
 			end
 			if weap.animations and weap.animations.magazine_empty then
 				weap.animations.magazine_empty = ""
@@ -30846,7 +31120,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 			if weap.sounds then
 				weap.sounds.use_fix = nil
 			end
-			
+
 			if weap.keep_ammo == 0 then
 				weap.dispose_mag_desc = true
 			end
@@ -30860,7 +31134,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 				end
 			end
 
-			if weap.supported then 
+			if weap.supported then
 				if weap.recategorize[1] == "unsupported" then
 					weap.recategorize[1] = "wpn_special"
 				elseif weap.recategorize[1] == "light_snp" or weap.recategorize[1] == "heavy_snp" or weap.recategorize[1] == "antim_snp" then
@@ -30943,17 +31217,17 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 
 			if weap.damage_falloff and weap.damage_falloff.start_dist and weap.rays and weap.damage_type and not table.contains(weap.categories, "flamethrower") then
 				weap.alt_shotgunraycast = weap.alt_shotgunraycast or true
-				if weap.recategorize and weap.damage_type == "shotgun" or weap.damage_type == "shotgun_heavy" then	
-					if weap.recategorize[1] == "light_shot" and not table.contains(weap.categories, "shotgun_light") then	
+				if weap.recategorize and weap.damage_type == "shotgun" or weap.damage_type == "shotgun_heavy" then
+					if weap.recategorize[1] == "light_shot" and not table.contains(weap.categories, "shotgun_light") then
 						table.insert(weap.categories, "shotgun_light")
 						if weap.CAN_TOGGLE_FIREMODE ~= true and weap.FIRE_MODE == "single" then
 							table.insert(weap.categories, "shotgun_light_semi")
 						end
 						weap.ene_hs_mult = table.contains(weap.categories, "shotgun_auto") and 0.35 or 0.5
-					elseif weap.recategorize[1] == "heavy_shot" and not table.contains(weap.categories, "shotgun_heavy") then	
+					elseif weap.recategorize[1] == "heavy_shot" and not table.contains(weap.categories, "shotgun_heavy") then
 						table.insert(weap.categories, "shotgun_heavy")
 						weap.ene_hs_mult = 0.65
-					elseif weap.recategorize[1] == "break_shot" and not table.contains(weap.categories, "shotgun_break") then	
+					elseif weap.recategorize[1] == "break_shot" and not table.contains(weap.categories, "shotgun_break") then
 						table.insert(weap.categories, "shotgun_break")
 						weap.ene_hs_mult = 0.8
 					end
@@ -30967,7 +31241,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 			if table.contains(weap.categories, "amr") then
 				weap.force_shake = true
 			end
-	
+
 			if table.contains(weap.categories, "dmr_l") or table.contains(weap.categories, "dmr_h") then
 				weap.SINGLE_FIRE_AP_ADD = 0.25
 			end
@@ -31005,7 +31279,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 			if table.contains(weap.recategorize, "handcannon") then
 				table.insert(weap.categories, "handcannon")
 			end
-			
+
 			table.insert(weap.categories, "tony")
 
 			if weap.recategorize and not weap.recoil_values then
@@ -31327,10 +31601,10 @@ function WeaponTweakData:calculate_ammo_pickup(weapon, id)
 			shotgun_heavy = 0.98, --Light
 			shotgun_break = 1.08, --Heavy
 			shotgun_super = 1.11,
-		--assault_rifle = 1, 
+		--assault_rifle = 1,
 			dmr_l = 0.9,
 			dmr_h = 0.9,
-			--snp = 1, 
+			--snp = 1,
 				semi_snp = 0.75,
 				amr = 0.96,
 		saw = 1.25, --Compensate for jankiness.
@@ -31362,7 +31636,7 @@ function WeaponTweakData:calculate_ammo_pickup(weapon, id)
 		"m134",
 		"shuno",
 	}
-	if id and weapon.AMMO_MAX and weapon.CLIP_AMMO_MAX and 
+	if id and weapon.AMMO_MAX and weapon.CLIP_AMMO_MAX and
 	not table.contains(exclude_ammo, id) and not table.contains(weapon.categories, "minigun") and not table.contains(weapon.categories, "saw") then
 		local mag_clamp = math.min(100, weapon.CLIP_AMMO_MAX / ((table.contains(weapon.categories, "akimbo") and 2) or 1) )
 		if mag_clamp * 2 > weapon.AMMO_MAX then
@@ -31376,28 +31650,28 @@ end
 
 WeaponTweakData.clone__create_table_structure = WeaponTweakData._create_table_structure
 function WeaponTweakData:_create_table_structure()
-	self:clone__create_table_structure()	
+	self:clone__create_table_structure()
 	self.hk23_sc_npc = {
 		usage = "is_lmg",
 		anim_usage = "is_rifle",
 		sounds = {},
 		use_data = {},
 		auto = {}
-	}	
+	}
 	self.m249_bravo_npc = {
 		usage = "is_lmg",
 		anim_usage = "is_rifle",
 		sounds = {},
 		use_data = {},
 		auto = {}
-	}			
+	}
 	self.scar_npc = {
 		usage = "is_dmr",
 		anim_usage = "is_rifle",
 		sounds = {},
 		use_data = {},
 		auto = {}
-	}	
+	}
 	self.hk21_sc_npc = {
 		usage = "is_lmg",
 		anim_usage = "is_rifle",
@@ -31435,13 +31709,13 @@ function WeaponTweakData:_create_table_structure()
 		anim_usage = "is_rifle",
 		sounds = {},
 		use_data = {}
-	}	
+	}
 	self.benelli_npc = {
 		usage = "is_shotgun_semi",
 		anim_usage = "is_shotgun_pump",
 		sounds = {},
 		use_data = {}
-	}	
+	}
 	self.osipr_gl_npc = {
 		usage = "is_rifle",
 		sounds = {},
@@ -31454,13 +31728,13 @@ function WeaponTweakData:_create_table_structure()
 		sounds = {},
 		use_data = {},
 		auto = {}
-	}	
+	}
 	self.smoke_npc = {
 		usage = "is_smg",
 		sounds = {},
 		use_data = {},
 		auto = {}
-	}		
+	}
 
 	--Crew shit below--
 	for i, wep_id in ipairs(damage_set.smg) do
@@ -31468,7 +31742,7 @@ function WeaponTweakData:_create_table_structure()
 			self[ wep_id ].usage = "is_smg"
 		end
 	end
-	
+
 	for i, wep_id in ipairs(damage_set.assault_rifle) do
 		if self[ wep_id ] and self[ wep_id ].usage then
 			self[ wep_id ].usage = "is_rifle"
@@ -31506,7 +31780,7 @@ function WeaponTweakData:_create_table_structure()
 	end
 
 	self.flamethrower_mk2_crew.usage = "flamethrower"
-	self.flamethrower_mk2_crew.anim_usage = "is_bullpup"	
+	self.flamethrower_mk2_crew.anim_usage = "is_bullpup"
 
 	self.peacemaker_crew = {
 		usage = "is_revolver",
@@ -31571,14 +31845,14 @@ function WeaponTweakData:_create_table_structure()
 		use_data = {},
 		auto = {}
 
-	}		
+	}
 	self.m14_crew = {
 		usage = "is_dmr",
 		anim_usage = "is_rifle",
 		sounds = {},
 		use_data = {},
 		auto = {}
-	}	
+	}
 	self.g3_crew = {
 		usage = "is_dmr",
 		anim_usage = "is_rifle",
@@ -31606,7 +31880,7 @@ function WeaponTweakData:_create_table_structure()
 		use_data = {},
 		auto = {}
 	}
-	
+
 	self.bessy_crew = {
 		usage = "is_sniper",
 		anim_usage = "is_rifle",
@@ -31744,4 +32018,4 @@ Hooks:PostHook( WeaponTweakData, "init", "resmod_cap", function(self)
 		})
 
 	end
-end)	
+end)


### PR DESCRIPTION
- Cleaned up trailing whitespaces in weapontweakdata and weaponfactorytweakdata, freeing an entire 9kb of storage space.
- Actually added support for the M203-less ACR.
- Made the Triad actually able to fire all barrels. Added limited shield piercing capabilities by default.
- Buffed the Polar 9mm by 4 stab.
- Made the Toy 1911 actually full-auto instead of technically.
- New weapons : HK45C (& akimbo), CBJ-MS, Mossberg 590A1, DVL-10, RPD.