### PR TITLE
Weapon batch number i forgot

### DIFF
--- a/lua/sc/loc/loc.lua
+++ b/lua/sc/loc/loc.lua
@@ -2520,6 +2520,7 @@ Hooks:Add("LocalizationManagerPostInit", "SC_Localization_Weapons_Eng", function
 				["bm_wp_upg_suppressor"] = "#{skill_color}#Silences## your weapon and #{risk}#reduces the chance of enemies evading your aim.##",
 				["bm_wp_upg_suppressor_boss"] = "\"What a thrill...\"\n\n#{skill_color}#Silences## your weapon and #{risk}#reduces the chance of enemies evading your aim.##",
 				["bm_wp_upg_suppressor_warn"] = "#{skill_color}#Silences## your weapon and #{risk}#reduces the chance of enemies evading your aim.##\n\n#{important_1}#May block sights.##",
+				["bm_wp_upg_unsuppressor"] = "#{skill_color}#Unsilences## your weapon and #{risk}#increases the chance of enemies evading your aim.##",
 				["bm_wp_upg_o_shortdot_dmc"] = "Shortdot Scope",
 				["bm_wp_upg_o_5_default"] = "Long-range scope.\nAttach to be able to modify the default sniper scope reticle.\n#{risk}#5x magnification.##",
 				["bm_wp_upg_mil_desc"] = "", --These didn't do anything when edited, maybe they aren't actually called?--
@@ -2800,6 +2801,8 @@ Hooks:Add("LocalizationManagerPostInit", "SC_Localization_Weapons_Eng", function
 					["bm_mg3_sc_desc"] = "#{skill_color}#Has improved spread and recoil while hipfired.##",
 					--M1919
 					["bm_wp_wpn_fps_upg_m1919a6_mag_ext"] = "125rnd Box Magazine",
+					--KE7
+					["bm_wp_wpn_fps_upg_sigke7_mag50"] = "50rnd Magazine",
 
 
 			--[[ SHOTGUNS ]]
@@ -2936,6 +2939,10 @@ Hooks:Add("LocalizationManagerPostInit", "SC_Localization_Weapons_Eng", function
 					["bm_wp_ck_concussive_desc"] = "A variant of the AR-23 featuring #{skill_color}#concussive rounds## and a modified red-dot sight.\n#{skill_color}#Concussive rounds stagger enemies up to 20 meters away.##\n#{risk}#Stagger range cannot be modified and burst-fire is removed.##",
 					--Bo6 XM4
 					["bm_wp_wpn_fps_ass_coslo723_mode_burst_desc"] = "#{risk}#Exchange full-auto for a 3-round auto-burst.##\n\nBursts will #{skill_color}#auto-cycle## so long as the trigger is held.",
+					-- Val mod 3
+					["bm_mod3_sc_desc"] = "Special modification of the Valkyria with improved ergonomics and shortened dimensions, seeing notable use in armed conflicts between PMCs in areas near the Russian coast of the Gulf of Finland.\n\nComes #{skill_color}#integrally suppressed## and #{skill_color}#deals 25% of its damage through body armor.##",
+					-- Malyuk
+					["bm_wp_wpn_fps_ass_malima_xmag"] = "45 Round Mag",
 
 			--[[ DMRs ]]
 				--Little Friend

--- a/lua/sc/tweak_data/weaponfactorytweakdata.lua
+++ b/lua/sc/tweak_data/weaponfactorytweakdata.lua
@@ -12805,6 +12805,8 @@ end)
 				--Prototype Barrel
 				self.parts.wpn_fps_ass_asval_b_proto.pcs = {}
 				self.parts.wpn_fps_ass_asval_b_proto.supported = true
+				self.parts.wpn_fps_ass_asval_b_proto.has_description = true
+				self.parts.wpn_fps_ass_asval_b_proto.desc_id = "bm_wp_upg_unsuppressor"
 				self.parts.wpn_fps_ass_asval_b_proto.stats = {
 					value = 2,
 					suppression = -13,
@@ -25856,6 +25858,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 				}
 
 				self.parts.wpn_fps_upg_lewis_mag_ext.supported = true
+				self.parts.wpn_fps_upg_lewis_mag_ext.has_description = false
 				self.parts.wpn_fps_upg_lewis_mag_ext.stats = {
 					value = 0,
 					extra_ammo = 50,
@@ -28829,7 +28832,17 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 
 				self.parts.wpn_fps_upg_svt40_pu_scope.pcs = nil	-- broken
 
-				self.wpn_fps_ass_svt40.override.wpn_fps_upg_i_autofire = {
+				self.parts.wpn_fps_upg_i_avt40 = {
+					pcs = {},
+					type = "custom",
+					sub_type = "autofire",
+					name_id = self.parts.wpn_fps_upg_i_autofire.name_id,
+					a_obj = "a_body",
+					has_description = true,
+					alt_icon = "guis/textures/pd2/blackmarket/icons/mods/wpn_fps_upg_i_autofire",
+					unit = "units/payday2/weapons/wpn_upg_dummy/wpn_upg_dummy",
+					third_unit = "units/payday2/weapons/wpn_upg_dummy/wpn_upg_dummy",
+					supported = true,
 					stats = {
 						spread = -5,
 						recoil = -8
@@ -28837,12 +28850,15 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 					custom_stats = {
 						rof_mult = 1.6,
 						falloff_start_mult = 0.5,
-						falloff_end_mult = 0.75
+						falloff_end_mult = 0.75,
+						can_toggle_firemode = true,
+						info_add_auto = true
 					},
+					internal_part = true,
 					desc_id = "bm_wp_upg_i_avt40_desc",
-					info_lock_auto = true
+					dlc = "sc"
 				}
-				table.insert(self.wpn_fps_ass_svt40.uses_parts, "wpn_fps_upg_i_autofire")
+				table.insert(self.wpn_fps_ass_svt40.uses_parts, "wpn_fps_upg_i_avt40")
 			end
 
 			if self.parts.wpn_fps_upg_fd338_supp then
@@ -28859,6 +28875,286 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 			if self.parts.wpn_fps_upg_merkel_usoptics_sn3_moa then
 				self.parts.wpn_fps_upg_merkel_usoptics_sn3_moa.pcs = nil
 			end
+
+			if self.parts.wpn_fps_snp_mas49_scope_apx then
+				self.parts.wpn_fps_upg_mas49_irons.pcs = nil -- borken
+				for i, part_id in pairs(self.wpn_fps_snp_mas49.default_blueprint) do
+					attachment_list = {
+						"wpn_fps_snp_mas49_scope_apx"
+					}
+					for _, replace_id in ipairs(attachment_list) do
+						if part_id == replace_id then
+							self.wpn_fps_snp_mas49.default_blueprint[i] = "wpn_fps_upg_mas49_irons"
+						end
+					end
+				end
+
+				self.parts.wpn_fps_upg_mas49_barrel_short.supported = true
+				self.parts.wpn_fps_upg_mas49_barrel_short.stats = deep_clone(barrels.short_b3_stats)
+				self.parts.wpn_fps_upg_mas49_barrel_short.custom_stats = deep_clone(barrels.short_b3_stats)
+			end
+
+			if self.parts.wpn_fps_upg_plr16_ns_flashhider then
+				self.parts.wpn_fps_upg_plr16_ns_flashhider.supported = true
+				self.parts.wpn_fps_upg_plr16_ns_flashhider.desc_id = "bm_wp_upg_flash_hider"
+				self.parts.wpn_fps_upg_plr16_ns_flashhider.has_description = true
+				self.parts.wpn_fps_upg_plr16_ns_flashhider.stats = deep_clone(muzzle_device.muzz_con_a)
+				self.parts.wpn_fps_upg_plr16_ns_flashhider.custom_stats = deep_clone(muzzle_device.muzz_con_a)
+				self.parts.wpn_fps_upg_plr16_ns_flashhider.custom_stats.muzzleflash = "effects/payday2/particles/weapons/9mm_auto_silence_fps"
+
+				self.parts.wpn_fps_upg_plr16_barrel_long.supported = true
+				self.parts.wpn_fps_upg_plr16_barrel_long.stats = deep_clone(barrels.long_b2_stats)
+				self.parts.wpn_fps_upg_plr16_barrel_long.custom_stats = deep_clone(barrels.long_b2_stats)
+
+				self.parts.wpn_fps_upg_plr16_mag_pmag.supported = true
+				self.parts.wpn_fps_upg_plr16_mag_pmag.has_description = false
+				self.parts.wpn_fps_upg_plr16_mag_pmag.stats = {
+					value = 2,
+					extra_ammo = 10,
+					reload = -3,
+					concealment = -1
+				}
+				self.parts.wpn_fps_upg_plr16_mag_pmag.custom_stats = {
+					ads_speed_mult = 1.025
+				}
+				self.parts.wpn_fps_upg_plr16_mag_pmag30.supported = true
+				self.parts.wpn_fps_upg_plr16_mag_pmag30.has_description = false
+				self.parts.wpn_fps_upg_plr16_mag_pmag30.stats = {
+					value = 1,
+					extra_ammo = 20,
+					reload = -3,
+					concealment = -4
+				}
+				self.parts.wpn_fps_upg_plr16_mag_pmag30.custom_stats = {
+					ads_speed_mult = 1.1
+				}
+				self.parts.wpn_fps_upg_plr16_mag_stanag.supported = true
+				self.parts.wpn_fps_upg_plr16_mag_stanag.has_description = false
+				self.parts.wpn_fps_upg_plr16_mag_stanag.stats = {
+					value = 2,
+					extra_ammo = 10,
+					reload = -3,
+					concealment = -1
+				}
+				self.parts.wpn_fps_upg_plr16_mag_stanag.custom_stats = {
+					ads_speed_mult = 1.025
+				}
+				self.parts.wpn_fps_upg_plr16_mag_stanag30.supported = true
+				self.parts.wpn_fps_upg_plr16_mag_stanag30.has_description = false
+				self.parts.wpn_fps_upg_plr16_mag_stanag30.stats = {
+					value = 1,
+					extra_ammo = 20,
+					reload = -3,
+					concealment = -4
+				}
+				self.parts.wpn_fps_upg_plr16_mag_stanag30.custom_stats = {
+					ads_speed_mult = 1.1
+				}
+
+				self.wpn_fps_pis_plr16.override.wpn_fps_upg_m4_s_standard = {
+					stats = deep_clone(stocks.add_adj_acc2_stats),
+					custom_stats = deep_clone(stocks.add_adj_acc2_stats)
+				}
+				self.wpn_fps_pis_plr16.override.wpn_fps_upg_m4_s_pts = {
+					stats = deep_clone(stocks.add_adj_acc3_stats),
+					custom_stats = deep_clone(stocks.add_adj_acc3_stats)
+				}
+				self.wpn_fps_pis_plr16.override.wpn_fps_sho_sko12_stock = {
+					stats = deep_clone(stocks.add_adj_acc3_stats),
+					custom_stats = deep_clone(stocks.add_adj_acc3_stats)
+				}
+				self.wpn_fps_pis_plr16.override.wpn_fps_upg_m4_s_crane = {
+					stats = deep_clone(stocks.add_adj_stats),
+					custom_stats = deep_clone(stocks.add_adj_stats)
+				}
+				self.wpn_fps_pis_plr16.override.wpn_fps_upg_m4_s_mk46 = {
+					stats = deep_clone(stocks.add_adj_stats),
+					custom_stats = deep_clone(stocks.add_adj_stats)
+				}
+				self.wpn_fps_pis_plr16.override.wpn_fps_snp_victor_s_mod0 = {
+					stats = deep_clone(stocks.add_adj_stats),
+					custom_stats = deep_clone(stocks.add_adj_stats)
+				}
+				self.wpn_fps_pis_plr16.override.wpn_fps_upg_m4_s_ubr = {
+					stats = deep_clone(stocks.add_hvy_rec_stats),
+					custom_stats = deep_clone(stocks.add_hvy_rec_stats)
+				}
+				self.wpn_fps_pis_plr16.override.wpn_fps_snp_tti_s_vltor = {
+					stats = deep_clone(stocks.add_hvy_acc_stats),
+					custom_stats = deep_clone(stocks.add_hvy_acc_stats)
+				}
+
+				self.parts.wpn_fps_upg_plr16_vg_fab_reg.pcs = nil
+				self.parts.wpn_fps_upg_plr16_vg_gp033.pcs = nil
+				self.parts.wpn_fps_upg_plr16_vg_bcm.pcs = nil
+			end
+
+			if self.parts.wpn_fps_upg_m40a5_omega then
+				self.parts.wpn_fps_upg_m40a5_omega.supported = true
+				self.parts.wpn_fps_upg_m40a5_omega.stats = {
+					value = 2,
+					suppression = 12,
+					alert_size = -1
+				}
+				self.parts.wpn_fps_upg_m40a5_omega.custom_stats = {}
+				self.parts.wpn_fps_upg_m40a5_omega.perks = {"silencer"}
+
+				self.parts.wpn_fps_snp_m40a5_m8541.supported = true
+				self.parts.wpn_fps_snp_m40a5_m8541.stats = {
+					value = 8,
+					zoom = 40
+				}
+				self.parts.wpn_fps_snp_m40a5_m8541.perks = {"scope"}
+
+				self.wpn_fps_snp_m40a5.override.wpn_fps_upg_o_acog = {
+					desc_id = "bm_wp_upg_o_4_cod",
+					stats = {
+						value = 8,
+						zoom = 30,
+						damage = 30,
+						recoil = -6,
+						concealment = -3,
+						total_ammo_mod = -104,
+						suppression = -1
+					},
+					custom_stats = {
+						rof_mult = 0.75,
+						ammo_pickup_max_mul = 0.6895,
+						ammo_pickup_min_mul = 0.6895,
+						alt_ammo_pickup_max_mul = 0.6895,
+						alt_ammo_pickup_min_mul = 0.6895
+					}
+				}
+			end
+
+			if self.parts.wpn_fps_upg_xm21_supp then
+				self.parts.wpn_fps_upg_xm21_supp.supported = true
+				self.parts.wpn_fps_upg_xm21_supp.stats = {
+					value = 2,
+					suppression = 12,
+					alert_size = -1
+				}
+				self.parts.wpn_fps_upg_xm21_supp.custom_stats = {}
+				self.parts.wpn_fps_upg_xm21_supp.perks = {"silencer"}
+
+				self.parts.wpn_fps_snp_xm21_redfield_art.supported = true
+				self.parts.wpn_fps_snp_xm21_redfield_art.stats = {
+					value = 8,
+					zoom = 40
+				}
+				self.parts.wpn_fps_snp_xm21_redfield_art.perks = {"scope"}
+
+				self.parts.wpn_fps_upg_xm21_stock_black.supported = true
+				self.parts.wpn_fps_upg_xm21_stock_black.stats = { value = 0 }
+				self.parts.wpn_fps_upg_xm21_stock_black.custom_stats = nil
+				self.parts.wpn_fps_upg_xm21_stock_camo_jungle.supported = true
+				self.parts.wpn_fps_upg_xm21_stock_camo_jungle.stats = { value = 0 }
+				self.parts.wpn_fps_upg_xm21_stock_camo_jungle.custom_stats = nil
+
+				self.parts.wpn_fps_upg_xm21_irons.supported = true
+				self.parts.wpn_fps_upg_xm21_irons.stats = { value = 0 }
+				self.parts.wpn_fps_upg_xm21_irons.custom_stats = nil
+			end
+
+			if self.parts.wpn_fps_upg_l35_barrel_long then
+				self.parts.wpn_fps_upg_l35_barrel_long.supported = true
+				self.parts.wpn_fps_upg_l35_barrel_long.stats = deep_clone(barrels.long_b2_stats)
+				self.parts.wpn_fps_upg_l35_barrel_long.custom_stats = deep_clone(barrels.long_b2_stats)
+
+				self.parts.wpn_fps_upg_l35_mag_ext.supported = true
+				self.parts.wpn_fps_upg_l35_mag_ext.has_description = true
+				self.parts.wpn_fps_upg_l35_mag_ext.stats = {
+					value = 2,
+					extra_ammo = 4,
+					concealment = -2,
+					reload = -4
+				}
+				self.parts.wpn_fps_upg_l35_mag_ext.custom_stats = { ads_speed_mult = 1.025 }
+				self.parts.wpn_fps_upg_l35_mag_long.supported = true
+				self.parts.wpn_fps_upg_l35_mag_long.has_description = true
+				self.parts.wpn_fps_upg_l35_mag_long.stats = {
+					value = 2,
+					extra_ammo = 8,
+					concealment = -3,
+					reload = -5
+				}
+				self.parts.wpn_fps_upg_l35_mag_long.custom_stats = { ads_speed_mult = 1.05 }
+				self.parts.wpn_fps_upg_l35_mag_drum.supported = true
+				self.parts.wpn_fps_upg_l35_mag_drum.has_description = true
+				self.parts.wpn_fps_upg_l35_mag_drum.stats = {
+					value = 2,
+					extra_ammo = 24,
+					concealment = -5,
+					reload = -7
+				}
+				self.parts.wpn_fps_upg_l35_mag_drum.custom_stats = { ads_speed_mult = 1.1 }
+
+				self.parts.wpn_fps_upg_l35_grip_rubber.supported = true
+				self.parts.wpn_fps_upg_l35_grip_rubber.stats = deep_clone(grips.quickdraw_1)
+				self.parts.wpn_fps_upg_l35_grip_rubber.custom_stats = deep_clone(grips.quickdraw_1)
+				self.parts.wpn_fps_upg_l35_grip_rubber_window.supported = true
+				self.parts.wpn_fps_upg_l35_grip_rubber_window.stats = deep_clone(grips.quickdraw_1)
+				self.parts.wpn_fps_upg_l35_grip_rubber_window.custom_stats = deep_clone(grips.quickdraw_1)
+
+				self.parts.wpn_fps_upg_l35_grip_wood.supported = true
+				self.parts.wpn_fps_upg_l35_grip_wood.stats = deep_clone(grips.recoil_1)
+				self.parts.wpn_fps_upg_l35_grip_wood_window.supported = true
+				self.parts.wpn_fps_upg_l35_grip_wood_window.stats = deep_clone(grips.recoil_1)
+
+				table.insert(self.wpn_fps_pis_l35.uses_parts, "wpn_fps_upg_o_rikt")
+				table.insert(self.wpn_fps_pis_l35.uses_parts, "wpn_fps_upg_o_rms")
+				table.insert(self.wpn_fps_pis_l35.uses_parts, "wpn_fps_upg_fl_pis_perst")
+
+				self.wpn_fps_pis_l35.override.wpn_fps_upg_o_rikt = {
+					parent = false
+				}
+				self.wpn_fps_pis_l35.override.wpn_fps_upg_o_rms = {
+					parent = false
+				}
+				self.wpn_fps_pis_l35.adds.wpn_fps_upg_fl_pis_perst = {
+					"wpn_fps_pis_l35_gadget_rail"
+				}
+			end
+
+			if self.parts.wpn_fps_upg_sigke7_barrel_short then
+				self.parts.wpn_fps_upg_sigke7_barrel_short.supported = true
+				self.parts.wpn_fps_upg_sigke7_barrel_short.stats = deep_clone(barrels.short_b2_stats)
+				self.parts.wpn_fps_upg_sigke7_barrel_short.custom_stats = deep_clone(barrels.short_b2_stats)
+
+				self.parts.wpn_fps_upg_sigke7_mag50.supported = true
+				self.parts.wpn_fps_upg_sigke7_mag50.has_description = false
+				self.parts.wpn_fps_upg_sigke7_mag50.stats = {
+					value = 0,
+					extra_ammo = 25,
+					concealment = -3,
+					reload = -5
+				}
+				self.parts.wpn_fps_upg_sigke7_mag50.custom_stats = {
+					ads_speed_mult = 1.1
+				}
+
+				self.parts.wpn_fps_upg_sigke7_bolt_light.supported = true
+				self.parts.wpn_fps_upg_sigke7_bolt_light.stats = {
+					value = 1,
+					spread = -1,
+					recoil = -2
+				}
+				self.parts.wpn_fps_upg_sigke7_bolt_light.custom_stats = {
+					rof_mult = 1.18181818
+				}
+
+				self.parts.wpn_fps_upg_sigke7_vanilia_ads.pcs = nil
+				self.parts.wpn_fps_upg_sigke7_scope_m84.pcs = nil
+
+				self.parts.wpn_fps_upg_sigke7_bipod.supported = true
+				self.parts.wpn_fps_upg_sigke7_bipod.has_description = true
+				self.parts.wpn_fps_upg_sigke7_bipod.desc_id = "bm_sc_bipod_desc"
+				self.parts.wpn_fps_upg_sigke7_bipod.stats = deep_clone(self.parts.wpn_fps_upg_bp_lmg_lionbipod.stats)
+				self.parts.wpn_fps_upg_sigke7_bipod.stats.value = 0
+				self.parts.wpn_fps_upg_sigke7_bipod.custom_stats = deep_clone(self.parts.wpn_fps_upg_bp_lmg_lionbipod.custom_stats)
+				self.parts.wpn_fps_upg_sigke7_bipod.perks = {"bipod"}
+			end
+
 
 	--[[ RJC9000'S MODS ]]
 
@@ -34495,16 +34791,154 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 		end
 
 		if self.parts.wpn_fps_ass_malima_receiver then
-			self.parts.wpn_fps_ass_malima_vertical_grip.stats = { value = 1 }
-			self.parts.wpn_fps_ass_malima_vertical_grip.custom_stats = nil
 			self.parts.wpn_fps_ass_malima_am_default.stats = { value = 1 }
 			self.parts.wpn_fps_ass_malima_am_default.custom_stats = nil
-			self.parts.wpn_fps_ass_malima_am_545.stats = { value = 1 }
-			self.parts.wpn_fps_ass_malima_am_545.custom_stats = nil
-			self.parts.wpn_fps_ass_malima_am_single_tap.stats = { value = 1 }
-			self.parts.wpn_fps_ass_malima_am_single_tap.custom_stats = nil
 			self.parts.wpn_fps_ass_malima_barrel.stats = { value = 1 }
 			self.parts.wpn_fps_ass_malima_barrel.custom_stats = nil
+			self.parts.wpn_fps_ass_malima_flash_hider.stats = { value = 1 }
+			self.parts.wpn_fps_ass_malima_flash_hider.custom_stats = nil
+			self.parts.wpn_fps_ass_malima_vertical_grip.stats = { value = 1 }
+			self.parts.wpn_fps_ass_malima_vertical_grip.custom_stats = nil
+
+			self.parts.wpn_fps_ass_malima_barrel_short.supported = true
+			self.parts.wpn_fps_ass_malima_barrel_short.stats = deep_clone(barrels.short_b1_stats)
+			self.parts.wpn_fps_ass_malima_barrel_short.custom_stats = deep_clone(barrels.short_b1_stats)
+
+			self.parts.wpn_fps_ass_malima_barrel_heavy.pcs = nil -- visually identical to the long barrel. could give it unique stats but ehh
+			self.parts.wpn_fps_ass_malima_barrel_long.supported = true
+			self.parts.wpn_fps_ass_malima_barrel_long.stats = deep_clone(barrels.long_b2_stats)
+			self.parts.wpn_fps_ass_malima_barrel_long.custom_stats = deep_clone(barrels.long_b2_stats)
+			self.parts.wpn_fps_ass_malima_barrel_heavy_long.supported = true
+			self.parts.wpn_fps_ass_malima_barrel_heavy_long.stats = deep_clone(barrels.long_b3_stats)
+			self.parts.wpn_fps_ass_malima_barrel_heavy_long.custom_stats = deep_clone(barrels.long_b3_stats)
+			self.parts.wpn_fps_ass_malima_barrel_heavy_sil.supported = true
+			self.parts.wpn_fps_ass_malima_barrel_heavy_sil.stats = {
+				value = 2,
+				suppression = 12,
+				alert_size = -1
+			}
+			self.parts.wpn_fps_ass_malima_barrel_heavy_sil.custom_stats = {}
+			self.parts.wpn_fps_ass_malima_barrel_heavy_sil.perks = {"silencer"}
+
+			self.parts.wpn_fps_ass_malima_comb_heavy.supported = true
+			self.parts.wpn_fps_ass_malima_comb_heavy.stats = {
+				value = 0,
+				concealment = -1,
+				recoil = 2
+			}
+			self.parts.wpn_fps_ass_malima_comb_ergo.supported = true
+			self.parts.wpn_fps_ass_malima_comb_ergo.stats = {
+				value = 0,
+				spread = -1,
+				recoil = 2
+			}
+			self.parts.wpn_fps_ass_malima_comb_tac.supported = true
+			self.parts.wpn_fps_ass_malima_comb_tac.stats = {
+				value = 0,
+				spread = 1,
+				recoil = -2
+			}
+
+			self.parts.wpn_fps_ass_malima_grip_heavy.supported = true
+			self.parts.wpn_fps_ass_malima_grip_heavy.stats = {
+				value = 0,
+				concealment = -1,
+				recoil = 2
+			}
+			self.parts.wpn_fps_ass_malima_grip_ergo.supported = true
+			self.parts.wpn_fps_ass_malima_grip_ergo.stats = {
+				value = 0,
+				spread = -1,
+				recoil = 2
+			}
+			self.parts.wpn_fps_ass_malima_grip_tac.supported = true
+			self.parts.wpn_fps_ass_malima_grip_tac.stats = {
+				value = 0,
+				spread = 1,
+				recoil = -2
+			}
+
+			self.parts.wpn_fps_ass_malima_handguard_heavy.supported = true
+			self.parts.wpn_fps_ass_malima_handguard_heavy.stats = {
+				value = 0,
+				concealment = -2,
+				recoil = 4
+			}
+			self.parts.wpn_fps_ass_malima_handguard_heavy_sil.supported = true
+			self.parts.wpn_fps_ass_malima_handguard_heavy_sil.stats = {
+				value = 0,
+				concealment = -3,
+				recoil = 6
+			}
+
+			self.parts.wpn_fps_ass_malima_smag.supported = true
+			self.parts.wpn_fps_ass_malima_smag.stats = {
+				value = 2,
+				concealment = 3,
+				reload = 8,
+				extra_ammo = -20
+			}
+			self.parts.wpn_fps_ass_malima_smag.custom_stats = {
+				ads_speed_mult = 0.9
+			}
+			self.parts.wpn_fps_ass_malima_xmag.supported = true
+			self.parts.wpn_fps_ass_malima_xmag.has_description = false
+			self.parts.wpn_fps_ass_malima_xmag.stats = {
+				value = 0,
+				extra_ammo = 15,
+				reload = -4,
+				concealment = -2
+			}
+			self.parts.wpn_fps_ass_malima_xmag.custom_stats = {
+				ads_speed_mult = 1.05
+			}
+
+			self.parts.wpn_fps_ass_malima_stock_light.supported = true
+			self.parts.wpn_fps_ass_malima_stock_light.stats = {
+				value = 2,
+				concealment = 1,
+				recoil = -2
+			}
+			self.parts.wpn_fps_ass_malima_stock_heavy.supported = true
+			self.parts.wpn_fps_ass_malima_stock_heavy.stats = {
+				value = 2,
+				concealment = -1,
+				recoil = 2
+			}
+			self.parts.wpn_fps_ass_malima_stock_tac.supported = true
+			self.parts.wpn_fps_ass_malima_stock_tac.stats = {
+				value = 2,
+				spread = -1,
+				recoil = 2
+			}
+
+			self.parts.wpn_fps_ass_malima_vg_fab.supported = true
+			self.parts.wpn_fps_ass_malima_vg_fab.stats = {
+				value = 2,
+				concealment = 1,
+				recoil = -2
+			}
+			self.wpn_fps_ass_malima.override.wpn_fps_upg_vg_ass_smg_stubby = {
+				stats = {
+					recoil = -2,
+					concealment = 1
+				}
+			}
+			self.wpn_fps_ass_malima.override.wpn_fps_smg_schakal_vg_surefire = {
+				stats = {
+					value = 0
+				}
+			}
+			self.wpn_fps_ass_malima.override.wpn_fps_upg_vg_ass_smg_verticalgrip = {
+				stats = {
+					value = 0
+				}
+			}
+			self.wpn_fps_ass_malima.override.wpn_fps_smg_mp7_vg_mgrip_unlock = {
+				stats = {
+					value = 0
+				}
+			}
 		end
 
 		if self.parts.wpn_fps_snp_sbeta_receiver then
@@ -39135,6 +39569,154 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 			table.insert(self.wpn_fps_snp_tkpd.uses_parts, "wpn_fps_upg_o_shortdot_dmc")
 		end
 
+		if self.parts.wpn_fps_pis_hipower_g_mk3 then
+			self.parts.wpn_fps_pis_hipower_g_mk3.supported = true
+			self.parts.wpn_fps_pis_hipower_g_mk3.stats = deep_clone(grips.recoil_acc)
+
+			self.parts.wpn_fps_pis_hipower_g_inglis.supported = true
+			self.parts.wpn_fps_pis_hipower_g_inglis.stats = deep_clone(grips.quickdraw_1)
+			self.parts.wpn_fps_pis_hipower_g_inglis.custom_stats = deep_clone(grips.quickdraw_1)
+
+			self.parts.wpn_fps_pis_hipower_m_ext.supported = true
+			self.parts.wpn_fps_pis_hipower_m_ext.stats = {
+				value = 1,
+				reload = -4,
+				extra_ammo = 7,
+				concealment = -2
+			}
+			self.wpn_fps_pis_x_hipower.override.wpn_fps_pis_hipower_m_ext.stats = {
+				value = 1,
+				reload = -4,
+				extra_ammo = 14,
+				concealment = -2
+			}
+		end
+
+		if self.parts.wpn_fps_shot_xmassg_cupscope then
+			self.parts.wpn_fps_shot_xmassg_cupscope.supported = true
+			self.parts.wpn_fps_shot_xmassg_cupscope.stats = { value = 0 }
+			self.parts.wpn_fps_shot_xmassg_cupscope.custom_stats = nil
+
+			table.insert(self.wpn_fps_shot_xmassg.uses_parts, "wpn_fps_upg_a_rip")
+		end
+
+		if self.parts.wpn_fps_pis_bootl1911_b_thr then
+			self.parts.wpn_fps_pis_bootl1911_b_thr.supported = true
+			self.parts.wpn_fps_pis_bootl1911_b_thr.stats = deep_clone(barrels.long_b1_stats)
+			self.parts.wpn_fps_pis_bootl1911_b_thr.custom_stats = deep_clone(barrels.long_b1_stats)
+
+			self.parts.wpn_fps_pis_bootl1911_ns_mb.supported = true
+			self.parts.wpn_fps_pis_bootl1911_ns_mb.stats = deep_clone(muzzle_device.muzz_rec2_c)
+			self.parts.wpn_fps_pis_bootl1911_ns_hp.supported = true
+			self.parts.wpn_fps_pis_bootl1911_ns_hp.stats = deep_clone(muzzle_device.supp_rec2_c)
+			self.parts.wpn_fps_pis_bootl1911_ns_hp.custom_stats = deep_clone(muzzle_device.supp_rec2_c)
+			self.parts.wpn_fps_pis_bootl1911_ns_hp.perks = {"silencer"}
+
+			self.parts.wpn_fps_pis_bootl1911_fl_compact.desc_id = "bm_wp_upg_fl_flashlight"
+
+			self.parts.wpn_fps_pis_bootl1911_g_ergo.supported = true
+			self.parts.wpn_fps_pis_bootl1911_g_ergo.stats = deep_clone(grips.quickdraw_1)
+			self.parts.wpn_fps_pis_bootl1911_g_ergo.custom_stats = deep_clone(grips.quickdraw_1)
+			self.parts.wpn_fps_pis_bootl1911_g_custom.supported = true
+			self.parts.wpn_fps_pis_bootl1911_g_custom.stats = deep_clone(grips.recoil_acc)
+			self.parts.wpn_fps_pis_bootl1911_g_engraved.supported = true
+			self.parts.wpn_fps_pis_bootl1911_g_engraved.has_description = false
+			self.parts.wpn_fps_pis_bootl1911_g_engraved.stats = deep_clone(grips.recoil_1)
+
+			self.parts.wpn_fps_pis_bootl1911_m_ext.supported = true
+			self.parts.wpn_fps_pis_bootl1911_m_ext.stats = {
+				value = 3,
+				concealment = -1,
+				extra_ammo = 4,
+				reload = -3
+			}
+			self.parts.wpn_fps_pis_bootl1911_m_ext.custom_stats = {
+				ads_speed_mult = 1.025
+			}
+			self.wpn_fps_pis_x_bootl1911.override.wpn_fps_pis_bootl1911_m_ext = {
+				stats = {
+					value = 3,
+					concealment = -1,
+					extra_ammo = 8,
+					reload = -3
+				}
+			}
+
+			self.parts.wpn_fps_pis_bootl1911_body_adamska.supported = true
+			self.parts.wpn_fps_pis_bootl1911_body_adamska.stats = { value = 0 }
+			self.parts.wpn_fps_pis_bootl1911_body_custom.supported = true
+			self.parts.wpn_fps_pis_bootl1911_body_custom.stats = {
+				value = 0,
+				recoil = 2,
+				concealment = -1
+			}
+			self.parts.wpn_fps_pis_bootl1911_body_custom.custom_stats = nil
+
+			self.parts.wpn_fps_pis_bootl1911_sl_adamska.supported = true
+			self.parts.wpn_fps_pis_bootl1911_sl_adamska.stats = { value = 0 }
+			self.parts.wpn_fps_pis_bootl1911_sl_custom.supported = true
+			self.parts.wpn_fps_pis_bootl1911_sl_custom.stats = {
+				value = 0,
+				recoil = 4,
+				spread = -2
+			}
+			self.parts.wpn_fps_pis_bootl1911_sl_hp.supported = true
+			self.parts.wpn_fps_pis_bootl1911_sl_hp.stats = { value = 0 }
+			self.parts.wpn_fps_pis_bootl1911_sl_lb.supported = true
+			self.parts.wpn_fps_pis_bootl1911_sl_lb.stats = deep_clone(barrels.long_b2_stats)
+			self.parts.wpn_fps_pis_bootl1911_sl_lb.custom_stats = deep_clone(barrels.long_b2_stats)
+			self.parts.wpn_fps_pis_bootl1911_sl_cb.supported = true
+			self.parts.wpn_fps_pis_bootl1911_sl_cb.stats = {
+				value = 0,
+				spread = 3,
+				recoil = 6,
+				concealment = -6
+			}
+			self.parts.wpn_fps_pis_bootl1911_sl_cb.custom_stats = {
+				falloff_start_mult = 1.225,
+				falloff_end_mult = 1.225,
+				ads_speed_mult = 1.15
+			}
+
+			for i, part_id in pairs(self.wpn_fps_pis_bootl1911.uses_parts) do
+				if part_id ~= "wpn_fps_pis_bootl1911_o_dummy" and self.parts[part_id] and self.parts[part_id].type and self.parts[part_id].type == "sight" then
+					table.insert(self.parts.wpn_fps_pis_bootl1911_sl_std.forbids, part_id)
+					table.insert(self.parts.wpn_fps_pis_bootl1911_sl_hp.forbids, part_id)
+					table.insert(self.parts.wpn_fps_pis_bootl1911_sl_lb.forbids, part_id)
+					table.insert(self.parts.wpn_fps_pis_bootl1911_sl_custom.forbids, part_id)
+					table.insert(self.parts.wpn_fps_pis_bootl1911_sl_adamska.forbids, part_id)
+				end
+			end
+
+			table.insert(self.wpn_fps_pis_bootl1911.uses_parts, "wpn_fps_upg_fl_pis_perst")
+			table.insert(self.wpn_fps_pis_x_bootl1911.uses_parts, "wpn_fps_upg_fl_pis_perst")
+			self.wpn_fps_pis_bootl1911.adds.wpn_fps_upg_fl_pis_perst = { "wpn_fps_pis_bootl1911_body_rail" }
+			self.wpn_fps_pis_x_bootl1911.adds.wpn_fps_upg_fl_pis_perst = { "wpn_fps_pis_bootl1911_body_rail" }
+		end
+
+		if self.parts.wpn_fps_upg_fnp45_mag_ext then
+			self.parts.wpn_fps_upg_fnp45_mag_ext.supported = true
+			self.parts.wpn_fps_upg_fnp45_mag_ext.stats = {
+				value = 3,
+				concealment = -1,
+				extra_ammo = 5,
+				reload = -4
+			}
+			self.parts.wpn_fps_upg_fnp45_mag_ext.custom_stats = {
+				ads_speed_mult = 1.025
+			}
+
+			table.insert(self.wpn_fps_pis_fnp45.uses_parts, "wpn_fps_upg_fl_pis_perst")
+			table.insert(self.wpn_fps_pis_fnp45.uses_parts, "wpn_fps_upg_o_rikt")
+			table.insert(self.wpn_fps_pis_fnp45.uses_parts, "wpn_fps_upg_o_rms")
+			self.wpn_fps_pis_fnp45.override.wpn_fps_upg_o_rikt = {
+				parent = "slide"
+			}
+			self.wpn_fps_pis_fnp45.override.wpn_fps_upg_o_rms = {
+				parent = "slide"
+			}
+		end
+
 		if self.parts.wpn_fps_ass_kurisumasu_b_std then
 			self.parts.wpn_fps_ass_kurisumasu_s_m4ss.supported = true
 			self.parts.wpn_fps_ass_kurisumasu_s_m4ss.stats = { value = 0 }
@@ -39888,6 +40470,42 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 					ammo_pickup_max_mul = 0.5641
 				},
 			}
+		end
+
+		if self.parts.wpn_fps_ass_ak556_grip_torn then
+			self.parts.wpn_fps_ass_ak556_grip_torn.supported = true
+			self.parts.wpn_fps_ass_ak556_grip_torn.stats = deep_clone(grips.recoil_1)
+
+			self.parts.wpn_fps_ass_ak556_bigmag.supported = true
+			self.parts.wpn_fps_ass_ak556_bigmag.stats = deep_clone(self.parts.wpn_fps_upg_m4_m_quad.stats)
+			self.parts.wpn_fps_ass_ak556_bigmag.custom_stats = deep_clone(self.parts.wpn_fps_upg_m4_m_quad.custom_stats)
+			self.parts.wpn_fps_ass_ak556_speed.supported = true
+			self.parts.wpn_fps_ass_ak556_speed.stats = deep_clone(self.parts.wpn_fps_m4_upg_m_quick.stats)
+			self.parts.wpn_fps_ass_ak556_pmag.supported = true
+			self.parts.wpn_fps_ass_ak556_pmag.stats = {
+				value = 0,
+				concealment = 1,
+				recoil = -2
+			}
+			self.parts.wpn_fps_ass_ak556_smolmag.supported = true
+			self.parts.wpn_fps_ass_ak556_smolmag.stats = deep_clone(self.parts.wpn_fps_upg_m4_m_straight.stats)
+			self.parts.wpn_fps_ass_ak556_smolmag.custom_stats = deep_clone(self.parts.wpn_fps_upg_m4_m_straight.custom_stats)
+
+			self.parts.wpn_fps_ass_ak556_stock_fold.supported = true
+			self.parts.wpn_fps_ass_ak556_stock_fold.stats = deep_clone(stocks.adj_to_nocheeks_stats)
+			self.parts.wpn_fps_ass_ak556_stock_fold.custom_stats = deep_clone(stocks.adj_to_nocheeks_stats)
+			self.parts.wpn_fps_ass_ak556_stock_none.supported = true
+			self.parts.wpn_fps_ass_ak556_stock_none.stats = deep_clone(stocks.remove_adj_stats)
+			self.parts.wpn_fps_ass_ak556_stock_none.custom_stats = deep_clone(stocks.remove_adj_stats)
+
+			self.parts.wpn_fps_ass_ak556_stock_tan.supported = true
+			self.parts.wpn_fps_ass_ak556_stock_tan.stats = { value = 0 }
+		end
+
+		if self.parts.wpn_fps_upg_mikon_s_viper then
+			self.parts.wpn_fps_upg_mikon_s_viper.supported = true
+			self.parts.wpn_fps_upg_mikon_s_viper.stats = deep_clone(stocks.adj_to_fold_stats)
+			self.parts.wpn_fps_upg_mikon_s_viper.custom_stats = deep_clone(stocks.adj_to_fold_stats)
 		end
 
 	--[[ ZDANN'S MODS ]]
@@ -43640,6 +44258,16 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 				recoil = 2,
 				concealment = -1
 			}
+
+			self.wpn_fps_shot_mossberg590.override = self.wpn_fps_shot_mossberg590.override or {}
+			self.wpn_fps_shot_mossberg590.override.wpn_fps_upg_a_slug = deep_clone(shot_ammo.a_slug_pump_override)
+			self.wpn_fps_shot_mossberg590.override.wpn_fps_upg_a_custom = deep_clone(shot_ammo.a_custom_pump_override)
+			self.wpn_fps_shot_mossberg590.override.wpn_fps_upg_a_custom_free = deep_clone(shot_ammo.a_custom_pump_override)
+			self.wpn_fps_shot_mossberg590.override.wpn_fps_upg_a_explosive = deep_clone(shot_ammo.a_explosive_pump_override)
+			self.wpn_fps_shot_mossberg590.override.wpn_fps_upg_a_rip = deep_clone(shot_ammo.a_rip_pump_override)
+			self.wpn_fps_shot_mossberg590.override.wpn_fps_upg_a_piercing = deep_clone(shot_ammo.a_piercing_pump_override)
+			self.wpn_fps_shot_mossberg590.override.wpn_fps_upg_a_dragons_breath = deep_clone(shot_ammo.a_dragons_breath_pump_override)
+		
 		end
 
 		if self.parts.wpn_fps_shot_qbs_barrel_long then
@@ -43671,6 +44299,15 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 			self.parts.wpn_fps_shot_qbs_nostock.supported = true
 			self.parts.wpn_fps_shot_qbs_nostock.stats = deep_clone(stocks.remove_nocheeks_stats)
 			self.parts.wpn_fps_shot_qbs_nostock.custom_stats = deep_clone(stocks.remove_nocheeks_stats)
+
+			self.wpn_fps_shot_qbs.override = self.wpn_fps_shot_qbs.override or {}
+			self.wpn_fps_shot_qbs.override.wpn_fps_upg_a_slug = deep_clone(shot_ammo.a_slug_semi_override)
+			self.wpn_fps_shot_qbs.override.wpn_fps_upg_a_custom = deep_clone(shot_ammo.a_custom_semi_override)
+			self.wpn_fps_shot_qbs.override.wpn_fps_upg_a_custom_free = deep_clone(shot_ammo.a_custom_semi_override)
+			self.wpn_fps_shot_qbs.override.wpn_fps_upg_a_explosive = deep_clone(shot_ammo.a_explosive_semi_override)
+			self.wpn_fps_shot_qbs.override.wpn_fps_upg_a_rip = deep_clone(shot_ammo.a_rip_semi_override)
+			self.wpn_fps_shot_qbs.override.wpn_fps_upg_a_piercing = deep_clone(shot_ammo.a_piercing_semi_override)
+			self.wpn_fps_shot_qbs.override.wpn_fps_upg_a_dragons_breath = deep_clone(shot_ammo.a_dragons_breath_semi_override)
 		end
 
 		if self.parts.wpn_fps_pis_welrod_b_short then
@@ -43812,6 +44449,17 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 				reload = -3
 			}
 		end
+
+		if self.wpn_fps_shot_candy then
+			self.wpn_fps_shot_candy.override.wpn_fps_upg_a_slug = deep_clone(shot_ammo.a_slug_pump_override)
+			self.wpn_fps_shot_candy.override.wpn_fps_upg_a_custom = deep_clone(shot_ammo.a_custom_pump_override)
+			self.wpn_fps_shot_candy.override.wpn_fps_upg_a_custom_free = deep_clone(shot_ammo.a_custom_pump_override)
+			self.wpn_fps_shot_candy.override.wpn_fps_upg_a_explosive = deep_clone(shot_ammo.a_explosive_pump_override)
+			self.wpn_fps_shot_candy.override.wpn_fps_upg_a_rip = deep_clone(shot_ammo.a_rip_pump_override)
+			self.wpn_fps_shot_candy.override.wpn_fps_upg_a_piercing = deep_clone(shot_ammo.a_piercing_pump_override)
+			self.wpn_fps_shot_candy.override.wpn_fps_upg_a_dragons_breath = deep_clone(shot_ammo.a_dragons_breath_pump_override)
+		end
+
 
 	--Akimbo Mosconi 12G
 	if self.wpn_fps_shot_x_huntsman then
@@ -45582,6 +46230,48 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 		self.parts.wpn_fps_bren2_stock_col.custom_stats = deep_clone(stocks.adj_hvy_acc_stats)
 	end
 
+	if self.parts.wpn_fps_iso_magazine_extend then
+		self.parts.wpn_fps_iso_magazine_extend.supported = true
+		self.parts.wpn_fps_iso_magazine_extend.stats = {
+			value = 4,
+			concealment = -1,
+			reload = -3,
+			extra_ammo = 10
+		}
+		self.parts.wpn_fps_iso_magazine_extend.custom_stats = {
+			ads_speed_mult = 1.025
+		}
+		self.parts.wpn_fps_iso_magazine_drum.supported = true
+		self.parts.wpn_fps_iso_magazine_drum.stats = {
+			value = 4,
+			concealment = -3,
+			reload = -6,
+			extra_ammo = 30
+		}
+		self.parts.wpn_fps_iso_magazine_drum.custom_stats = {
+			ads_speed_mult = 1.075
+		}
+
+		self.parts.wpn_fps_iso_barrel_medium.supported = true
+		self.parts.wpn_fps_iso_barrel_medium.stats = deep_clone(barrels.long_b2_stats)
+		self.parts.wpn_fps_iso_barrel_medium.custom_stats = deep_clone(barrels.long_b2_stats)
+		self.parts.wpn_fps_iso_barrel_long.supported = true
+		self.parts.wpn_fps_iso_barrel_long.stats = deep_clone(barrels.long_b3_stats)
+		self.parts.wpn_fps_iso_barrel_long.custom_stats = deep_clone(barrels.long_b3_stats)
+		self.parts.wpn_fps_iso_barrel_silenced.supported = true
+		self.parts.wpn_fps_iso_barrel_silenced.stats = deep_clone(muzzle_device.supp_dual2_c)
+		self.parts.wpn_fps_iso_barrel_silenced.custom_stats = deep_clone(muzzle_device.supp_dual2_c)
+		self.parts.wpn_fps_iso_barrel_silenced.perks = {"silencer"}
+
+		self.parts.wpn_fps_iso_stock_folded.supported = true
+		self.parts.wpn_fps_iso_stock_folded.stats = deep_clone(stocks.fold_nocheeks_stats)
+		self.parts.wpn_fps_iso_stock_folded.custom_stats = deep_clone(stocks.fold_nocheeks_stats)
+		self.parts.wpn_fps_iso_stock_full.supported = true
+		self.parts.wpn_fps_iso_stock_full.stats = deep_clone(stocks.nocheeks_to_adj_acc_stats)
+		self.parts.wpn_fps_iso_stock_full.custom_stats = deep_clone(stocks.nocheeks_to_adj_acc_stats)
+	end
+
+
 	if self.parts.wpn_fps_upg_m_quad100 then
 		self.parts.wpn_fps_upg_m_quad100.supported = true
 		self.parts.wpn_fps_upg_m_quad100.stats = deep_clone(self.parts.wpn_fps_upg_m4_m_drum.stats)
@@ -46185,6 +46875,36 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 		}
 	end
 
+	if self.parts.wpn_fps_pis_degle_fr_big then
+		self.parts.wpn_fps_pis_degle_fr_big.supported = true
+		self.parts.wpn_fps_pis_degle_fr_big.stats = {
+			value = 99,
+			spread = 10,
+			concealment = -10
+		}
+		self.parts.wpn_fps_pis_degle_fr_big.custom_stats = {
+			falloff_start_mult = 1.75,
+			falloff_end_mult = 1.75,
+			ads_speed_mult = 1.337
+		}
+
+		self.parts.wpn_fps_pis_degle_m_big.supported = true
+		self.parts.wpn_fps_pis_degle_m_big.stats = {
+			value = 99,
+			extra_ammo = 68,
+			concealment = -6,
+			reload = -8
+		}
+
+		self.parts.wpn_fps_pis_degle_gr_camo.supported = true
+		self.parts.wpn_fps_pis_degle_gr_camo.stats = { value = 0 }
+		self.parts.wpn_fps_pis_degle_gr_camo.forbids = nil
+		self.parts.wpn_fps_pis_degle_gr_wood.supported = true
+		self.parts.wpn_fps_pis_degle_gr_wood.stats = { value = 0 }
+		self.parts.wpn_fps_pis_degle_gr_wood.forbids = nil
+	end
+
+
 	if self.parts.wpn_fps_pis_mp443_m_extended then
 		self.parts.wpn_fps_pis_mp443_m_extended.supported = true
 		self.parts.wpn_fps_pis_mp443_m_extended.stats = {
@@ -46400,6 +47120,18 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 		}
 	end
 
+	if self.wpn_fps_pis_chinesium then
+		table.insert(self.wpn_fps_pis_chinesium.uses_parts, "wpn_fps_upg_fl_pis_perst")
+		table.insert(self.wpn_fps_pis_chinesium.uses_parts, "wpn_fps_upg_o_rikt")
+		table.insert(self.wpn_fps_pis_chinesium.uses_parts, "wpn_fps_upg_o_rms")
+		self.wpn_fps_pis_chinesium.override.wpn_fps_upg_o_rikt = {
+			parent = "slide"
+		}
+		self.wpn_fps_pis_chinesium.override.wpn_fps_upg_o_rms = {
+			parent = "slide"
+		}
+	end
+
 	if self.parts.wpn_fps_sho_dp12_fg_standard then
 		self.parts.wpn_fps_sho_dp12_fg_standard.supported = true
 		self.parts.wpn_fps_sho_dp12_fg_standard.stats = {value = 0}
@@ -46430,6 +47162,16 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 		self.parts.wpn_fps_sho_dp12_fg_novg_rail.pcs = nil
 		self.parts.wpn_fps_sho_dp12_fg_novg.pcs = nil
 		self.parts.wpn_fps_sho_dp12_o_non.pcs = nil
+
+		self.wpn_fps_sho_dp12.override = self.wpn_fps_sho_dp12.override or {}
+		self.wpn_fps_sho_dp12.override.wpn_fps_upg_a_slug = deep_clone(shot_ammo.a_slug_pump_override)
+		self.wpn_fps_sho_dp12.override.wpn_fps_upg_a_custom = deep_clone(shot_ammo.a_custom_pump_override)
+		self.wpn_fps_sho_dp12.override.wpn_fps_upg_a_custom_free = deep_clone(shot_ammo.a_custom_pump_override)
+		self.wpn_fps_sho_dp12.override.wpn_fps_upg_a_explosive = deep_clone(shot_ammo.a_explosive_pump_override)
+		self.wpn_fps_sho_dp12.override.wpn_fps_upg_a_rip = deep_clone(shot_ammo.a_rip_pump_override)
+		self.wpn_fps_sho_dp12.override.wpn_fps_upg_a_piercing = deep_clone(shot_ammo.a_piercing_pump_override)
+		self.wpn_fps_sho_dp12.override.wpn_fps_upg_a_dragons_breath = deep_clone(shot_ammo.a_dragons_breath_pump_override)
+	
 	end
 
 	if self.parts.wpn_fps_snp_iuhTTIPlus_gl then --iuhggiuhhgbnr's SR-25
@@ -47095,6 +47837,26 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 		table.insert(self.wpn_fps_pis_x_sw659.uses_parts, "wpn_fps_upg_fl_pis_perst")
 		self.wpn_fps_pis_sw659.adds.wpn_fps_upg_fl_pis_perst = { "wpn_fps_pis_sw659_fl_adapter" }
 		self.wpn_fps_pis_x_sw659.adds.wpn_fps_upg_fl_pis_perst = { "wpn_fps_pis_sw659_fl_adapter" }
+	end
+
+	if self.parts.wpn_fps_ass_howa_b_para then
+		self.parts.wpn_fps_ass_howa_b_para.supported = true
+		self.parts.wpn_fps_ass_howa_b_para.stats = deep_clone(barrels.short_b2_stats)
+		self.parts.wpn_fps_ass_howa_b_para.custom_stats = deep_clone(barrels.short_b2_stats)
+
+		self.parts.wpn_fps_ass_howa_m_para.supported = true
+		self.parts.wpn_fps_ass_howa_m_para.stats = deep_clone(self.parts.wpn_fps_upg_m4_m_straight.stats)
+		self.parts.wpn_fps_ass_howa_m_para.custom_stats = deep_clone(self.parts.wpn_fps_upg_m4_m_straight.custom_stats)
+		self.parts.wpn_fps_ass_howa_m_supido.supported = true
+		self.parts.wpn_fps_ass_howa_m_supido.stats = deep_clone(self.parts.wpn_fps_m4_upg_m_quick.stats)
+
+		self.parts.wpn_fps_ass_howa_s_skeletal.supported = true
+		self.parts.wpn_fps_ass_howa_s_skeletal.stats = deep_clone(stocks.fixed_to_folder_stats)
+		self.parts.wpn_fps_ass_howa_s_skeletal.custom_stats = deep_clone(stocks.fixed_to_folder_stats)
+
+		self.parts.wpn_fps_ass_howa_t64_body.pcs = nil -- if you need a separate hold and reload animation why not just take the easy way and make it a different gun
+		self.parts.wpn_fps_ass_howa_s_wrapped.pcs = nil
+		self.parts.wpn_fps_ass_howa_bayonet.pcs = nil
 	end
 
 	if self.parts.wpn_fps_ass_mdr_308_barrel_sniper then

--- a/lua/sc/tweak_data/weapontweakdata.lua
+++ b/lua/sc/tweak_data/weapontweakdata.lua
@@ -17411,6 +17411,10 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 
 			if self.vsk94 then
 				self.vsk94.warsaw = true
+				self.vsk94.categories = {
+					"assault_rifle",
+					"dmr_l",
+				}
 				self.vsk94.recategorize = { "dmr_ar" }
 				self.vsk94.damage_type = "assault_rifle"
 				self.vsk94.CLIP_AMMO_MAX = 20
@@ -17455,6 +17459,108 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 				self.vsk94.stats_modifiers = nil
 				self.vsk94.panic_suppression_chance = 0.05
 				self.vsk94.timers = deep_clone(self.ak5.timers)
+			end
+
+			if self.ak556 then
+				self.ak556.nato = true
+				self.ak556.categories = {
+					"assault_rifle"
+				}
+				self.ak556.recategorize = {"light_ar"}
+				self.ak556.damage_type = "assault_rifle"
+				self.ak556.use_data.selection_index = 1
+				self.ak556.tactical_reload = 1
+				self.ak556.CLIP_AMMO_MAX = 30
+				self.ak556.AMMO_MAX = 75
+				self.ak556.fire_mode_data.fire_rate = 0.0923076923076923
+				self.ak556.auto.fire_rate = 0.0923076923076923
+				self.ak556.FIRE_MODE = "auto"
+				self.ak556.BURST_FIRE = false
+				self.ak556.CAN_TOGGLE_FIREMODE = true
+				self.ak556.sounds.fire = "m4_olympic_fire_single"
+				self.ak556.sounds.fire_single = "m4_olympic_fire_single"
+				self.ak556.sounds.fire_auto = "m4_olympic_fire"
+				self.ak556.sounds.stop_fire = "m4_olympic_stop"
+				self.ak556.kick = self.stat_info.kick_tables.right_recoil
+				self.ak556.kick_pattern = {
+					{0, self.stat_info.kick_tables.right_kick},
+					{6, self.stat_info.kick_tables.even_recoil},
+					{10, self.stat_info.kick_tables.pattern_l1},
+					{18, self.stat_info.kick_tables.left_kick},
+					{19, self.stat_info.kick_tables.right_recoil}
+				}
+				self.ak556.supported = true
+				self.ak556.ads_speed = 0.260
+				self.ak556.damage_falloff = {
+					start_dist = 2000,
+					end_dist = 6000,
+					min_mult = 0.5
+				}
+				self.ak556.stats = {
+					damage = 24,
+					spread = 77,
+					recoil = 85,
+					spread_moving = 6,
+					zoom = 1,
+					concealment = 27,
+					suppression = 8,
+					alert_size = 2,
+					extra_ammo = 101,
+					total_ammo_mod = 400,
+					value = 1,
+					reload = 20
+				}
+				self.ak556.stats_modifiers = nil
+				self.ak556.panic_suppression_chance = 0.05
+				self.ak556.timers = deep_clone(self.ak5.timers)
+			end
+
+			if self.mikon then
+				self.mikon.recategorize = { "light_ar" }
+				self.mikon.damage_type = "assault_rifle"
+				self.mikon.tactical_reload = 1
+				self.mikon.nato = true
+				self.mikon.BURST_FIRE = false
+				self.mikon.ADAPTIVE_BURST_SIZE = false
+				self.mikon.FIRE_MODE = "auto"
+				self.mikon.CLIP_AMMO_MAX = 30
+				self.mikon.AMMO_MAX = 150
+				self.mikon.fire_mode_data.fire_rate = 0.1
+				self.mikon.kick = self.stat_info.kick_tables.moderate_kick
+				self.mikon.kick_pattern = {
+					{0, self.stat_info.kick_tables.right_kick},
+					{9, self.stat_info.kick_tables.vertical_kick},
+					{11, self.stat_info.kick_tables.left_kick},
+					{15, self.stat_info.kick_tables.vertical_kick},
+					{20, self.stat_info.kick_tables.right_kick}
+				}
+				self.mikon.supported = true
+				self.mikon.ads_speed = 0.320
+				self.mikon.damage_falloff = {
+					start_dist = 3600,
+					end_dist = 7000,
+					min_mult = 0.5
+				}
+				self.mikon.stats = {
+					damage = 24,
+					spread = 84,
+					recoil = 77,
+					spread_moving = 6,
+					zoom = 1,
+					concealment = 24,
+					suppression = 9,
+					alert_size = 2,
+					extra_ammo = 101,
+					total_ammo_mod = 400,
+					value = 1,
+					reload = 20
+				}
+				self.mikon.stats_modifiers = nil
+				self.mikon.panic_suppression_chance = 0.05
+				self.mikon.lock_slide = true
+				self.mikon.reload_speed_multiplier = 1.05
+				self.mikon.sounds.magazine_empty = "wp_rifle_slide_lock"
+				self.mikon.timers = deep_clone(self.new_m4.timers)
 			end
 
 		--[[     ZDANN'S MODS     ]]--
@@ -20728,7 +20834,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 			if self.einhander then
 				self.einhander.recategorize = { "light_smg" }
 				self.einhander.damage_type = "machine_gun"
-				self.einhander.AMMO_MAX = 90
+				self.einhander.AMMO_MAX = 100
 				self.einhander.CLIP_AMMO_MAX = 60
 				self.einhander.FIRE_MODE = "auto"
 				self.einhander.fire_mode_data = {}
@@ -20751,9 +20857,9 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 					min_mult = 0.3
 				}
 				self.einhander.stats = {
-					damage = 20,
+					damage = 18,
 					spread = 54,
-					recoil = 81,
+					recoil = 91,
 					spread_moving = 10,
 					zoom = 1,
 					concealment = 28,
@@ -21438,6 +21544,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 				self.toz66.stats_modifiers = nil
 				self.toz66.reload_speed_multiplier = 1.1
 				self.toz66.panic_suppression_chance = 0.05
+				self.toz66.timers = deep_clone(self.huntsman.timers)
 				if BeardLib.Utils:FindMod("Restored Mosconi Reload Animation") then
 					self.toz66.animations.ignore_nonemptyreload = true
 				end
@@ -21590,6 +21697,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 				}
 				self.triple.stats_modifiers = nil
 				self.triple.panic_suppression_chance = 0.05
+				self.triple.timers = deep_clone(self.huntsman.timers)
 				if BeardLib.Utils:FindMod("Restored Mosconi Reload Animation") then
 					self.triple.animations.ignore_nonemptyreload = true
 				end
@@ -21800,6 +21908,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 				self.mk12.upgrade_blocks = nil
 				self.mk12.has_description = true
 				self.mk12.desc_id = "bm_ap_weapon_semi_sc_desc"
+				self.mk12.tactical_reload = 1
 				self.mk12.CLIP_AMMO_MAX = 20
 				self.mk12.AMMO_MAX = 72
 				self.mk12.FIRE_MODE = "single"
@@ -22403,6 +22512,8 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 				self.svt40.has_description = true
 				self.svt40.lock_slide = true
 				self.svt40.sounds.magazine_empty = "wp_rifle_slide_lock"
+				self.svt40.sounds.fire = "siltstone_fire"
+				self.svt40.sounds.fire_single = "siltstone_fire"
 				self.svt40.desc_id = "bm_ap_armor_75_weapon_sc_desc"
 				self.svt40.CLIP_AMMO_MAX = 10
 				self.svt40.tactical_reload = 1
@@ -22422,6 +22533,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 				self.svt40.can_shoot_through_shield = false
 				self.svt40.can_shoot_through_wall = false
 				self.svt40.supported = true
+				self.svt40.no_auto_anims = true
 				self.svt40.ads_speed = 0.300
 				self.svt40.damage_falloff = {
 					start_dist = 2500,
@@ -22548,6 +22660,314 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 				self.merkel.armor_piercing_chance = 1
 				self.merkel.reload_speed_multiplier = 0.8
 				self.merkel.timers = deep_clone(self.b682.timers)
+			end
+
+			if self.mas49 then
+				self.mas49.categories = {
+					"assault_rifle",
+					"dmr_h"
+				}
+				self.mas49.recategorize = { "dmr_ar" }
+				self.mas49.damage_type = "sniper"
+				self.mas49.upgrade_blocks = nil
+				self.mas49.has_description = true
+				self.mas49.lock_slide = true
+				self.mas49.sounds.magazine_empty = "wp_rifle_slide_lock"
+				self.mas49.desc_id = "bm_ap_armor_75_weapon_sc_desc"
+				self.mas49.CLIP_AMMO_MAX = 10
+				self.mas49.tactical_reload = 1
+				self.mas49.AMMO_MAX = 40
+				self.mas49.FIRE_MODE = "single"
+				self.mas49.fire_mode_data.fire_rate = 0.133333333
+				self.mas49.sms = sms_preset.semi_snp_light
+				self.mas49.kick = self.stat_info.kick_tables.vertical_kick
+				self.mas49.kick_pattern = {
+					{0, self.stat_info.kick_tables.vertical_kick},
+					{3, self.stat_info.kick_tables.right_kick},
+					{5, self.stat_info.kick_tables.vertical_kick},
+					{8, self.stat_info.kick_tables.moderate_right_kick}
+				}
+				self.mas49.can_shoot_through_enemy = true
+				self.mas49.can_shoot_through_enemy_unlim = true
+				self.mas49.can_shoot_through_shield = false
+				self.mas49.can_shoot_through_wall = false
+				self.mas49.supported = true
+				self.mas49.ads_speed = 0.300
+				self.mas49.damage_falloff = {
+					start_dist = 2200,
+					end_dist = 5400,
+					min_mult = 0.5
+				}
+				self.mas49.stats = {
+					damage = 90,
+					spread = 82,
+					recoil = 61,
+					spread_moving = 6,
+					zoom = 1,
+					concealment = 25,
+					suppression = 7,
+					alert_size = 2,
+					extra_ammo = 101,
+					total_ammo_mod = 400,
+					value = 9,
+					reload = 20
+				}
+				self.mas49.armor_piercing_chance = 0.75
+				self.mas49.stats_modifiers = nil
+				self.mas49.panic_suppression_chance = 0.05
+				self.mas49.timers = deep_clone(self.siltstone.timers)
+			end
+
+			if self.plr16 then
+				self.plr16.nato = true
+				self.plr16.categories = {
+					"assault_rifle",
+					"dmr_l"
+				}
+				self.plr16.recategorize = {"dmr_ar"}
+				self.plr16.damage_type = "assault_rifle"
+				self.plr16.AMMO_MAX = 48
+				self.plr16.CLIP_AMMO_MAX = 10
+				self.plr16.tactical_reload = 1
+				self.plr16.FIRE_MODE = "single"
+				self.plr16.fire_mode_data = {}
+				self.plr16.fire_mode_data.fire_rate = 0.1
+				self.plr16.kick = self.stat_info.kick_tables.moderate_right_kick
+				self.plr16.kick_pattern = {
+					{0, self.stat_info.kick_tables.vertical_kick},
+					{4, self.stat_info.kick_tables.moderate_kick},
+					{7, self.stat_info.kick_tables.right_kick},
+					{14, self.stat_info.kick_tables.moderate_left_kick},
+					{16, self.stat_info.kick_tables.moderate_right_kick},
+				}
+				self.plr16.rays = nil
+				self.plr16.supported = true
+				self.plr16.ads_speed = 0.200
+				self.plr16.damage_falloff = {
+					start_dist = 1400,
+					end_dist = 4000,
+					min_mult = 0.5
+				}
+				self.plr16.stats = {
+					damage = 20,
+					spread = 69,
+					recoil = 79,
+					spread_moving = 6,
+					zoom = 1,
+					concealment = 30,
+					suppression = 8,
+					alert_size = 2,
+					extra_ammo = 101,
+					total_ammo_mod = 400,
+					value = 1,
+					reload = 20
+				}
+				self.plr16.stats_modifiers = nil
+				self.plr16.hs_mult = 2.25
+				self.plr16.panic_suppression_chance = 0.05
+				self.plr16.reload_speed_multiplier = 1.4
+				self.plr16.timers = deep_clone(self.ak5.timers)
+			end
+
+			if self.m40a5 then
+				self.m40a5.categories = {
+					"snp"
+				}
+				self.m40a5.recategorize = { "light_snp" }
+				self.m40a5.damage_type = "sniper"
+				self.m40a5.always_play_anims = true
+				self.m40a5.has_description = true
+				self.m40a5.desc_id = "bm_ap_weapon_sc_desc"
+				self.m40a5.upgrade_blocks = nil
+				self.m40a5.CLIP_AMMO_MAX = 5
+				self.m40a5.AMMO_MAX = 40
+				self.m40a5.tactical_reload = 1
+				self.m40a5.fire_mode_data.fire_rate = 1
+				self.m40a5.fire_rate_multiplier = 1.11666666
+				self.m40a5.kick = self.stat_info.kick_tables.vertical_kick
+				self.m40a5.muzzleflash = "effects/payday2/particles/weapons/awp_muzzle"
+				self.m40a5.supported = true
+				self.m40a5.ads_speed = 0.340
+				self.m40a5.damage_falloff = {
+					start_dist = 4300,
+					end_dist = 9000,
+					min_mult = 0.5
+				}
+				self.m40a5.stats = {
+					damage = 90,
+					spread = 100,
+					recoil = 49,
+					spread_moving = 9,
+					zoom = 1,
+					concealment = 26,
+					suppression = 5,
+					alert_size = 2,
+					extra_ammo = 101,
+					total_ammo_mod = 400,
+					value = 9,
+					reload = 20
+				}
+				self.m40a5.stats_modifiers = nil
+				self.m40a5.panic_suppression_chance = 0.05
+				self.m40a5.armor_piercing_chance = 1
+				self.m40a5.reload_speed_multiplier = 1.2
+				self.m40a5.timers = deep_clone(self.model70.timers)
+			end
+
+			if self.xm21 then
+				self.xm21.nato = true
+				self.xm21.categories = {
+					"snp",
+					"semi_snp"
+				}
+				self.xm21.recategorize = { "light_snp" }
+				self.xm21.damage_type = "sniper"
+				self.xm21.upgrade_blocks = nil
+				self.xm21.has_description = true
+				self.xm21.lock_slide = true
+				self.xm21.sounds.magazine_empty = "wp_rifle_slide_lock"
+				self.xm21.desc_id = "bm_ap_weapon_semi_sc_desc"
+				self.xm21.CLIP_AMMO_MAX = 20
+				self.xm21.tactical_reload = 1
+				self.xm21.AMMO_MAX = 60
+				self.xm21.FIRE_MODE = "single"
+				self.xm21.fire_mode_data.fire_rate = 0.17142857
+				self.xm21.sms = sms_preset.semi_snp_light
+				self.xm21.kick = self.stat_info.kick_tables.vertical_kick
+				self.xm21.kick_pattern = {
+					{0, self.stat_info.kick_tables.right_kick},
+					{3, self.stat_info.kick_tables.left_kick},
+					{8, self.stat_info.kick_tables.even_recoil},
+					{11, self.stat_info.kick_tables.vertical_kick}
+				}
+				self.xm21.can_shoot_through_enemy = true
+				self.xm21.can_shoot_through_shield = true
+				self.xm21.can_shoot_through_wall = true
+				self.xm21.supported = true
+				self.xm21.ads_speed = 0.480
+				self.xm21.damage_falloff = {
+					start_dist = 2500,
+					end_dist = 7000,
+					min_mult = 0.5
+				}
+				self.xm21.stats = {
+					damage = 60,
+					spread = 85,
+					recoil = 37,
+					zoom = 1,
+					concealment = 22,
+					suppression = 8,
+					alert_size = 2,
+					extra_ammo = 101,
+					total_ammo_mod = 400,
+					value = 9,
+					reload = 20
+				}
+				self.xm21.armor_piercing_chance = 1
+				self.xm21.stats_modifiers = nil
+				self.xm21.panic_suppression_chance = 0.05
+				self.xm21.timers = deep_clone(self.new_m14.timers)
+			end
+
+			if self.l35 then
+				self.l35.recategorize = {"light_pis"}
+				self.l35.damage_type = "pistol"
+				self.l35.lock_slide = true
+				self.l35.AMMO_MAX = 75
+				self.l35.CLIP_AMMO_MAX = 8
+				self.l35.tactical_reload = 1
+				self.l35.fire_mode_data.fire_rate = 0.0882352
+				self.l35.kick = self.stat_info.kick_tables.right_recoil
+				self.l35.kick_pattern = {
+					{0, self.stat_info.kick_tables.even_recoil},
+					{4, self.stat_info.kick_tables.right_recoil}
+				}
+				self.l35.supported = true
+				self.l35.ads_speed = 0.120
+				self.l35.damage_falloff = {
+					start_dist = 1800,
+					end_dist = 4500,
+					min_mult = 0.25
+				}
+				self.l35.stats = {
+					damage = 24,
+					spread = 62,
+					recoil = 81,
+					spread_moving = 9,
+					zoom = 1,
+					concealment = 31,
+					suppression = 11,
+					alert_size = 2,
+					extra_ammo = 101,
+					total_ammo_mod = 400,
+					value = 1,
+					reload = 20
+				}
+				self.l35.stats_modifiers = nil
+				self.l35.panic_suppression_chance = 0.05
+				self.l35.reload_speed_multiplier = 1.15
+				self.l35.weapon_movement_penalty = 1.08
+				self.l35.stats_modifiers = nil
+				self.l35.timers = deep_clone(self.breech.timers)
+			end
+
+			if self.sigke7 then
+				self.sigke7.recategorize = { "heavy_mg" }
+				self.sigke7.categories = {
+					"lmg",
+					"smg",
+					"mmg",
+					"mmg_moving"
+				}
+				self.sigke7.damage_type = "machine_gun"
+				self.sigke7.CLIP_AMMO_MAX = 25
+				self.sigke7.BURST_FIRE = false
+				self.sigke7.CAN_TOGGLE_FIREMODE = true
+				self.sigke7.fire_mode_data.fire_rate = 0.1090909
+				self.sigke7.AMMO_MAX = 160
+				self.sigke7.kick = self.stat_info.kick_tables.random_right_recoil
+				self.sigke7.kick_pattern = {
+					{0, self.stat_info.kick_tables.random_left_recoil},
+					{8, self.stat_info.kick_tables.pattern_l2},
+					{10, self.stat_info.kick_tables.pattern_l1},
+					{14, self.stat_info.kick_tables.vertical_kick},
+					{20, self.stat_info.kick_tables.left_kick}
+				}
+				self.sigke7.muzzleflash = "_dmc/effects/heavy_muzzle"
+				self.sigke7.muzzleflash_silenced = "_dmc/effects/heavy_suppressed"
+				self.sigke7.supported = true
+				self.sigke7.ads_speed = 0.480
+				self.sigke7.damage_falloff = {
+					start_dist = 1600,
+					end_dist = 5800,
+					min_mult = 0.53333
+				}
+				self.sigke7.stats = {
+					damage = 45,
+					spread = 56,
+					recoil = 61,
+					spread_moving = 5,
+					zoom = 1,
+					concealment = 15,
+					suppression = 5,
+					alert_size = 2,
+					extra_ammo = 101,
+					total_ammo_mod = 400,
+					value = 9,
+					reload = 20
+				}
+				self.sigke7.stats_modifiers = nil
+				self.sigke7.panic_suppression_chance = 0.05
+				self.sigke7.sounds.spin_start = "wp_mg42_lever_release"
+				self.sigke7.spin_up_shoot = true
+				self.sigke7.spin_up_t = 0.08
+				self.sigke7.spin_down_t = 0.00000001
+				self.sigke7.reload_speed_multiplier = 0.8
+				self.sigke7.sms = sms_preset.lmg_90
+				self.sigke7.weapon_movement_penalty = sms_preset.lmg_90
+				self.sigke7.timers = deep_clone(self.fal.timers)
+				self.sigke7.timers.reload_empty = self.sigke7.timers.reload_not_empty
+				self.sigke7.timers.reload_exit_empty = self.sigke7.timers.reload_exit_not_empty
 			end
 
 			--Pawcio's GTAV Pack
@@ -23984,6 +24404,324 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 				self.tkpd.panic_suppression_chance = 0.05
 				self.tkpd.reload_speed_multiplier = 0.7
 				self.tkpd.timers = deep_clone(self.siltstone.timers)
+			end
+
+			if self.hipower then
+				self.hipower.recategorize = {"light_pis"}
+				self.hipower.has_description = false
+				self.hipower.tactical_reload = 1
+				self.hipower.fire_mode_data.fire_rate = 0.08571428571
+				self.hipower.single.fire_rate = 0.08571428571
+				self.hipower.CLIP_AMMO_MAX = 13
+				self.hipower.AMMO_MAX = 75
+				self.hipower.kick = self.stat_info.kick_tables.even_recoil
+				self.hipower.kick_pattern = {
+					{0, self.stat_info.kick_tables.even_recoil},
+					{3, self.stat_info.kick_tables.left_kick},
+					{7, self.stat_info.kick_tables.moderate_kick}
+				}
+				self.hipower.supported = true
+				self.hipower.ads_speed = 0.140
+				self.hipower.damage_falloff = {
+					start_dist = 1500,
+					end_dist = 3600,
+					min_mult = 0.25
+				}
+				self.hipower.stats = {
+					damage = 24,
+					spread = 60,
+					recoil = 89,
+					spread_moving = 5,
+					zoom = 1,
+					concealment = 31,
+					suppression = 11,
+					alert_size = 2,
+					extra_ammo = 101,
+					total_ammo_mod = 400,
+					value = 1,
+					reload = 20
+				}
+				self.hipower.stats_modifiers = nil
+				self.hipower.panic_suppression_chance = 0.05
+				self.hipower.reload_speed_multiplier = 1.2
+				self.hipower.timers = deep_clone(self.pl14.timers)
+
+					self.x_hipower.recategorize = {"light_pis"}
+					self.x_hipower.categories = {
+						"akimbo",
+						"pistol"
+					}
+					self.x_hipower.fire_mode_data.fire_rate =  0.08571428571
+					self.x_hipower.BURST_FIRE = {
+						count = 2,
+						delay = 0.15,
+						rof_mult = 4,
+						recoil_mult = 0.25,
+						last_recoil_mult = 1.05,
+					}
+					self.x_hipower.AMMO_MAX = 150
+					self.x_hipower.CLIP_AMMO_MAX = 26
+					self.x_hipower.tactical_reload = 2
+					self.x_hipower.lock_slide = true
+					self.x_hipower.kick = self.stat_info.kick_tables.even_recoil
+					self.x_hipower.kick_pattern = {
+						{0, self.stat_info.kick_tables.even_recoil},
+						{3, self.stat_info.kick_tables.left_kick},
+						{7, self.stat_info.kick_tables.moderate_kick}
+					}
+					self.x_hipower.supported = true
+					self.x_hipower.ads_speed = 0.140
+					self.x_hipower.damage_falloff = {
+						start_dist = 1500,
+						end_dist = 3600,
+						min_mult = 0.25
+					}
+					self.x_hipower.stats = {
+						damage = 24,
+						spread = 50,
+						recoil = 79,
+						spread_moving = 5,
+						zoom = 1,
+						concealment = 31,
+						suppression = 11,
+						alert_size = 2,
+						extra_ammo = 101,
+						total_ammo_mod = 400,
+						value = 1,
+						reload = 20
+					}
+					self.x_hipower.stats_modifiers = nil
+					self.x_hipower.panic_suppression_chance = 0.05
+					self.x_hipower.timers = deep_clone(self.x_b92fs.timers)
+			end
+
+			if self.xmassg then
+				self.xmassg.recategorize = { "break_shot" }
+				self.xmassg.categories = { "shotgun" }
+				self.xmassg.damage_type = "shotgun_heavy"
+				self.xmassg.damage_type_single_ray = "anti_materiel"
+				self.xmassg.rays = 8
+				self.xmassg.muzzleflash = "effects/payday2/particles/weapons/big_51b_auto_fps" --"effects/particles/shotgun/shotgun_gen"
+				self.xmassg.AMMO_MAX = 30
+				self.xmassg.sounds.fire_single = "huntsman_fire"
+				self.xmassg.sounds.fire_auto = "huntsman_fire"
+				self.xmassg.BURST_FIRE = {
+					count = 2,
+					delay = 0.15,
+					rof_mult = 5,
+					recoil_mult = 0.75,
+					last_recoil_mult = 1.25
+				}
+				self.xmassg.fire_mode_data = {}
+				self.xmassg.fire_mode_data.fire_rate = 0.2
+				self.xmassg.kick = self.stat_info.kick_tables.vertical_kick
+				self.xmassg.kick_pattern = {
+					{0, self.stat_info.kick_tables.vertical_kick},
+					{2, self.stat_info.kick_tables.pattern_r4},
+					{3, self.stat_info.kick_tables.pattern_v4},
+				}
+				self.xmassg.supported = true
+				self.xmassg.ads_speed = 0.380
+				self.xmassg.damage_falloff = {
+					start_dist = 700,
+					end_dist = 3200,
+					min_mult = 0.125
+				}
+				self.xmassg.stats = {
+					damage = 240,
+					spread = 66,
+					recoil = 41,
+					spread_moving = 6,
+					zoom = 1,
+					concealment = 23,
+					suppression = 6,
+					alert_size = 2,
+					extra_ammo = 101,
+					total_ammo_mod = 400,
+					value = 1,
+					reload = 20
+				}
+				self.xmassg.stats_modifiers = nil
+				self.xmassg.reload_speed_multiplier = 1.12
+				self.xmassg.timers = deep_clone(self.huntsman.timers)
+				self.xmassg.panic_suppression_chance = 0.05
+				if BeardLib.Utils:FindMod("Restored Mosconi Reload Animation") then
+					self.xmassg.animations.ignore_nonemptyreload = true
+				end
+			end
+
+			if self.bootl1911 then
+				self.bootl1911.recategorize = {"heavy_pis"}
+				self.bootl1911.damage_type = "heavy_pistol"
+				self.bootl1911.tactical_reload = 1
+				self.bootl1911.fire_mode_data.fire_rate = 0.11111111111
+				self.bootl1911.single.fire_rate = 0.11111111111
+				self.bootl1911.CLIP_AMMO_MAX = 8
+				self.bootl1911.AMMO_MAX = 40
+				self.bootl1911.kick = self.stat_info.kick_tables.even_recoil
+				self.bootl1911.kick_pattern = {
+					{0, self.stat_info.kick_tables.vertical_kick},
+					{3, self.stat_info.kick_tables.right_kick},
+					{6, self.stat_info.kick_tables.right_recoil}
+				}
+				self.bootl1911.supported = true
+				self.bootl1911.ads_speed = 0.160
+				self.bootl1911.damage_falloff = {
+					start_dist = 1000,
+					end_dist = 3000,
+					min_mult = 0.2
+				}
+				self.bootl1911.stats = {
+					damage = 45,
+					spread = 54,
+					recoil = 83,
+					spread_moving = 5,
+					zoom = 1,
+					concealment = 30,
+					suppression = 9,
+					alert_size = 2,
+					extra_ammo = 101,
+					total_ammo_mod = 400,
+					value = 1,
+					reload = 20
+				}
+				self.bootl1911.stats_modifiers = nil
+				self.bootl1911.panic_suppression_chance = 0.05
+				self.bootl1911.timers = deep_clone(self.pl14.timers)
+
+					self.x_bootl1911.recategorize = {"light_pis"}
+					self.x_bootl1911.categories = {
+						"akimbo",
+						"pistol"
+					}
+					self.x_bootl1911.fire_mode_data.fire_rate =  0.11111111111
+					self.x_bootl1911.BURST_FIRE = {
+						count = 2,
+						delay = 0.15,
+						rof_mult = 4,
+						recoil_mult = 0.25,
+						last_recoil_mult = 1.05,
+					}
+					self.x_bootl1911.AMMO_MAX = 80
+					self.x_bootl1911.CLIP_AMMO_MAX = 16
+					self.x_bootl1911.tactical_reload = 2
+					self.x_bootl1911.lock_slide = true
+					self.x_bootl1911.kick = self.stat_info.kick_tables.even_recoil
+					self.x_bootl1911.kick_pattern = {
+						{0, self.stat_info.kick_tables.vertical_kick},
+						{3, self.stat_info.kick_tables.right_kick},
+						{6, self.stat_info.kick_tables.right_recoil}
+					}
+					self.x_bootl1911.supported = true
+					self.x_bootl1911.ads_speed = 0.160
+					self.x_bootl1911.damage_falloff = {
+						start_dist = 1000,
+						end_dist = 3000,
+						min_mult = 0.2
+					}
+					self.x_bootl1911.stats = {
+						damage = 45,
+						spread = 44,
+						recoil = 73,
+						spread_moving = 5,
+						zoom = 1,
+						concealment = 30,
+						suppression = 9,
+						alert_size = 2,
+						extra_ammo = 101,
+						total_ammo_mod = 400,
+						value = 1,
+						reload = 20
+					}
+					self.x_bootl1911.stats_modifiers = nil
+					self.x_bootl1911.panic_suppression_chance = 0.05
+					self.x_bootl1911.timers = deep_clone(self.x_b92fs.timers)
+			end
+
+			if self.fnp45 then
+				self.fnp45.recategorize = { "heavy_pis" }
+				self.fnp45.damage_type = "heavy_pistol"
+				self.fnp45.fire_mode_data.fire_rate = 0.122448979
+				self.fnp45.CLIP_AMMO_MAX = 15
+				self.fnp45.AMMO_MAX = 40
+				self.fnp45.kick = self.stat_info.kick_tables.right_recoil
+				self.fnp45.kick_pattern = {
+					{0, self.stat_info.kick_tables.right_kick},
+					{3, self.stat_info.kick_tables.moderate_kick},
+					{7, self.stat_info.kick_tables.right_recoil}
+				}
+				self.fnp45.supported = true
+				self.fnp45.ads_speed = 0.200
+				self.fnp45.damage_falloff = {
+					start_dist = 1200,
+					end_dist = 3800,
+					min_mult = 0.2
+				}
+				self.fnp45.stats = {
+					damage = 45,
+					spread = 61,
+					recoil = 77,
+					spread_moving = 8,
+					zoom = 1,
+					concealment = 27,
+					suppression = 9,
+					alert_size = 2,
+					extra_ammo = 101,
+					total_ammo_mod = 400,
+					value = 1,
+					reload = 20
+				}
+				self.fnp45.stats_modifiers = nil
+				self.fnp45.reload_speed_multiplier = 1.05
+				self.fnp45.panic_suppression_chance = 0.05
+				self.fnp45.timers = deep_clone(self.packrat.timers)
+			end
+
+			if self.nightgoddess then
+				self.nightgoddess.warsaw = true
+				self.nightgoddess.recategorize = { "heavy_ar" }
+				self.nightgoddess.damage_type = "assault_rifle"
+				self.nightgoddess.CLIP_AMMO_MAX = 30
+				self.nightgoddess.tactical_reload = 1
+				self.nightgoddess.AMMO_MAX = 120
+				self.nightgoddess.desc_id = "bm_mod3_sc_desc"
+				self.nightgoddess.has_description = true
+				self.nightgoddess.fire_mode_data.fire_rate = 0.06666666666
+				self.nightgoddess.auto.fire_rate = 0.06666666666
+				self.nightgoddess.kick = self.stat_info.kick_tables.moderate_right_kick
+				self.nightgoddess.kick_pattern = {
+					{0, self.stat_info.kick_tables.moderate_kick},
+					{4, self.stat_info.kick_tables.right_kick},
+					{6, self.stat_info.kick_tables.right_recoil},
+					{7, self.stat_info.kick_tables.right_kick},
+					{11, self.stat_info.kick_tables.vertical_kick},
+					{12, self.stat_info.kick_tables.right_kick}
+				}
+				self.nightgoddess.supported = true
+				self.nightgoddess.ads_speed = 0.260
+				self.nightgoddess.armor_piercing_chance = 0.25
+				self.nightgoddess.damage_falloff = {
+					start_dist = 1000,
+					end_dist = 3800,
+					min_mult = 0.6
+				}
+				self.nightgoddess.stats = {
+					damage = 30,
+					spread = 72,
+					recoil = 83,
+					spread_moving = 6,
+					zoom = 1,
+					concealment = 27,
+					suppression = 8,
+					alert_size = 2,
+					extra_ammo = 101,
+					total_ammo_mod = 400,
+					value = 1,
+					reload = 20
+				}
+				self.nightgoddess.stats_modifiers = nil
+				self.nightgoddess.panic_suppression_chance = 0.05
+				self.nightgoddess.timers = deep_clone(self.akmsu.timers)
 			end
 
 		--[[     RJC9000'S MODS     ]]--
@@ -30099,6 +30837,50 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 				self.x_m3.timers.reload_exit_empty = self.m3.timers.reload_exit_not_empty
 			end
 
+			if self.candy then
+				self.candy.recategorize = { "heavy_shot" }
+				self.candy.damage_type = "shotgun_heavy"
+				self.candy.damage_type_single_ray = "sniper"
+				self.candy.has_description = false
+				self.candy.tactical_reload = 1
+				self.candy.rays = 8
+				self.candy.CLIP_AMMO_MAX = 5
+				self.candy.AMMO_MAX = 20
+				self.candy.fire_mode_data.fire_rate = 0.6
+				self.candy.muzzleflash = "effects/payday2/particles/weapons/big_51b_auto_fps" --"effects/particles/shotgun/shotgun_gen"
+				self.candy.kick = self.stat_info.kick_tables.left_kick
+				self.candy.kick_pattern = {
+					{0, self.stat_info.kick_tables.vertical_kick},
+					{3, self.stat_info.kick_tables.right_kick},
+					{4, self.stat_info.kick_tables.random_recoil}
+				}
+				self.candy.fire_rate_multiplier = 0.85
+				self.candy.supported = true
+				self.candy.ads_speed = 0.280
+				self.candy.damage_falloff = {
+					start_dist = 800,
+					end_dist = 2600,
+					min_mult = 0.1333
+				}
+				self.candy.stats = {
+					damage = 180,
+					spread = 63,
+					recoil = 49,
+					spread_moving = 6,
+					zoom = 1,
+					concealment = 23,
+					suppression = 7,
+					alert_size = 2,
+					extra_ammo = 101,
+					total_ammo_mod = 400,
+					value = 1,
+					reload = 20
+				}
+				self.candy.stats_modifiers = {damage = 1}
+				self.candy.panic_suppression_chance = 0.05
+				self.candy.timers = deep_clone(self.m1897.timers)
+			end
+
 			if self.nothing then --Silent Enforcer's No Wep
 				self.nothing.recategorize = { "wpn_special" }
 				self.nothing.fire_mode_data.fire_rate = 0.8695652
@@ -31039,6 +31821,98 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 			self.bren2.timers = deep_clone(self.new_m4.timers)
 		end
 
+		if self.pdw then
+			self.pdw.recategorize = {"light_smg"}
+			self.pdw.damage_type = "machine_gun"
+			self.pdw.tactical_reload = 1
+			self.pdw.BURST_FIRE = false
+			self.pdw.ADAPTIVE_BURST_SIZE = false
+			self.pdw.FIRE_MODE = "auto"
+			self.pdw.CLIP_AMMO_MAX = 30
+			self.pdw.AMMO_MAX = 75
+			self.pdw.fire_mode_data.fire_rate = 0.08571428571
+			self.pdw.kick = self.stat_info.kick_tables.moderate_kick
+			self.pdw.kick_pattern = {
+				{0, self.stat_info.kick_tables.right_kick},
+				{9, self.stat_info.kick_tables.vertical_kick},
+				{11, self.stat_info.kick_tables.left_kick},
+				{15, self.stat_info.kick_tables.vertical_kick},
+				{20, self.stat_info.kick_tables.right_kick}
+			}
+			self.pdw.supported = true
+			self.pdw.ads_speed = 0.200
+			self.pdw.damage_falloff = {
+				start_dist = 2500,
+				end_dist = 3500,
+				min_mult = 0.5
+			}
+			self.pdw.stats = {
+				damage = 24,
+				spread = 71,
+				recoil = 77,
+				spread_moving = 6,
+				zoom = 1,
+				concealment = 27,
+				suppression = 9,
+				alert_size = 2,
+				extra_ammo = 101,
+				total_ammo_mod = 400,
+				value = 1,
+				reload = 20
+			}
+			self.pdw.stats_modifiers = nil
+			self.pdw.panic_suppression_chance = 0.05
+			self.pdw.lock_slide = true
+			self.pdw.sounds.magazine_empty = "wp_rifle_slide_lock"
+			self.pdw.timers = deep_clone(self.new_m4.timers)
+		end
+
+		if self.iso then
+			self.iso.recategorize = {"light_smg"}
+			self.iso.damage_type = "machine_gun"
+			self.iso.tactical_reload = 1
+			self.iso.BURST_FIRE = false
+			self.iso.ADAPTIVE_BURST_SIZE = false
+			self.iso.FIRE_MODE = "auto"
+			self.iso.CLIP_AMMO_MAX = 20
+			self.iso.AMMO_MAX = 90
+			self.iso.fire_mode_data.fire_rate = 0.055555555555555
+			self.iso.kick = self.stat_info.kick_tables.even_recoil
+			self.iso.kick_pattern = {
+				{0, self.stat_info.kick_tables.pattern_r2},
+				{3, self.stat_info.kick_tables.pattern_r1},
+				{5, self.stat_info.kick_tables.moderate_right_kick},
+				{9, self.stat_info.kick_tables.right_recoil},
+				{13, self.stat_info.kick_tables.even_recoil}
+			}
+			self.iso.supported = true
+			self.iso.ads_speed = 0.180
+			self.iso.damage_falloff = {
+				start_dist = 1000,
+				end_dist = 3300,
+				min_mult = 0.3
+			}
+			self.iso.stats = {
+				damage = 20,
+				spread = 58,
+				recoil = 79,
+				spread_moving = 8,
+				zoom = 1,
+				concealment = 29,
+				suppression = 11,
+				alert_size = 2,
+				extra_ammo = 101,
+				total_ammo_mod = 400,
+				value = 1,
+				reload = 20
+			}
+			self.iso.stats_modifiers = nil
+			self.iso.panic_suppression_chance = 0.05
+			self.iso.lock_slide = true
+			self.iso.sounds.magazine_empty = "wp_rifle_slide_lock"
+			self.iso.timers = deep_clone(self.shepheard.timers)
+		end
+
 		if self.fg42 then --Killerwolf's FG42
 			self.fg42.categories = {
 				"assault_rifle",
@@ -31326,6 +32200,51 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 			self.kar98k.timers = deep_clone(self.mosin.timers)
 		end
 
+		if self.degle then
+			self.degle.recategorize = { "heavy_pis", "handcannon" }
+			self.degle.bmp = 1337
+			self.degle.desc_id = "bm_ap_armor_weapon_sc_desc"
+			self.degle.has_description = true
+			self.degle.damage_type = "handcannon"
+			self.degle.fire_mode_data.fire_rate = 0.4
+			self.degle.use_data.selection_index = 2
+			self.degle.muzzleflash = "effects/payday2/particles/weapons/big_51b_auto_fps"
+			self.degle.AMMO_MAX = 60
+			self.degle.CLIP_AMMO_MAX = 7
+			self.degle.kick = self.stat_info.kick_tables.vertical_kick
+			self.degle.kick_pattern = {
+				{1, self.stat_info.kick_tables.right_kick},
+				{3, self.stat_info.kick_tables.vertical_kick},
+				{3, self.stat_info.kick_tables.right_kick},
+				{7, self.stat_info.kick_tables.vertical_kick}
+			}
+			self.degle.supported = true
+			self.degle.ads_speed = 0.1337
+			self.degle.damage_falloff = {
+				start_dist = 1337,
+				end_dist = 9001,
+				min_mult = 0.00833333333
+			}
+			self.degle.stats = {
+				damage = 60,
+				spread = 51,
+				recoil = 101,
+				spread_moving = 6,
+				zoom = 1,
+				concealment = 32,
+				suppression = 20,
+				alert_size = 1,
+				extra_ammo = 101,
+				total_ammo_mod = 400,
+				value = 1,
+				reload = 20
+			}
+			self.degle.stats_modifiers = nil
+			self.degle.panic_suppression_chance = 0.05
+			self.degle.armor_piercing_chance = 1
+			self.degle.timers = deep_clone(self.deagle.timers)
+		end
+
 		if self.enfield_no5i then
 			self.enfield_no5i.categories = {
 				"snp"
@@ -31607,6 +32526,46 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 			self.dp12.panic_suppression_chance = 0.05
 			self.dp12.timers.shotgun_reload_exit_not_empty = 0.9
 			self.dp12.timers.shotgun_reload_exit_empty = 0.9
+		end
+
+		if self.chinesium then
+			self.chinesium.recategorize = { "heavy_pis" }
+			self.chinesium.damage_type = "heavy_pistol"
+			self.chinesium.fire_mode_data.fire_rate = 0.1263157894
+			self.chinesium.CLIP_AMMO_MAX = 10
+			self.chinesium.AMMO_MAX = 40
+			self.chinesium.kick = self.stat_info.kick_tables.right_recoil
+			self.chinesium.kick_pattern = {
+				{0, self.stat_info.kick_tables.vertical_kick},
+				{3, self.stat_info.kick_tables.right_kick},
+				{6, self.stat_info.kick_tables.right_recoil}
+			}
+			self.chinesium.supported = true
+			self.chinesium.armor_piercing_chance = 0
+			self.chinesium.ads_speed = 0.200
+			self.chinesium.damage_falloff = {
+				start_dist = 1800,
+				end_dist = 4000,
+				min_mult = 0.2222
+			}
+			self.chinesium.stats = {
+				damage = 45,
+				spread = 62,
+				recoil = 89,
+				spread_moving = 7,
+				zoom = 1,
+				concealment = 29,
+				suppression = 9,
+				alert_size = 2,
+				extra_ammo = 101,
+				total_ammo_mod = 400,
+				value = 4,
+				reload = 20
+			}
+			self.chinesium.stats_modifiers = nil
+			self.chinesium.reload_speed_multiplier = 1.05
+			self.chinesium.panic_suppression_chance = 0.05
+			self.chinesium.timers = deep_clone(self.p226.timers)
 		end
 
 		if self.abzats then
@@ -31974,6 +32933,55 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 				self.x_sw659.timers = deep_clone(self.x_b92fs.timers)
 		end
 
+		if self.howa then
+			self.howa.nato = true
+			self.howa.categories = {
+				"assault_rifle"
+			}
+			self.howa.recategorize = {"light_ar"}
+			self.howa.damage_type = "assault_rifle"
+			self.howa.tactical_reload = 1
+			self.howa.CLIP_AMMO_MAX = 30
+			self.howa.AMMO_MAX = 150
+			self.howa.fire_mode_data.fire_rate = 0.08
+			self.howa.auto.fire_rate = 0.08
+			self.howa.FIRE_MODE = "auto"
+			self.howa.BURST_FIRE = false
+			self.howa.CAN_TOGGLE_FIREMODE = true
+			self.howa.kick = self.stat_info.kick_tables.right_recoil
+			self.howa.kick_pattern = {
+				{0, self.stat_info.kick_tables.right_kick},
+				{6, self.stat_info.kick_tables.even_recoil},
+				{10, self.stat_info.kick_tables.pattern_l1},
+				{18, self.stat_info.kick_tables.left_kick},
+				{19, self.stat_info.kick_tables.right_recoil}
+			}
+			self.howa.supported = true
+			self.howa.ads_speed = 0.300
+			self.howa.damage_falloff = {
+				start_dist = 2700,
+				end_dist = 7000,
+				min_mult = 0.5
+			}
+			self.howa.stats = {
+				damage = 24,
+				spread = 85,
+				recoil = 77,
+				spread_moving = 6,
+				zoom = 1,
+				concealment = 24,
+				suppression = 8,
+				alert_size = 2,
+				extra_ammo = 101,
+				total_ammo_mod = 400,
+				value = 1,
+				reload = 20
+			}
+			self.howa.stats_modifiers = nil
+			self.howa.panic_suppression_chance = 0.05
+			self.howa.timers = deep_clone(self.ak5.timers)
+		end
+
 		if self.mdr_308 then --H.H. Hartmann's MDRX
 			self.mdr_308.categories = {
 				"assault_rifle",
@@ -32291,6 +33299,7 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 			self.dl.AMMO_MAX = 24
 			self.dl.fire_mode_data.fire_rate = 1
 			self.dl.kick = self.stat_info.kick_tables.vertical_kick
+			self.dl.shell_ejection = "effects/payday2/particles/weapons/shells/shell_9mm"
 			self.dl.supported = true
 			self.dl.ads_speed = 0.320
 			self.dl.damage_falloff = {


### PR DESCRIPTION
New weapons : 
- Pistols : AM D114 (& akimbo), Browning High Power (& akimbo) (Mira's version), FNP-45, Lahti L-35, NP762
- SMGs : B&T APC-9, KAC PDW, 
- Shotguns : Candy Shotgun, Gingerbread Shotgun
- ARs : AK 5.56, AS VAL Mod 3, Howa 89, Malyuk (was only partially supported), PLR-16, Remington R5, 
- Snipers : M40A5, MAS-49, XM21
- Machine-guns : SIG KE7
- Weapons of mass destruction : Degle .50

- Added description to attachments that remove integrated suppressors (like the Val's proto barrel)
- Changed the Einhander to the 36 damage tier.
- The SVT-40 shouldn't break with the autofire mod on. Make sure to sell and re-buy the weapons to make sure you don't have any screwy rifles left.
- Fixed the De Lisle ejecting rifle casings.
- Added proper ammunition overrides for previously supported shotguns.
