### PR TITLE
Allow certain contours to show through walls even on loud Pro Jobs

### DIFF
--- a/lua/sc/managers/gameplaycentralmanager.lua
+++ b/lua/sc/managers/gameplaycentralmanager.lua
@@ -112,8 +112,8 @@ function GamePlayCentralManager:set_flashlights_on(flashlights_on)
 	end
 end
 
--- This need for PJ outlines changes (for 6th sense skill)
-Hooks:OverrideFunction(GamePlayCentralManager, "auto_highlight_enemy", function(self, unit, use_player_upgrades)
+-- The added 'context' field allows for changing the contour based on the context the highlighting was applied.
+Hooks:OverrideFunction(GamePlayCentralManager, "auto_highlight_enemy", function(self, unit, use_player_upgrades, context)
 	self._auto_highlighted_enemies = self._auto_highlighted_enemies or {}
 
 	if self._auto_highlighted_enemies[unit:key()] and Application:time() < self._auto_highlighted_enemies[unit:key()] then
@@ -127,26 +127,25 @@ Hooks:OverrideFunction(GamePlayCentralManager, "auto_highlight_enemy", function(
 	end
 
 	local time_multiplier = 1
-	local contour_type = "mark_enemy_sixth_sense" -- default outline for 6th sense
+	local contour_type = "mark_enemy"
+	local wallhack = false
 
 	if unit:base() and unit:base().is_security_camera then
 		contour_type = "mark_unit"
 		time_multiplier = managers.player:upgrade_value("player", "mark_enemy_time_multiplier", 1)
-    elseif use_player_upgrades then
-        contour_type = managers.player:get_contour_for_marked_enemy(unit:base().get_type and unit:base():get_type()) or contour_type
-        -- Different check because `get_contour_for_marked_enemy` will return wrong outline otherwise
-        if managers.player:has_category_upgrade("player", "marked_enemy_extra_damage") then
-            contour_type = "mark_enemy_damage_bonus"
-        end
+	elseif use_player_upgrades then
+		contour_type = managers.player:get_contour_for_marked_enemy(unit:base().get_type and unit:base():get_type()) or contour_type
+		time_multiplier = managers.player:upgrade_value("player", "mark_enemy_time_multiplier", 1)
+	end
 
-        if managers.player:has_category_upgrade("player", "marked_inc_dmg_distance") then
-            contour_type = "mark_enemy_damage_bonus_distance"
-        end
-        
-        time_multiplier = managers.player:upgrade_value("player", "mark_enemy_time_multiplier", 1)
-    end
+	local context = context or "none"
 
-	unit:contour():add(contour_type, true, time_multiplier)
+	-- Trip mines, Sixth Sense Basic, and ADS (if applicable) allow for marking through walls, even during a Pro Job.
+	if context == "trip_mine" or context == "sixth_sense" or context == "steelsight" then
+		wallhack = true
+	end
+
+	unit:contour():add(contour_type, true, time_multiplier, nil, nil, wallhack)
 
 	return true
 end)

--- a/lua/sc/units/contourext.lua
+++ b/lua/sc/units/contourext.lua
@@ -22,20 +22,11 @@ ContourExt._types.deployable_blackout = { --for autumn's deployable disabling ab
 	priority = 1,
 	color = Vector3(0.5,0,1)
 }
-ContourExt._types.mark_enemy_sixth_sense = { -- 6th sense still will be useful with new PJ contours changes
-	fadeout = 4.5,
-	priority = 5,
-	material_swap_required = true,
-	fadeout_silent = 13.5,
-	--trigger_marked_event = true,
-	color = tweak_data.contour.character.dangerous_color
-}
-ContourExt._types.mark_enemy.priority = 6 -- Need lower priority for new 6th sense outline
 
 -- PJ modifier: Marked enemy will show contour only in LoS (unless you using any marking skills); Medic and LPF flash outlines are disabled;
 if is_pro_job then
 	ContourExt._types.mark_enemy.ray_check_reverse = true
-	--ContourExt._types.mark_unit.ray_check_reverse = true
+	ContourExt._types.mark_unit.ray_check_reverse = true
 	ContourExt._types.medic_show.color = Vector3(0,0,0)
 	ContourExt._types.medic_show.priority = 10
 	ContourExt._types.omnia_heal.color = Vector3(0,0,0)
@@ -59,7 +50,7 @@ local deployable_contours = {
 	"deployable_interactable"
 }
 
-Hooks:OverrideFunction(ContourExt, "add", function(self, type, sync, multiplier, override_color, is_element)
+Hooks:OverrideFunction(ContourExt, "add", function(self, type, sync, multiplier, override_color, is_element, wallhack)
 local disable_outlines = managers.mutators:modify_value("ContourExt:DisableOutlines", false)
 local do_outline = true
 
@@ -168,6 +159,7 @@ if do_outline then
 		fadeout_start_t = fadeout_start_t_dummy or nil,
 		fadeout_length = fadeout_length_dummy or nil,
 		color = override_color or nil,
+		wallhack = wallhack or false,
 		data = data
 	}
 
@@ -180,7 +172,7 @@ if do_outline then
 		end
 	end
 	
-	if data.ray_check_reverse then
+	if data.ray_check_reverse and not setup.wallhack then
 		setup.upd_skip_count_reverse = ContourExt.raycast_update_skip_count
 		local mov_ext = self._unit:movement()
 
@@ -293,7 +285,7 @@ if self.fadeout_start_percent == nil then -- for Vanilla Contours
 				end
 			end
 			--for PJ
-			if is_current and setup.data.ray_check_reverse and not managers.groupai:state():whisper_mode() then
+			if is_current and setup.data.ray_check_reverse and not setup.wallhack and not managers.groupai:state():whisper_mode() then
 				if setup.upd_skip_count_reverse > 0 then
 					setup.upd_skip_count_reverse = setup.upd_skip_count_reverse - 1
 
@@ -348,7 +340,7 @@ if self.fadeout_start_percent == nil then -- for Vanilla Contours
 			end
 
 			if is_current then
-				if setup.data.ray_check_reverse and not managers.groupai:state():whisper_mode() then
+				if setup.data.ray_check_reverse and not setup.wallhack and not managers.groupai:state():whisper_mode() then
 					if turn_off then
 						self:_upd_opacity(self.mod_lerp_opacity and setup.fadeout_t and math.lerp(1, 0, t / setup.fadeout_t) or 1)	
 					else
@@ -392,7 +384,7 @@ else -- for Smooth Contours
 				end
 			end
 			-- for PJ
-			if is_current and data.ray_check_reverse and not managers.groupai:state():whisper_mode() then
+			if is_current and data.ray_check_reverse and not setup.wallhack and not managers.groupai:state():whisper_mode() then
 				local turn_on = nil
 				local cam_pos = managers.viewport:get_current_camera_position()
 				if cam_pos then
@@ -431,7 +423,7 @@ else -- for Smooth Contours
 			
 
 			if opacity then
-				if data.ray_check_reverse and not managers.groupai:state():whisper_mode() then
+				if data.ray_check_reverse and not setup.wallhack and not managers.groupai:state():whisper_mode() then
 					if turn_off then
 						self:_upd_opacity(opacity)	
 					else

--- a/lua/sc/units/player/playerstandard.lua
+++ b/lua/sc/units/player/playerstandard.lua
@@ -1823,7 +1823,7 @@ function PlayerStandard:_update_omniscience(t, dt)
 				if not self._state_data.omniscience_units_detected[unit:key()] or self._state_data.omniscience_units_detected[unit:key()] <= t then
 					self._state_data.omniscience_units_detected[unit:key()] = t + tweak_data.player.omniscience.target_resense_t
 
-					managers.game_play_central:auto_highlight_enemy(unit, true)
+					managers.game_play_central:auto_highlight_enemy(unit, true, "sixth_sense")
 					break
 				end
 			end

--- a/lua/sc/units/weapons/newraycastweaponbase.lua
+++ b/lua/sc/units/weapons/newraycastweaponbase.lua
@@ -2629,6 +2629,37 @@ function NewRaycastWeaponBase:_set_parts_visible(visible)
 	self:_chk_charm_upd_state()
 end
 
+-- Adds context to the highlighting to support marking enemies through walls in Pro Job.
+function NewRaycastWeaponBase:check_highlight_unit(unit)
+	if not self._can_highlight then
+		return
+	end
+
+	if not self._can_highlight_with_skill and self:is_second_sight_on() then
+		return
+	end
+
+	if unit:in_slot(8) and alive(unit:parent()) then
+		unit = unit:parent() or unit
+	end
+
+	if not unit or not unit:base() then
+		return
+	end
+
+	if unit:character_damage() and unit:character_damage().dead and unit:character_damage():dead() then
+		return
+	end
+
+	local is_enemy_in_cool_state = managers.enemy:is_enemy(unit) and not managers.groupai:state():enemy_weapons_hot()
+
+	if not is_enemy_in_cool_state and not unit:base().can_be_marked then
+		return
+	end
+
+	managers.game_play_central:auto_highlight_enemy(unit, true, "steelsight")
+end
+
 local g3_niphen = restoration.Options:GetValue("WEAPONS/WEAPONANIMS/g3_niphen")
 
 Hooks:PostHook(NewRaycastWeaponBase, "weapon_tweak_data", "res_weapon_tweak_data", function(self)

--- a/lua/sc/units/weapons/trip_mine/tripminebase.lua
+++ b/lua/sc/units/weapons/trip_mine/tripminebase.lua
@@ -20,7 +20,7 @@ function TripMineBase:_sensor(t)
 			self._sensor_units_detected[ray.unit:key()] = true
 
 			if managers.player:has_category_upgrade("trip_mine", "sensor_highlight") then
-				managers.game_play_central:auto_highlight_enemy(ray.unit, true)
+				managers.game_play_central:auto_highlight_enemy(ray.unit, true, "trip_mine")
 				self:_emit_sensor_sound_and_effect()
 
 				if managers.network:session() then


### PR DESCRIPTION
This PR allows for Sixth Sense, Trip Mines, and ADS, with the relevant skills / perks like Alert Aced, to show marks through walls even on Loud Pro Jobs. Shouting without relevant skills / perks like Spotter still makes the mark not show through walls.

The changes in this PR as follows.
- Rewrote `GamePlayCentralManager:auto_highlight_enemy`:
  - Removed the Sixth Sense outline setup. From what I can see, this was added when the decision was made to not show outlines through walls in Loud Pro Jobs. The default `mark_enemy` countour was set up to disappear so, and a new contour named after Sixth Sense was added, which did not have that set up.
  - Largely reverted the above function to its vanilla counterpart. The addition of `get_contour_for_marked_enemy` to it to fix trip mines not marking undid the Sixth Sense fix I mentioned above. `get_contour_for_marked_enemy` returned `mark_enemy` in most cases, which overwrote `mark_enemy_sixth_sense`.
  - The duplicate logic for setting the contour type was removed, as since we're calling `get_contour_for_marked_enemy` anyway, there's no point in keeping it in `auto_highlight_enemy`.
  - Added a `context` parameter that can supply, well, context. Currently only used for "wallhacks" for contours created. See below for that.
- Changed the contours:
  - Removed the Sixth Sense contour, per the reasoning at the top.
  - Added the `wallhack` parameter to `ContourExt:add` and to the contour setup struct. If this is set to true, the contour ignores the loud Pro Job limitation of only showing in Line of Sight.
- For Sixth Sense, Trip Mines, and ADS (with the relevant skills / perks), a matching context is added for the highlighting.