### PR TITLE
"Fix" wallhack contours not being synced

### DIFF
--- a/lua/sc/managers/gameplaycentralmanager.lua
+++ b/lua/sc/managers/gameplaycentralmanager.lua
@@ -135,7 +135,7 @@ Hooks:OverrideFunction(GamePlayCentralManager, "auto_highlight_enemy", function(
 	elseif use_player_upgrades then
 		contour_type = managers.player:get_contour_for_marked_enemy(unit:base().get_type and unit:base():get_type()) or contour_type
 
-		-- Trip mines, Sixth Sense Basic, and ADS (if applicable) "upgrade" the default mark_enemy contour to be visible_if_locked through walls even during a Pro Job.
+		-- Trip mines, Sixth Sense Basic, and ADS (if applicable) "upgrade" the default mark_enemy contour to be visible through walls even during a Pro Job.
 		if (context == "trip_mine" or context == "sixth_sense" or context == "steelsight") and contour_type == "mark_enemy" then
 			contour_type = "mark_enemy_through_walls"
 		end

--- a/lua/sc/managers/gameplaycentralmanager.lua
+++ b/lua/sc/managers/gameplaycentralmanager.lua
@@ -128,24 +128,24 @@ Hooks:OverrideFunction(GamePlayCentralManager, "auto_highlight_enemy", function(
 
 	local time_multiplier = 1
 	local contour_type = "mark_enemy"
-	local wallhack = false
 
 	if unit:base() and unit:base().is_security_camera then
 		contour_type = "mark_unit"
 		time_multiplier = managers.player:upgrade_value("player", "mark_enemy_time_multiplier", 1)
 	elseif use_player_upgrades then
 		contour_type = managers.player:get_contour_for_marked_enemy(unit:base().get_type and unit:base():get_type()) or contour_type
+
+		-- Trip mines, Sixth Sense Basic, and ADS (if applicable) "upgrade" the default mark_enemy contour to be visible_if_locked through walls even during a Pro Job.
+		if (context == "trip_mine" or context == "sixth_sense" or context == "steelsight") and contour_type == "mark_enemy" then
+			contour_type = "mark_enemy_through_walls"
+		end
+
 		time_multiplier = managers.player:upgrade_value("player", "mark_enemy_time_multiplier", 1)
 	end
 
 	local context = context or "none"
 
-	-- Trip mines, Sixth Sense Basic, and ADS (if applicable) allow for marking through walls, even during a Pro Job.
-	if context == "trip_mine" or context == "sixth_sense" or context == "steelsight" then
-		wallhack = true
-	end
-
-	unit:contour():add(contour_type, true, time_multiplier, nil, nil, wallhack)
+	unit:contour():add(contour_type, true, time_multiplier)
 
 	return true
 end)

--- a/lua/sc/units/contourext.lua
+++ b/lua/sc/units/contourext.lua
@@ -22,6 +22,16 @@ ContourExt._types.deployable_blackout = { --for autumn's deployable disabling ab
 	priority = 1,
 	color = Vector3(0.5,0,1)
 }
+-- Equivalent to mark_enemy except in priority (and Pro Jobs not enabling ray_check_reverse for it).
+ContourExt._types.mark_enemy_through_walls = {
+	fadeout = 4.5,
+	priority = 5,
+	material_swap_required = true,
+	fadeout_silent = 13.5,
+	trigger_marked_event = true,
+	color = tweak_data.contour.character.dangerous_color
+}
+ContourExt._types.mark_enemy.priority = 6 -- Lower priority for mark_enemy so that mark_enemy_through_walls can overwrite it.
 
 -- PJ modifier: Marked enemy will show contour only in LoS (unless you using any marking skills); Medic and LPF flash outlines are disabled;
 if is_pro_job then
@@ -50,7 +60,7 @@ local deployable_contours = {
 	"deployable_interactable"
 }
 
-Hooks:OverrideFunction(ContourExt, "add", function(self, type, sync, multiplier, override_color, is_element, wallhack)
+Hooks:OverrideFunction(ContourExt, "add", function(self, type, sync, multiplier, override_color, is_element)
 local disable_outlines = managers.mutators:modify_value("ContourExt:DisableOutlines", false)
 local do_outline = true
 
@@ -159,7 +169,6 @@ if do_outline then
 		fadeout_start_t = fadeout_start_t_dummy or nil,
 		fadeout_length = fadeout_length_dummy or nil,
 		color = override_color or nil,
-		wallhack = wallhack or false,
 		data = data
 	}
 
@@ -172,7 +181,7 @@ if do_outline then
 		end
 	end
 	
-	if data.ray_check_reverse and not setup.wallhack then
+	if data.ray_check_reverse then
 		setup.upd_skip_count_reverse = ContourExt.raycast_update_skip_count
 		local mov_ext = self._unit:movement()
 
@@ -285,7 +294,7 @@ if self.fadeout_start_percent == nil then -- for Vanilla Contours
 				end
 			end
 			--for PJ
-			if is_current and setup.data.ray_check_reverse and not setup.wallhack and not managers.groupai:state():whisper_mode() then
+			if is_current and setup.data.ray_check_reverse and not managers.groupai:state():whisper_mode() then
 				if setup.upd_skip_count_reverse > 0 then
 					setup.upd_skip_count_reverse = setup.upd_skip_count_reverse - 1
 
@@ -340,7 +349,7 @@ if self.fadeout_start_percent == nil then -- for Vanilla Contours
 			end
 
 			if is_current then
-				if setup.data.ray_check_reverse and not setup.wallhack and not managers.groupai:state():whisper_mode() then
+				if setup.data.ray_check_reverse and not managers.groupai:state():whisper_mode() then
 					if turn_off then
 						self:_upd_opacity(self.mod_lerp_opacity and setup.fadeout_t and math.lerp(1, 0, t / setup.fadeout_t) or 1)	
 					else
@@ -384,7 +393,7 @@ else -- for Smooth Contours
 				end
 			end
 			-- for PJ
-			if is_current and data.ray_check_reverse and not setup.wallhack and not managers.groupai:state():whisper_mode() then
+			if is_current and data.ray_check_reverse and not managers.groupai:state():whisper_mode() then
 				local turn_on = nil
 				local cam_pos = managers.viewport:get_current_camera_position()
 				if cam_pos then
@@ -423,7 +432,7 @@ else -- for Smooth Contours
 			
 
 			if opacity then
-				if data.ray_check_reverse and not setup.wallhack and not managers.groupai:state():whisper_mode() then
+				if data.ray_check_reverse and not managers.groupai:state():whisper_mode() then
 					if turn_off then
 						self:_upd_opacity(opacity)	
 					else


### PR DESCRIPTION
Despite what the title says, what this PR actually does is reimplement some parts of @Hater-mater's contour additions. Instead of a contour just for Sixth Sense specifically though, this PR adds a contour for marks without any upgrades but not done through shouts (i.e., ADS from some scopes, Trip Mines, Sixth Sense).

The entire `wallhack` logic in `ContourExt:add()` was thrown out in favour of `GamePlayCentralManager:auto_highlight_enemy()` being able to "upgrade" the default `mark_enemy` contour to this new one under the circumstances described above.

This effectively results in what Hater originally intended, a separate non-souped-up mark that can be seen through walls even on Pro Jobs.