### PR TITLE
Actually fix PJ contours

### DIFF
--- a/lua/sc/managers/gameplaycentralmanager.lua
+++ b/lua/sc/managers/gameplaycentralmanager.lua
@@ -134,13 +134,12 @@ Hooks:OverrideFunction(GamePlayCentralManager, "auto_highlight_enemy", function(
 		time_multiplier = managers.player:upgrade_value("player", "mark_enemy_time_multiplier", 1)
 	elseif use_player_upgrades then
 		contour_type = managers.player:get_contour_for_marked_enemy(unit:base().get_type and unit:base():get_type()) or contour_type
-
-		-- Trip mines, Sixth Sense Basic, and ADS (if applicable) "upgrade" the default mark_enemy contour to be visible through walls even during a Pro Job.
-		if (context == "trip_mine" or context == "sixth_sense" or context == "steelsight") and contour_type == "mark_enemy" then
-			contour_type = "mark_enemy_through_walls"
-		end
-
 		time_multiplier = managers.player:upgrade_value("player", "mark_enemy_time_multiplier", 1)
+	end
+
+	-- Trip mines, Sixth Sense Basic, and ADS (if applicable) "upgrade" the default mark_enemy contour to be visible through walls even during a Pro Job.
+	if (context == "trip_mine" or context == "sixth_sense" or context == "steelsight") and contour_type == "mark_enemy" then
+		contour_type = "mark_enemy_through_walls"
 	end
 
 	local context = context or "none"

--- a/lua/sc/units/contourext.lua
+++ b/lua/sc/units/contourext.lua
@@ -33,6 +33,19 @@ ContourExt._types.mark_enemy_through_walls = {
 }
 ContourExt._types.mark_enemy.priority = 6 -- Lower priority for mark_enemy so that mark_enemy_through_walls can overwrite it.
 
+-- Reindexes the indexed_types table. Technically, this is only necessary for contours that would effect units (i.e., mark_enemy_through_walls), but we may as well index every Resmod-defined contour.
+ContourExt.indexed_types = {}
+
+for name, preset in pairs(ContourExt._types) do
+	table.insert(ContourExt.indexed_types, name)
+end
+
+table.sort(ContourExt.indexed_types)
+
+if #ContourExt.indexed_types > 128 then
+	Application:error("[ContourExt] max # contour presets exceeded!")
+end
+
 -- PJ modifier: Marked enemy will show contour only in LoS (unless you using any marking skills); Medic and LPF flash outlines are disabled;
 if is_pro_job then
 	ContourExt._types.mark_enemy.ray_check_reverse = true

--- a/lua/sc/units/contourext.lua
+++ b/lua/sc/units/contourext.lua
@@ -46,6 +46,7 @@ end
 local enemy_contours = {
 	"friendly",
 	"mark_enemy",
+	"mark_enemy_through_walls",
 	"mark_enemy_damage_bonus",
 	"mark_enemy_damage_bonus_distance",
 	"mark_unit_dangerous",

--- a/lua/sc/units/player_team/logics/teamailogicassault.lua
+++ b/lua/sc/units/player_team/logics/teamailogicassault.lua
@@ -120,11 +120,11 @@ function TeamAILogicAssault.find_enemy_to_mark(attention_objects)
 								mark = true
 							else
 								if attention_info.is_deployable then
-									if not att_contour:has_id("mark_unit_dangerous") and not att_contour:has_id("mark_unit_dangerous_damage_bonus") and not att_contour:has_id("mark_unit_dangerous_damage_bonus_distance") then
+									if not att_contour:has_id("mark_unit_dangerous") and not att_contour:has_id("mark_unit_dangerous_damage_bonus") and not att_contour:has_id("mark_unit_dangerous_damage_bonus_distance") and not att_contour:has_id("mark_enemy_through_walls") then
 										mark = true
 									end
 								else
-									if not att_contour:has_id("mark_enemy") and not att_contour:has_id("mark_enemy_damage_bonus") and not att_contour:has_id("mark_enemy_damage_bonus_distance") then
+									if not att_contour:has_id("mark_enemy") and not att_contour:has_id("mark_enemy_damage_bonus") and not att_contour:has_id("mark_enemy_damage_bonus_distance") and not att_contour:has_id("mark_enemy_through_walls") then
 										mark = true
 									end
 								end


### PR DESCRIPTION
This PR contains two changes:
- I previously erroneously added the see through walls "upgrading" for the default marking to the part of the code where it requires an upgrade. This obviously doesn't make sense, and led to the game still using `mark_enemy` for trip mines and the like.
- When the upgrade to `mark_enemy_through_walls` did happen, it wouldn't be synchronised over to other clients because `ContourExt:add()` uses the indexed contour type list -- so I just copied over the indexing from Vanilla.

Also I forgot to put `mark_enemy_through_walls` as a potential enemy contour, and technically would have allowed AI teammates to overwrite it with their non-wallhack-y marks.

Managed to test this with a friend, and he could see the marks, so I'm hoping it *actually* works and we didn't just accidentally engineer the perfect erroneous scenario.