### PR TITLE
Skip Bullseye (and Head Games) activation when there's no armour (or health) to recover

### DIFF
--- a/lua/sc/managers/gameplaycentralmanager.lua
+++ b/lua/sc/managers/gameplaycentralmanager.lua
@@ -142,8 +142,6 @@ Hooks:OverrideFunction(GamePlayCentralManager, "auto_highlight_enemy", function(
 		contour_type = "mark_enemy_through_walls"
 	end
 
-	local context = context or "none"
-
 	unit:contour():add(contour_type, true, time_multiplier)
 
 	return true

--- a/lua/sc/managers/playermanager.lua
+++ b/lua/sc/managers/playermanager.lua
@@ -1154,16 +1154,26 @@ function PlayerManager:on_headshot_dealt(unit, attack_data)
 		return
 	end
 
-	self._on_headshot_dealt_t = t + (tweak_data.upgrades.on_headshot_dealt_cooldown or 0)
 	local damage_ext = player_unit:character_damage()
+
+	local replenishable_armour = damage_ext:_max_armor() - damage_ext:get_real_armor()
+	local replenishable_health = damage_ext:_max_health() - damage_ext:get_real_health()
 	local regen_armor_bonus = managers.player:upgrade_value("player", "headshot_regen_armor_bonus", 0)
+	local regen_health_bonus = managers.player:upgrade_value("player", "headshot_regen_health_bonus", 0)
+
+	if (replenishable_armour <= 0 or regen_armor_bonus == 0) and (replenishable_health <= 0 or regen_health_bonus == 0) then
+		-- Do not "waste" the Bullseye timer if we:
+		-- - Don't have armour to recover with it or don't have Bullseye, and we
+		-- - Don't have health to recover Head Games or we don't have that.
+		return
+	end
+
+	self._on_headshot_dealt_t = t + (tweak_data.upgrades.on_headshot_dealt_cooldown or 0)
+	managers.hud:start_buff("bullseye", tweak_data.upgrades.on_headshot_dealt_cooldown)
 
 	if damage_ext and regen_armor_bonus > 0 then
 		damage_ext:restore_armor(damage_ext:_max_armor() * regen_armor_bonus)
-		managers.hud:start_buff("bullseye", tweak_data.upgrades.on_headshot_dealt_cooldown)
 	end
-
-	local regen_health_bonus = managers.player:upgrade_value("player", "headshot_regen_health_bonus", 0)
 
 	if damage_ext and regen_health_bonus > 0 then
 		damage_ext:restore_health(regen_health_bonus, true)


### PR DESCRIPTION
Simply put, this PR skips updating `_on_headshot_dealt_t` if a headshot wouldn't result in gaining armour from Bullseye or health from Head Games.

The way this works now, you need to have:
- Armour to recover AND Bullseye, **or**
- Health to recover AND Head Games

to actually engage with the rest of the code.  
This also fixes an issue where despite Head Games saying it shares a cooldown with Bullseye, it never actually made said cooldown show on the Buff Tracker, because the association between the *actual* cooldown timer and the displayed Bullseye cooldown indicator is quite loose.  
*(Though if need be, I could add a separate icon for it for the Buff Tracker.)*

Also I removed a line that was doing nothing besides bothering me in `auto_highlight_enemy`.