### PR TITLE
Do not re-sort ContourExt.indexed_types, instead just add `mark_enemy_through_walls` to the end

### DIFF
--- a/lua/sc/units/contourext.lua
+++ b/lua/sc/units/contourext.lua
@@ -33,14 +33,7 @@ ContourExt._types.mark_enemy_through_walls = {
 }
 ContourExt._types.mark_enemy.priority = 6 -- Lower priority for mark_enemy so that mark_enemy_through_walls can overwrite it.
 
--- Reindexes the indexed_types table. Technically, this is only necessary for contours that would effect units (i.e., mark_enemy_through_walls), but we may as well index every Resmod-defined contour.
-ContourExt.indexed_types = {}
-
-for name, preset in pairs(ContourExt._types) do
-	table.insert(ContourExt.indexed_types, name)
-end
-
-table.sort(ContourExt.indexed_types)
+table.insert(ContourExt.indexed_types, "mark_enemy_through_walls")
 
 if #ContourExt.indexed_types > 128 then
 	Application:error("[ContourExt] max # contour presets exceeded!")

--- a/lua/sc/units/enemies/copdamage.lua
+++ b/lua/sc/units/enemies/copdamage.lua
@@ -2053,9 +2053,7 @@ function CopDamage:die(attack_data)
 	end
 
 	if self._unit:contour() then
-		self._unit:contour():remove("omnia_heal", false)
 		self._unit:contour():remove("medic_show", false)
-		self._unit:contour():remove("medic_buff", false)
 	end
 	
 	if self._unit:base() then

--- a/lua/sc/units/enemies/copmovement.lua
+++ b/lua/sc/units/enemies/copmovement.lua
@@ -288,14 +288,10 @@ function CopMovement:do_omnia(self)
 								managers.groupai:state():chk_say_enemy_chatter(self._unit, self._m_pos, heal_vo)
 							end										
 							if enemy:contour() then
-								if overheal_mult > 1 then								
-									--enemy:contour():add("omnia_heal", false)
-									--enemy:contour():flash("omnia_heal", 0.2)
+								if overheal_mult > 1 then
 									enemy:base():enable_lpf_buff(true)
 									enemy:base():lpf_heal_effect(true)
 								else
-									--enemy:contour():add("medic_heal", false)
-									--enemy:contour():flash("medic_heal", 0.2)
 									enemy:base():lpf_heal_effect(false)
 								end
 							end		

--- a/lua/sc/units/enemies/huskcopdamage.lua
+++ b/lua/sc/units/enemies/huskcopdamage.lua
@@ -7,9 +7,7 @@ function HuskCopDamage:die(attack_data)
 	end
 
 	if self._unit:contour() then
-		self._unit:contour():remove("omnia_heal", false)
 		self._unit:contour():remove("medic_show", false)
-		self._unit:contour():remove("medic_buff", false)
 	end
 	
 	if self._unit:base() then

--- a/lua/sc/units/enemies/logics/coplogicintimidated.lua
+++ b/lua/sc/units/enemies/logics/coplogicintimidated.lua
@@ -42,12 +42,7 @@ function CopLogicIntimidated._do_tied(data, aggressor_unit)
 
 	if data.unit:unit_data().mission_element then
 		data.unit:unit_data().mission_element:event("tied", data.unit)
-	end
-	
-	if data.unit:contour() then
-		data.unit:contour():remove("omnia_heal", true)
-		data.unit:contour():remove("medic_buff", true)
-	end			
+	end	
 
 	if aggressor_unit then
 		data.unit:character_damage():drop_pickup()


### PR DESCRIPTION
Unlikely to be the actual cause for the contour desyncs, but might as well eliminate one potential cause.

There is a difference between dev games before and after [this commit](https://github.com/payday-restoration/restoration-mod/commit/08b2f2e87313c0d82168b94d2479e849f20a8a44) in what contour types they have indexed:

|Before|After|
|---|---|
|boris|boris|
|deployable_active|deployable_active|
|deployable_disabled|deployable_blackout|
|deployable_interactable|deployable_disabled|
|deployable_selected|deployable_interactable|
|drunk_pilot|deployable_selected|
|friendly|drunk_pilot|
|generic_interactable|friendly|
|generic_interactable_selected|generic_interactable|
|highlight|generic_interactable_selected|
|highlight_character|highlight|
|hostage_trade|highlight_character|
|mark_enemy|hostage_trade|
|mark_enemy_damage_bonus|mark_enemy|
|mark_enemy_damage_bonus_distance|mark_enemy_damage_bonus|
|mark_unit|mark_enemy_damage_bonus_distance|
|mark_unit_dangerous|mark_enemy_through_walls|
|mark_unit_dangerous_damage_bonus|mark_unit|
|mark_unit_dangerous_damage_bonus_distance|mark_unit_dangerous|
|mark_unit_friendly|mark_unit_dangerous_damage_bonus|
|medic_heal|mark_unit_dangerous_damage_bonus_distance|
|taxman|mark_unit_friendly|
|teammate|medic_buff|
|teammate_cuffed|medic_heal|
|teammate_dead|medic_show|
|teammate_downed|omnia_heal|
|teammate_downed_selected|taxman|
|tmp_invulnerable|teammate|
|vulnerable|teammate_cuffed|
|vulnerable_character|teammate_dead|
|???|teammate_downed|
|???|teammate_downed_selected|
|???|tmp_invulnerable|
|???|vulnerable|
|???|vulnerable_character|

What this table means that for example, if you're playing with someone who is on a commit before that one, and they mark an enemy with no upgrades, you'd see the hostage trade outline (`mark_enemy` becomes `hostage_trade` for you). Meanwhile, if you marked an enemy with Spotter Aced\*, they would see it as the Medic heal mark (your `mark_unit_dangerous_damage_bonus_distance` becomes `medic_heal` for them).

What this PR does is instead of inserting the Trip Mine / Sixth Sense / ADS marking through walls without upgrades contour and *then* re-sorting the indexed types, it just inserts `mark_enemy_through_walls` at the end.  
The rest of the ResMod outlines don't get synced, so they no longer get inserted (even though Vanilla inserts basically every outlines into `indexed_types`).

I also went around and removed the various stray `medic_buff` and `omnia_heal` contour removals. I suppose I could have removed them from the contour types too, but eh.