### PR TITLE
Fix Spotter Basic granting Spotter Aced benefits as well

### DIFF
--- a/lua/sc/managers/playermanager.lua
+++ b/lua/sc/managers/playermanager.lua
@@ -1923,6 +1923,39 @@ function PlayerManager:add_deployable_equipment(equipment_id, amount)
 	end
 end
 
+--- Reversed the order in which the `_damage_bonus_distance` and `_damage_bonus` contours are applied.
+--- This needed to be done because unlike Vanilla's High Value Target, Spotter has logic based on distance
+--- in the Basic version of the skill, not aced.
+--- Leaving it unreversed would result in the Spotter Basic contour applying no matter if you had Basic or Aced.
+--- 
+--- Please note that the contours now handle distance differently! See contourext.lua for more info.
+function PlayerManager:get_contour_for_marked_enemy(enemy_type)
+	local contour_type = "mark_enemy"
+
+	if enemy_type == "swat_turret" or enemy_type == "sentry_gun" then
+		contour_type = "mark_unit_dangerous"
+
+		if managers.player:has_category_upgrade("player", "marked_inc_dmg_distance") then
+			contour_type = "mark_unit_dangerous_damage_bonus_distance"
+		end
+
+		if managers.player:has_category_upgrade("player", "marked_enemy_extra_damage") then
+			contour_type = "mark_unit_dangerous_damage_bonus"
+		end
+	else
+
+		if managers.player:has_category_upgrade("player", "marked_inc_dmg_distance") then
+			contour_type = "mark_enemy_damage_bonus_distance"
+		end
+
+		if managers.player:has_category_upgrade("player", "marked_enemy_extra_damage") then
+			contour_type = "mark_enemy_damage_bonus"
+		end
+	end
+
+	return contour_type
+end
+
 -- Tag Team: tagged player will hear activation sound
 Hooks:PostHook(PlayerManager, "sync_tag_team", "sync_tag_team_sound_effect", function(self, tagged, owner, end_time)
 	if tagged == self:local_player() then

--- a/lua/sc/units/contourext.lua
+++ b/lua/sc/units/contourext.lua
@@ -33,6 +33,14 @@ ContourExt._types.mark_enemy_through_walls = {
 }
 ContourExt._types.mark_enemy.priority = 6 -- Lower priority for mark_enemy so that mark_enemy_through_walls can overwrite it.
 
+-- The distance-based marking contours now no longer give a default damage bonus.
+-- Meanwhile, the non-distance based ones now give a damage bonus on distance too.
+-- For the why, see PlayerManager:get_contour_for_marked_enemy().
+ContourExt._types.mark_unit_dangerous_damage_bonus.damage_bonus_distance = 1
+ContourExt._types.mark_unit_dangerous_damage_bonus_distance.damage_bonus = nil
+ContourExt._types.mark_enemy_damage_bonus.damage_bonus_distance = 1
+ContourExt._types.mark_enemy_damage_bonus_distance.damage_bonus = nil
+
 table.insert(ContourExt.indexed_types, "mark_enemy_through_walls")
 
 if #ContourExt.indexed_types > 128 then

--- a/lua/sc/units/enemies/copdamage.lua
+++ b/lua/sc/units/enemies/copdamage.lua
@@ -449,16 +449,18 @@ function CopDamage:damage_fire(attack_data)
 		end
 	end
 		
+	-- Separated the two damage boosts from marking.
+	-- Could have just swapped their order, but honestly, there's no reason why one should depend on the other anyway.
 	if self._marked_dmg_mul then
 		damage = damage * self._marked_dmg_mul
+	end
 
-		if not attack_data.is_fire_dot_damage and self._marked_dmg_dist_mul and alive(attacker_unit) then
-			local dst = mvector3.distance(attacker_unit:position(), self._unit:position())
-			local spott_dst = tweak_data.upgrades.values.player.marked_inc_dmg_distance[self._marked_dmg_dist_mul]
+	if not attack_data.is_fire_dot_damage and self._marked_dmg_dist_mul and alive(attacker_unit) then
+		local dst = mvector3.distance(attacker_unit:position(), self._unit:position())
+		local spott_dst = tweak_data.upgrades.values.player.marked_inc_dmg_distance[self._marked_dmg_dist_mul]
 
-			if spott_dst[1] < dst then
-				damage = damage * spott_dst[2]
-			end
+		if spott_dst[1] < dst then
+			damage = damage * spott_dst[2]
 		end
 	end
 
@@ -1058,16 +1060,18 @@ function CopDamage:damage_bullet(attack_data)
 			damage = self._health * 10
 		end
 	end
-		
+
+	-- Separated the two damage boosts from marking.
+	-- Could have just swapped their order, but honestly, there's no reason why one should depend on the other anyway.
 	if self._marked_dmg_mul then
 		damage = damage * self._marked_dmg_mul
+	end
 
-		if self._marked_dmg_dist_mul then
-			local spott_dst = tweak_data.upgrades.values.player.marked_inc_dmg_distance[self._marked_dmg_dist_mul]
+	if self._marked_dmg_dist_mul then
+		local spott_dst = tweak_data.upgrades.values.player.marked_inc_dmg_distance[self._marked_dmg_dist_mul]
 
-			if spott_dst[1] < distance then
-				damage = damage * spott_dst[2]
-			end
+		if spott_dst[1] < distance then
+			damage = damage * spott_dst[2]
 		end
 	end
 
@@ -2285,16 +2289,18 @@ function CopDamage:damage_explosion(attack_data)
 		end	
 	end	
 
+	-- Separated the two damage boosts from marking.
+	-- Could have just swapped their order, but honestly, there's no reason why one should depend on the other anyway.
 	if self._marked_dmg_mul then
 		damage = damage * self._marked_dmg_mul
+	end
 
-		if self._marked_dmg_dist_mul and alive(attacker_unit) then
-			local dst = mvector3.distance(attacker_unit:position(), self._unit:position())
-			local spott_dst = tweak_data.upgrades.values.player.marked_inc_dmg_distance[self._marked_dmg_dist_mul]
+	if self._marked_dmg_dist_mul and alive(attacker_unit) then
+		local dst = mvector3.distance(attacker_unit:position(), self._unit:position())
+		local spott_dst = tweak_data.upgrades.values.player.marked_inc_dmg_distance[self._marked_dmg_dist_mul]
 
-			if spott_dst[1] < dst then
-				damage = damage * spott_dst[2]
-			end
+		if spott_dst[1] < dst then
+			damage = damage * spott_dst[2]
 		end
 	end
 

--- a/lua/sc/units/equipment/sentrygundamage.lua
+++ b/lua/sc/units/equipment/sentrygundamage.lua
@@ -288,16 +288,18 @@ function SentryGunDamage:damage_bullet(attack_data)
 	local object_damage_mul = weap_base and weap_base.get_object_damage_mult and weap_base:get_object_damage_mult() or 1
 	damage = damage * object_damage_mul
 
+	-- Separated the two damage boosts from marking.
+	-- Could have just swapped their order, but honestly, there's no reason why one should depend on the other anyway.
 	if self._marked_dmg_mul then
 		damage = damage * self._marked_dmg_mul
+	end
 
-		if self._marked_dmg_dist_mul then
-			local dst = mvector3.distance(attack_data.origin, self._unit:movement():m_head_pos())
-			local spott_dst = tweak_data.upgrades.values.player.marked_inc_dmg_distance[self._marked_dmg_dist_mul]
+	if self._marked_dmg_dist_mul then
+		local dst = mvector3.distance(attack_data.origin, self._unit:movement():m_head_pos())
+		local spott_dst = tweak_data.upgrades.values.player.marked_inc_dmg_distance[self._marked_dmg_dist_mul]
 
-			if spott_dst[1] < dst then
-				damage = damage * spott_dst[2]
-			end
+		if spott_dst[1] < dst then
+			damage = damage * spott_dst[2]
 		end
 	end
 
@@ -428,16 +430,18 @@ function SentryGunDamage:damage_fire(attack_data)
 
 	local damage = attack_data.damage
 
+	-- Separated the two damage boosts from marking.
+	-- Could have just swapped their order, but honestly, there's no reason why one should depend on the other anyway.
 	if self._marked_dmg_mul then
 		damage = damage * self._marked_dmg_mul
+	end
 
-		if self._marked_dmg_dist_mul and alive(attacker_unit) then
-			local dst = mvector3.distance(attacker_unit:position(), self._unit:movement():m_head_pos())
-			local spott_dst = tweak_data.upgrades.values.player.marked_inc_dmg_distance[self._marked_dmg_dist_mul]
+	if self._marked_dmg_dist_mul and alive(attacker_unit) then
+		local dst = mvector3.distance(attacker_unit:position(), self._unit:movement():m_head_pos())
+		local spott_dst = tweak_data.upgrades.values.player.marked_inc_dmg_distance[self._marked_dmg_dist_mul]
 
-			if spott_dst[1] < dst then
-				damage = damage * spott_dst[2]
-			end
+		if spott_dst[1] < dst then
+			damage = damage * spott_dst[2]
 		end
 	end
 
@@ -565,16 +569,18 @@ function SentryGunDamage:damage_explosion(attack_data)
 
 	local damage = attack_data.damage
 
+	-- Separated the two damage boosts from marking.
+	-- Could have just swapped their order, but honestly, there's no reason why one should depend on the other anyway.
 	if self._marked_dmg_mul then
 		damage = damage * self._marked_dmg_mul
+	end
 
-		if self._marked_dmg_dist_mul and alive(attacker_unit) then
-			local dst = mvector3.distance(attacker_unit:position(), self._unit:movement():m_head_pos())
-			local spott_dst = tweak_data.upgrades.values.player.marked_inc_dmg_distance[self._marked_dmg_dist_mul]
+	if self._marked_dmg_dist_mul and alive(attacker_unit) then
+		local dst = mvector3.distance(attacker_unit:position(), self._unit:movement():m_head_pos())
+		local spott_dst = tweak_data.upgrades.values.player.marked_inc_dmg_distance[self._marked_dmg_dist_mul]
 
-			if spott_dst[1] < dst then
-				damage = damage * spott_dst[2]
-			end
+		if spott_dst[1] < dst then
+			damage = damage * spott_dst[2]
 		end
 	end
 


### PR DESCRIPTION
This PR fixes the issue per the title.

The cause of this bug seems to be the "reversed logic" compared to Vanilla. In Vanilla, High Value Target Basic grants the unconditional damage increase first, on which then the Aced version builds with a distance-based conditional extra damage. As such, most of the logic assumes this order.

This means that when the logic was reversed for Spotter, Spotter Basic (which now grants a distance based damage increase) always won out. As long as you had Spotter Basic, you also gained the Spotter Aced benefits, and Spotter Aced did nothing.

I elected to fix this in what I saw to be the least intrusive way, but eeeeeeeeh.  
- PlayerManager's `get_contour_for_marked_enemy()` was overwritten to swap the order in which Spotter Basic and Aced contours get applied, so Aced actually *does* get applied.
- For the contours, I removed the flat damage bonus from the `_damage_bonus_distance` versions, and added the distance-based bonus to the `_damage_bonus` versions.
- In CopDamage and SentryGunDamage, I've separated the flat damage bonus logic and the distance-based damage bonus logic. I could have swapped the two, but honestly, they don't depend on each other *that* much besides typically being as part of a Basic/Aced skill pair.