### PR TITLE
LPF and ASU buffs no longer stick around forever

### DIFF
--- a/lua/sc/tweak_data/tweakdata.lua
+++ b/lua/sc/tweak_data/tweakdata.lua
@@ -1084,6 +1084,8 @@ tweak_data.medic.overheal_decay_delay_t = 5 --- In seconds, the amount of time s
 
 --ASU damage bonus (Titan HRT)
 tweak_data.asu_buff_radius = 800
+tweak_data.asu_buff_decay_delay = 10 --- In seconds, the amount of time before the ASU damage bonus decays from a unit without the ASU unit being nearby to refresh it.
+
 if difficulty_index <= 6 then
 	tweak_data.asu_damage_buff = 10
 elseif difficulty_index == 7 then

--- a/lua/sc/tweak_data/tweakdata.lua
+++ b/lua/sc/tweak_data/tweakdata.lua
@@ -1076,6 +1076,12 @@ tweak_data.medic.cooldown = 0
 tweak_data.medic.radius = 900
 tweak_data.medic.lpf_radius = 800
 
+-- LPF related tweak data
+
+tweak_data.medic.overheal_decay_percent = 0.1 --- When not being actively overhealed, how much of the overheal should be lost. Percent of the total max possible overheal.
+tweak_data.medic.overheal_decay_t = 1 --- In seconds, how often the unit should lose overheal_decay_percent amount of overheal.
+tweak_data.medic.overheal_decay_delay_t = 5 --- In seconds, the amount of time since last being near an LPF before the unit starts losing overheal.
+
 --ASU damage bonus (Titan HRT)
 tweak_data.asu_buff_radius = 800
 if difficulty_index <= 6 then

--- a/lua/sc/units/enemies/copbase.lua
+++ b/lua/sc/units/enemies/copbase.lua
@@ -224,14 +224,31 @@ function CopBase:lpf_heal_effect(overheal)
 	end
 end
 
-function CopBase:enable_asu_laser(state)
+--- Enables the ASU laser *and* applies the damage boost if it doesn't already exist.
+--- @param boost number Percentage by which to boost damage. Typically 0.1 to 0.2 for a 10%-20% damage boost.
+--- @param t number The time when the buff was applied.
+--- @param keep_forever boolean If true, the damage boost should be kept forever (typically from Medics or Dozer faceplate breaking).
+function CopBase:enable_asu_laser(boost, t, keep_forever)
+	self._last_asu_buff_t = t
+
+	self._asu_keep_forever = self._asu_keep_forever or keep_forever -- Cannot remove forever buff!
+	if self._asu_buff_id then
+		return
+	end
+	self._asu_buff_id = self:add_buff("base_damage", boost)
+
 	local weapon = self._unit:inventory():equipped_unit()
 	if weapon and alive(weapon) then
-		weapon:base():set_asu_laser_enabled(state)
+		weapon:base():set_asu_laser_enabled(true)
 	end
 end
 
-function CopBase:disable_asu_laser(state)
+function CopBase:disable_asu_laser()
+	if self._asu_buff_id then
+		self:remove_buff_by_id("base_damage", self._asu_buff_id)
+		self._asu_buff_id = nil
+	end
+
 	local weapon = self._unit:inventory():equipped_unit()
 	if weapon and alive(weapon) then
 		weapon:base():set_asu_laser_enabled(false)
@@ -317,7 +334,18 @@ Hooks:PostHook(CopBase, "post_init", "postinithooksex", function(self)
 		end
 	end		
 	
+	self._last_asu_buff_t = 0 -- To keep track of when the ASU buff was last applied.
+	self._asu_buff_id = nil -- If not nil, we know we already have an ASU buff applied to us.
+	self._asu_keep_forever = false -- Some damage boosts should stick around forever.
 end)
+
+function CopBase:decay_buffs(t)
+	-- 1.3 was largely chosen on a whim, I just don't want cops to be 
+	-- "toggling" their buffs on and off while near an ASU.
+	if self._last_asu_buff_t + 1.3 < t and not self._asu_keep_forever then
+		self:disable_asu_laser()
+	end
+end
 
 local enemy_variations_texas_pd_table = {
 	["units/pd2_mod_lapd/characters/ene_swat_1/ene_swat_1"] = "awesometexpd",

--- a/lua/sc/units/enemies/copbase.lua
+++ b/lua/sc/units/enemies/copbase.lua
@@ -344,10 +344,9 @@ Hooks:PostHook(CopBase, "post_init", "postinithooksex", function(self)
 	self._may_decay_buffs = true
 end)
 
+--- Forces the ASU buff to disappear if the unit hasn't been affected by an ASU unit's buff in a bit.
 function CopBase:decay_buffs(t)
-	-- 2 sounds like a lot, but I think there's some timing fuckery going on, as 1.3 was just not enough.
-	-- (For reference, ASUs re-add their buffs every second.)
-	if self._last_asu_buff_t and self._last_asu_buff_t + 2 < t and not self._asu_keep_forever then
+	if self._last_asu_buff_t and self._last_asu_buff_t + (tweak_data.asu_buff_decay_delay or 10) < t and not self._asu_keep_forever then
 		self:disable_asu_laser()
 	end
 end

--- a/lua/sc/units/enemies/copbase.lua
+++ b/lua/sc/units/enemies/copbase.lua
@@ -200,6 +200,7 @@ end
 function CopBase:disable_lpf_buff()
 	if self._overheal_unit then
 		World:effect_manager():fade_kill(self._overheal_unit)
+		self._overheal_unit = nil
 	end
 end
 

--- a/lua/sc/units/enemies/copbase.lua
+++ b/lua/sc/units/enemies/copbase.lua
@@ -337,12 +337,17 @@ Hooks:PostHook(CopBase, "post_init", "postinithooksex", function(self)
 	self._last_asu_buff_t = 0 -- To keep track of when the ASU buff was last applied.
 	self._asu_buff_id = nil -- If not nil, we know we already have an ASU buff applied to us.
 	self._asu_keep_forever = false -- Some damage boosts should stick around forever.
+
+	--- I've been running into issues where CopMovement doesn't recognise decay_buffs().
+	--- So one way I thought I could force the issue was by setting a "flag" to signal
+	--- we're ready.
+	self._may_decay_buffs = true
 end)
 
 function CopBase:decay_buffs(t)
-	-- 1.3 was largely chosen on a whim, I just don't want cops to be 
-	-- "toggling" their buffs on and off while near an ASU.
-	if self._last_asu_buff_t and self._last_asu_buff_t + 1.3 < t and not self._asu_keep_forever then
+	-- 2 sounds like a lot, but I think there's some timing fuckery going on, as 1.3 was just not enough.
+	-- (For reference, ASUs re-add their buffs every second.)
+	if self._last_asu_buff_t and self._last_asu_buff_t + 2 < t and not self._asu_keep_forever then
 		self:disable_asu_laser()
 	end
 end

--- a/lua/sc/units/enemies/copbase.lua
+++ b/lua/sc/units/enemies/copbase.lua
@@ -342,7 +342,7 @@ end)
 function CopBase:decay_buffs(t)
 	-- 1.3 was largely chosen on a whim, I just don't want cops to be 
 	-- "toggling" their buffs on and off while near an ASU.
-	if self._last_asu_buff_t + 1.3 < t and not self._asu_keep_forever then
+	if self._last_asu_buff_t and self._last_asu_buff_t + 1.3 < t and not self._asu_keep_forever then
 		self:disable_asu_laser()
 	end
 end

--- a/lua/sc/units/enemies/copdamage.lua
+++ b/lua/sc/units/enemies/copdamage.lua
@@ -2127,12 +2127,6 @@ function CopDamage:die(attack_data)
 	if self._unit:contour() then
 		self._unit:contour():remove("medic_show", false)
 	end
-
-	if tweak_data.character[self._unit:base()._tweak_table].do_asu then
-		for _, buffed_target in ipairs(self._unit:movement()._buff_targets or {}) do
-			buffed_target:base():disable_asu_laser()
-		end
-	end
 	
 	if self._unit:base() then
 		self._unit:base():disable_lpf_buff()

--- a/lua/sc/units/enemies/copdamage.lua
+++ b/lua/sc/units/enemies/copdamage.lua
@@ -225,6 +225,11 @@ Hooks:PostHook(CopDamage, "init", "res_init", function(self, unit)
 	self._player_damage_ratio = 0 --Damage dealt to this enemy by players that contributed to the kill.
 	self._last_overheal_t = 0 --- The last time the enemy has been near an LPF.
 	self._decay_start_t = 0 --- When the overheal decay last started.
+
+	--- I've been running into issues where CopMovement doesn't recognise decay_buffs().
+	--- So one way I thought I could force the issue was by setting a "flag" to signal
+	--- we're ready.
+	self._may_decay_buffs = true
 	
 	-- i don't want to sift through every single .object file in the game to do this so
 	if self._head_gear_decal_mesh then

--- a/lua/sc/units/enemies/copdamage.lua
+++ b/lua/sc/units/enemies/copdamage.lua
@@ -223,7 +223,8 @@ local is_pro = Global.game_settings and Global.game_settings.one_down
 
 Hooks:PostHook(CopDamage, "init", "res_init", function(self, unit)
 	self._player_damage_ratio = 0 --Damage dealt to this enemy by players that contributed to the kill.
-
+	self._last_overheal_t = 0 --- The last time the enemy has been near an LPF.
+	self._decay_start_t = 0 --- When the overheal decay last started.
 	
 	-- i don't want to sift through every single .object file in the game to do this so
 	if self._head_gear_decal_mesh then
@@ -241,6 +242,50 @@ Hooks:PostHook(CopDamage, "convert_to_criminal", "convert_to_criminal_mutator_no
 		self._unit:base():converted_enemy_effect(true)
 	end
 end)
+
+Hooks:PostHook(CopDamage, "_apply_damage_to_health", "res_apply_damage_to_health", function(self, damage)
+
+	if self._health > self._HEALTH_INIT then
+		self._unit:base():enable_lpf_buff(true)
+	else
+		self._unit:base():disable_lpf_buff()
+	end
+end)
+
+function CopDamage:decay_buffs(t)
+	local decay_delay_t = tweak_data.medic.overheal_decay_delay_t or 5
+	
+	if self._last_overheal_t + decay_delay_t < t then
+		-- It's been enough time to start decaying overheal if we have any.
+		local decay_t = tweak_data.medic.overheal_decay_t or 1
+		if not self._decay_start_t then
+			self._decay_start_t = self._last_overheal_t + decay_delay_t
+		end
+
+		if self._health > self._HEALTH_INIT and self._decay_start_t + decay_t < t then
+			-- Since this only gets run when CopMovement runs _upd_actions, there can be a situation where
+			-- we're lagging behind several decay_t amount of seconds.
+			-- So, we'll "catch up" to where our overheal decay should be in that case.
+			-- ...There's probably a smarter way of doing this.
+			local times_happened = math.floor((t - self._decay_start_t)/decay_t)
+
+			local self_tweak_data = tweak_data.character[self._unit:base()._tweak_table]
+			local overheal_mult = self_tweak_data.overheal_mult or 1
+			local overheal_full = self._HEALTH_INIT * overheal_mult - self._HEALTH_INIT -- Difference of max heal WITH overheal and just normal max health.
+			local decay_percent_loss = tweak_data.medic.overheal_decay_percent or 0.1
+
+			local final_damage = math.max(0,math.min(overheal_full * decay_percent_loss * times_happened, self._health - self._HEALTH_INIT))
+			self:_apply_damage_to_health(final_damage)	
+
+			self._decay_start_t = self._decay_start_t + times_happened * decay_t
+		end
+	end
+end
+
+function CopDamage:refresh_overheal_decay_timer(t)
+	self._last_overheal_t = t
+	self._decay_start_t = nil -- To enforce a recalculation in decay_buffs()
+end
 
 function CopDamage:_spawn_head_gadget(params)
 	local unit_name = self._unit:name()
@@ -3944,7 +3989,6 @@ function CopDamage:lpf_disable()
 	if self._unit:base() then
 		self._unit:base():change_char_tweak("omnia_lpf_no_heal")
 	end
-	
 	if self._unit:character_damage() and self._unit:character_damage().force_hurt then
 		local attack_data = {
 			variant = "bullet",
@@ -3959,7 +4003,28 @@ function CopDamage:lpf_disable()
 
 		self._unit:character_damage():force_hurt(attack_data)
 	end	
-	
+
+	if not self._unit:movement()._buff_targets then
+		return
+	end
+
+	for _, buffed_target in ipairs(self._unit:movement()._buff_targets) do
+		if alive(buffed_target) and buffed_target:character_damage() and buffed_target:character_damage().force_hurt then
+			local attack_data = {
+				variant = "bullet",
+				type = "hurt",
+				position = buffed_target:oobb():center(),
+				direction = buffed_target:rotation():y(),
+				col_ray = {
+					position = buffed_target:oobb():center(),
+					ray = buffed_target:rotation():y(),
+				}
+			}
+
+			buffed_target:character_damage():_apply_damage_to_health(math.max(buffed_target:character_damage()._health - buffed_target:character_damage()._HEALTH_INIT, 0)) -- Only take damage equivalent to the overheal, if any.
+			buffed_target:character_damage():force_hurt(attack_data)
+		end
+	end
 end
 
 --Added stuff for CG22 mutator

--- a/lua/sc/units/enemies/copdamage.lua
+++ b/lua/sc/units/enemies/copdamage.lua
@@ -2122,10 +2122,16 @@ function CopDamage:die(attack_data)
 	if self._unit:contour() then
 		self._unit:contour():remove("medic_show", false)
 	end
+
+	if tweak_data.character[self._unit:base()._tweak_table].do_asu then
+		for _, buffed_target in ipairs(self._unit:movement()._buff_targets or {}) do
+			buffed_target:base():disable_asu_laser()
+		end
+	end
 	
 	if self._unit:base() then
 		self._unit:base():disable_lpf_buff()
-		self._unit:base():disable_asu_laser(true)
+		self._unit:base():disable_asu_laser()
 		self._unit:base():converted_enemy_effect(false)
 	end
 

--- a/lua/sc/units/enemies/copmovement.lua
+++ b/lua/sc/units/enemies/copmovement.lua
@@ -215,6 +215,7 @@ Hooks:PostHook(CopMovement, "_upd_actions", "res_upd_actions", function(self, t)
 	end
 
 	self._unit:character_damage():decay_buffs(t)
+	self._unit:base():decay_buffs(t)
 end)
 
 Hooks:PreHook(CopMovement, "_upd_stance", "res_upd_stance", function(self, t)
@@ -332,6 +333,9 @@ function CopMovement:do_asu(self)
 			local buff_range = tweak_data.asu_buff_radius or 800
 			local asu_vo = "asu_command"
 			local damage_buff = tweak_data.asu_damage_buff or 10
+			
+			-- Finding valid targets to buff
+			self._buff_targets = {}
 						
 			local enemies = World:find_units_quick(self._unit, "sphere", self._unit:position(), buff_range, managers.slot:get_mask("enemies"))
 			if enemies then
@@ -348,24 +352,22 @@ function CopMovement:do_asu(self)
 					
 					local team = enemy:brain() and enemy:brain()._logic_data and enemy:brain()._logic_data.team
 					local my_team = self._unit:brain() and self._unit:brain()._logic_data and self._unit:brain()._logic_data.team
+					local convert = enemy:brain() and enemy:brain()._logic_data and enemy:brain()._logic_data.is_converted
 					
-					if enemy_found and my_team == team then		
-						local convert = enemy:brain() and enemy:brain()._logic_data and enemy:brain()._logic_data.is_converted
-						if convert then
-							return
-						end	
-					
-						if enemy:base():get_total_buff("base_damage") > 0 then
-							return
-						end
-																		
-						managers.groupai:state():chk_say_enemy_chatter(self._unit, self._m_pos, asu_vo)		
-														
-						enemy:base():enable_asu_laser(true)
-						
-						enemy:base():add_buff("base_damage", damage_buff * 0.01)
+					if enemy_found and my_team == team and not convert then
+						table.insert(self._buff_targets, enemy)
 					end
 				end
+			end
+
+			for _, buffed_target in ipairs(self._buff_targets) do
+				if buffed_target:base():get_total_buff("base_damage") > 0 then
+					-- When the ASU buffs were rewritten, I was originally gonna change this too,
+					-- but actually, it makes sense to look for general damage buffs.
+					return
+				end
+				managers.groupai:state():chk_say_enemy_chatter(self._unit, self._m_pos, asu_vo)
+				buffed_target:base():enable_asu_laser(damage_buff * 0.01, t, false)
 			end
 		end
 	else

--- a/lua/sc/units/enemies/copmovement.lua
+++ b/lua/sc/units/enemies/copmovement.lua
@@ -250,6 +250,7 @@ function CopMovement:do_omnia(self)
 			end
 			
 			-- Finding valid targets to overheal
+			self._buff_targets = {}
 			
 			local enemies = World:find_units_quick(self._unit, "sphere", self._unit:position(), heal_range, managers.slot:get_mask("enemies"))
 			if enemies then
@@ -276,25 +277,6 @@ function CopMovement:do_omnia(self)
 					if enemy_found and my_team == team and not convert then
 						table.insert(self._buff_targets, enemy)
 					end
-				end
-			end
-
-			-- Checking the buff_targets list to see if all inserted allies are actually valid
-
-			-- Iterating backwards to not accidentally skip over indices as I remove stuff
-			for i=#self._buff_targets,1,-1 do
-				local buffed_target = self._buff_targets[i]
-				local already_removed = false
-				if not alive(buffed_target) then
-					table.remove(self._buff_targets, i)
-					already_removed = true
-				end
-
-				local dst = mvector3.distance(buffed_target:position(), self._unit:movement():m_head_pos())
-
-				if not already_removed and dst > heal_range then
-					table.remove(self._buff_targets, i)
-					already_removed = true
 				end
 			end
 

--- a/lua/sc/units/enemies/copmovement.lua
+++ b/lua/sc/units/enemies/copmovement.lua
@@ -214,8 +214,13 @@ Hooks:PostHook(CopMovement, "_upd_actions", "res_upd_actions", function(self, t)
 		end
 	end
 
-	self._unit:character_damage():decay_buffs(t)
-	self._unit:base():decay_buffs(t)
+	if self._unit:character_damage() and self._unit:character_damage()._may_decay_buffs then
+		self._unit:character_damage():decay_buffs(t)
+	end
+	
+	if self._unit:base() and self._unit:base()._may_decay_buffs then
+		self._unit:base():decay_buffs(t)
+	end
 end)
 
 Hooks:PreHook(CopMovement, "_upd_stance", "res_upd_stance", function(self, t)

--- a/lua/sc/units/enemies/copmovement.lua
+++ b/lua/sc/units/enemies/copmovement.lua
@@ -189,6 +189,9 @@ function CopMovement:post_init()
 	self._omnia_cooldown = 0
 	self._asu_cooldown = 0
 	self._cloaked = false
+
+	--- Contains references to units that are affected by either this unit's LPF overheal or ASU damage boost.
+	self._buff_targets = {}
 	
 	if self._tweak_data.do_autumn_blackout then 
 		managers.groupai:state():register_blackout_source(self._unit)
@@ -209,7 +212,9 @@ Hooks:PostHook(CopMovement, "_upd_actions", "res_upd_actions", function(self, t)
 		if not self._unit:character_damage():dead() then			
 			self:do_asu(self)		
 		end
-	end		
+	end
+
+	self._unit:character_damage():decay_buffs(t)
 end)
 
 Hooks:PreHook(CopMovement, "_upd_stance", "res_upd_stance", function(self, t)
@@ -244,6 +249,8 @@ function CopMovement:do_omnia(self)
 				heal_vo = "heal_chatter_winters"
 			end
 			
+			-- Finding valid targets to overheal
+			
 			local enemies = World:find_units_quick(self._unit, "sphere", self._unit:position(), heal_range, managers.slot:get_mask("enemies"))
 			if enemies then
 				for _,enemy in ipairs(enemies) do
@@ -264,40 +271,63 @@ function CopMovement:do_omnia(self)
 					end
 					local team = enemy:brain() and enemy:brain()._logic_data and enemy:brain()._logic_data.team
 					local my_team = self._unit:brain() and self._unit:brain()._logic_data and self._unit:brain()._logic_data.team
+					local convert = enemy:brain() and enemy:brain()._logic_data and enemy:brain()._logic_data.is_converted
 					
-					if enemy_found and my_team == team then
-						local health_left = enemy:character_damage()._health
-						local max_health = enemy:character_damage()._HEALTH_INIT
-						local overheal_mult = enemy_tweak_data.overheal_mult or 1
-						local convert = enemy:brain() and enemy:brain()._logic_data and enemy:brain()._logic_data.is_converted
-						
-						if convert then
-							return
-						end
-						
-						max_health = enemy:character_damage()._HEALTH_INIT * overheal_mult
-						
-						if health_left < max_health then
-							local amount_to_heal = math.ceil(((max_health - health_left) / 20))
-							local disable_outlines = managers.mutators:modify_value("CopMovement:DisableOutlines", false)
-							if self._unit:contour()  then
-								if not disable_outlines then
-									self._unit:contour():add("medic_show", false)
-									self._unit:contour():flash("medic_show", 0.2)
-								end
-								managers.groupai:state():chk_say_enemy_chatter(self._unit, self._m_pos, heal_vo)
-							end										
-							if enemy:contour() then
-								if overheal_mult > 1 then
-									enemy:base():enable_lpf_buff(true)
-									enemy:base():lpf_heal_effect(true)
-								else
-									enemy:base():lpf_heal_effect(false)
-								end
-							end		
-							enemy:character_damage():_apply_damage_to_health((amount_to_heal * -1))
-						end
+					if enemy_found and my_team == team and not convert then
+						table.insert(self._buff_targets, enemy)
 					end
+				end
+			end
+
+			-- Checking the buff_targets list to see if all inserted allies are actually valid
+
+			-- Iterating backwards to not accidentally skip over indices as I remove stuff
+			for i=#self._buff_targets,1,-1 do
+				local buffed_target = self._buff_targets[i]
+				local already_removed = false
+				if not alive(buffed_target) then
+					table.remove(self._buff_targets, i)
+					already_removed = true
+				end
+
+				local dst = mvector3.distance(buffed_target:position(), self._unit:movement():m_head_pos())
+
+				if not already_removed and dst > heal_range then
+					table.remove(self._buff_targets, i)
+					already_removed = true
+				end
+			end
+
+			-- Applying buffs to all the valid targets
+
+			for _, buffed_target in ipairs(self._buff_targets) do
+				local buffed_target_tweak_data = tweak_data.character[buffed_target:base()._tweak_table]
+				local health_left = buffed_target:character_damage()._health
+				local max_health = buffed_target:character_damage()._HEALTH_INIT
+				local overheal_mult = buffed_target_tweak_data.overheal_mult or 1
+				
+				max_health = buffed_target:character_damage()._HEALTH_INIT * overheal_mult
+
+				buffed_target:character_damage():refresh_overheal_decay_timer(t)
+				
+				if health_left < max_health then
+					local amount_to_heal = math.ceil(((max_health - health_left) / 20))
+					local disable_outlines = managers.mutators:modify_value("CopMovement:DisableOutlines", false)
+					if self._unit:contour()  then
+						if not disable_outlines then
+							self._unit:contour():add("medic_show", false)
+							self._unit:contour():flash("medic_show", 0.2)
+						end
+						managers.groupai:state():chk_say_enemy_chatter(self._unit, self._m_pos, heal_vo)
+					end										
+					if buffed_target:contour() then
+						if overheal_mult > 1 then
+							buffed_target:base():lpf_heal_effect(true)
+						else
+							buffed_target:base():lpf_heal_effect(false)
+						end
+					end		
+					buffed_target:character_damage():_apply_damage_to_health((amount_to_heal * -1))
 				end
 			end
 		end

--- a/lua/sc/units/enemies/copmovement.lua
+++ b/lua/sc/units/enemies/copmovement.lua
@@ -366,11 +366,6 @@ function CopMovement:do_asu(self)
 			end
 
 			for _, buffed_target in ipairs(self._buff_targets) do
-				if buffed_target:base():get_total_buff("base_damage") > 0 then
-					-- When the ASU buffs were rewritten, I was originally gonna change this too,
-					-- but actually, it makes sense to look for general damage buffs.
-					return
-				end
 				managers.groupai:state():chk_say_enemy_chatter(self._unit, self._m_pos, asu_vo)
 				buffed_target:base():enable_asu_laser(damage_buff * 0.01, t, false)
 			end

--- a/lua/sc/units/enemies/huskcopdamage.lua
+++ b/lua/sc/units/enemies/huskcopdamage.lua
@@ -12,7 +12,7 @@ function HuskCopDamage:die(attack_data)
 	
 	if self._unit:base() then
 		self._unit:base():disable_lpf_buff()
-		self._unit:base():disable_asu_laser(true)
+		self._unit:base():disable_asu_laser()
 		self._unit:base():converted_enemy_effect(false)
 	end	
 

--- a/lua/sc/units/enemies/logics/coplogicintimidated.lua
+++ b/lua/sc/units/enemies/logics/coplogicintimidated.lua
@@ -1,6 +1,6 @@
 --Remove ASU Laser when they surrender
 Hooks:PostHook(CopLogicIntimidated, "enter", "fuck_enter", function(data, new_logic_name, enter_params)
-	data.unit:base():disable_asu_laser(true)
+	data.unit:base():disable_asu_laser()
 end)
 
 --Remove OMNIA buffs/no pager on tie down

--- a/lua/sc/units/enemies/medic/medicdamage.lua
+++ b/lua/sc/units/enemies/medic/medicdamage.lua
@@ -33,9 +33,7 @@ function MedicDamage:heal_unit(unit)
 	--To do: make this actually sync correctly, since Overkill likely never will
 	if Global.game_settings.difficulty == "sm_wish" then
 		if my_tweak_data == "medic" or my_tweak_data == "tank_medic" then
-			unit:base():add_buff("base_damage", 15 * 0.01)
-
-			unit:base():enable_asu_laser(true)
+			unit:base():enable_asu_laser(15 * 0.01, TimerManager:game():time(), true)
 		end
 	end	
 

--- a/lua/sc/units/enemies/tankcopdamage.lua
+++ b/lua/sc/units/enemies/tankcopdamage.lua
@@ -32,9 +32,8 @@ function TankCopDamage:seq_clbk_vizor_shatter()
 		if Global.game_settings.difficulty == "sm_wish" then
 			self._unit:sound():say("visor_lost")
 			self._unit:sound():play("clk_turn", nil, nil)
-			self._unit:base():add_buff("base_damage", 10 * 0.01)
 			self._unit:movement():play_redirect("use_syringe")
-			self._unit:base():enable_asu_laser(true)
+			self._unit:base():enable_asu_laser(10 * 0.01, TimerManager:game():time(), true)
 		else
 			self._unit:sound():say("visor_lost")
 		end		


### PR DESCRIPTION
This PR changes how the LPF overheal and the ASU damage buff behaves by making them disappear one way or another after the LPF / ASU unit is dealt with.

- LPF overheal now decays naturally at a steady rate after a unit has been out of any LPF unit's range for a given time. Current numbers are 5 seconds after being out of an LPF unit's range, the unit starts losing 10% of their max potential overheal each second.
- When an LPF unit's antenna thing is shot, every nearby unit that was getting healed by the LPF at that moment is momentarily stunned alongside the LPF, and they all completely lose their overheal (in addition to the LPF no longer able to heal or overheal, which is the current effect).
- Similarly, units leaving the vicinity of an ASU unit lose their damage boost from the ASU in 1.3 seconds (mainly because ASU checks to apply buffs every 1 second).
- If an ASU unit dies, it forces any unit it was damage boosting at that moment to immediately lose their damage boosts.
- Damage boosts received from other sources (like from a unit being healed by a Medic, or the one that the Dozer gets when its faceplate is broken) are left untouched and stick around forever still.