### PR TITLE
Fix carry stacker bug that "revives" you when you drop a bag

### DIFF
--- a/lua/sc/managers/playermanager.lua
+++ b/lua/sc/managers/playermanager.lua
@@ -2153,6 +2153,10 @@ Hooks:PostHook(PlayerManager, "can_carry", "ResCarryStackerCanCarry", function(s
     return check_weight >= max_weight
 end)
 
+Hooks:PreHook(PlayerManager, "drop_carry", "ResCarryStackerPreDropCarry", function(self, _)
+	self._player_state_before_drop = self._current_state
+end)
+
 --- Makes the timing before you can interact again consistent. That's it.
 --- We DO base it on the synced_carry_stacker length rather than synced_carry, though this is
 --- because of the code reorganisation that mandates we trust the host with dropping stuff.
@@ -2166,6 +2170,15 @@ Hooks:PostHook(PlayerManager, "drop_carry", "ResCarryStackerDropCarry", function
 
 	self:update_carrystacker_hud(peer_id)
 	self:recalculate_carried_weights()
+
+	if not self._player_state_before_drop then
+		return
+	end
+	if self._player_state_before_drop == "carry" then
+		managers.player:set_player_state("standard")
+	else
+		managers.player:set_player_state(self._player_state_before_drop)
+	end
 end)
 
 --- This is a bit delayed compared to the original CarryStacker implementation where this (or rather


### PR DESCRIPTION
This PR fixes an issue where the player state is set to standard if the player goes into bleedout with 2 or more bags, then throws one.

The issue is caused by `PlayerManager:drop_carry()` checking if the playerstate was carrying, and if it was, it sets it to standard. This ordinarily wouldn't cause problems, but gaining a bag from your carry stacker stack sets your state to carrying, which causes the logic to get confused and force you to stand up from bleeding out.  
I simply added a pre-hook to it that saves the state, then uses that in the post-hook to make the same decision.

I _thiiiiink_ this should work, at least. Looked fine in testing.