### PR TITLE
Fix Bullseye and Hostage Taker Aced

### DIFF
--- a/lua/sc/units/enemies/copdamage.lua
+++ b/lua/sc/units/enemies/copdamage.lua
@@ -598,6 +598,11 @@ function CopDamage:damage_fire(attack_data)
 			}
 			self._player_damage_ratio = 0
 		else
+			if head then
+				-- This feels... weird, but flames can technically headshot, I guess!
+				managers.player:on_lethal_headshot_dealt(attack_data.attacker_unit, attack_data)
+			end
+
 			result = {
 				type = "death",
 				variant = attack_data.variant
@@ -1791,6 +1796,8 @@ function CopDamage:damage_melee(attack_data)
 			attack_data.damage_effect = self._health
 
 			if head then
+				managers.player:on_lethal_headshot_dealt(attack_data.attacker_unit, attack_data)
+
 				if table_contains(grenadier_smash, self._unit:name()) then
 					self._unit:damage():run_sequence_simple("grenadier_glass_break")
 				else

--- a/lua/sc/units/interactions/interactionext.lua
+++ b/lua/sc/units/interactions/interactionext.lua
@@ -363,7 +363,7 @@ function IntimitateInteractionExt:interact(player)
 		self:remove_interact()
 		self:set_active(false)
 		player:sound():play("cable_tie_apply")
-		self._unit:brain():on_tied(player, false, managers.player:has_category_upgrade("player", "civilians_dont_flee")) --No longer uses super_syndrome.
+		self._unit:brain():on_tied(player, false, not managers.player:has_category_upgrade("player", "civilians_dont_flee")) --No longer uses super_syndrome.
 	end
 end
 


### PR DESCRIPTION
This PR fixes Bullseye not decreasing its cooldown on lethal headshots with melee (and flames), and Hostage Taker Aced's "Your civillian hostages will not flee when they have been rescued by law enforcers" not working.

The former was just a missing function call from the two non-bullet damage functions.   
The latter was reversed logic, `on_tied()` last parameter specifies when the unit *can* flee, not when it cannot. And yes, this *does* mean that taking Hostage Taker Aced actually nerfed you before, as it would be the thing that allowed civilians you tied down to flee after being rescued.