### PR TITLE
Intimidated guards now check in during stealth, slowly raising suspicion

### DIFF
--- a/lua/managers/HUDManager.lua
+++ b/lua/managers/HUDManager.lua
@@ -127,6 +127,7 @@ function HUDManager:_upd_animate_level_suspicion(t,amount,amount_max,amount_inte
 	panel:child("suspicion_interp"):set_color(Color(amount_interpolated/amount_max,0,0))
 	suspicion_icon:set_alpha(ratio + base_icon_alpha)
 	panel:child("suspicion_circle"):set_color(Color(ratio,0,0)) --progress radial
+	panel:child("suspicion_checkin"):set_color(Color(tweak_data.stealth_intimidiated_checkin.limit,0,0)) -- Show the stealth checkin limit.
 	local alert_on = amount >= amount_max
 	
 	if alert_on then
@@ -180,7 +181,7 @@ function HUDManager:_create_level_suspicion_hud(hud)
 		texture = radial_texture, -- "guis/dlcs/coco/textures/pd2/hud_absorb_shield", --for soft blue outline instead
 		color = Color.black, --starts out invisible
 		alpha = 0.5,
-		layer = 3,
+		layer = 4,
 		w = radial_size,
 		h = radial_size
 	})
@@ -190,9 +191,19 @@ function HUDManager:_create_level_suspicion_hud(hud)
 		texture = radial_texture,
 		color = Color.black,
 		alpha = 1,
-		layer = 2,
+		layer = 3,
 		w = radial_size,
 		h = radial_size
+	})
+	local suspicion_checkin = level_suspicion_panel:bitmap({ -- Used to visually show how much can checkins add to suspicion.
+		name = "suspicion_checkin",
+		render_template = "VertexColorTexturedRadial",
+		texture = "guis/dlcs/coco/textures/pd2/hud_absorb_shield",
+		color = Color.black,
+		alpha = 0.5,
+		layer = 2,
+		w = radial_size * 0.46, -- The textures (this and hud_rip) are actually roughly the same size visually, but hud_rip has comical amounts of padding to it.
+		h = radial_size * 0.46
 	})
 	local suspicion_bg = level_suspicion_panel:bitmap({ --circle outline bg
 		name = "suspicion_bg",
@@ -225,6 +236,7 @@ function HUDManager:_create_level_suspicion_hud(hud)
 	local center_x,center_y = level_suspicion_panel:center()
 	suspicion_circle:set_center(center_x,center_y)
 	suspicion_interp:set_center(center_x,center_y)
+	suspicion_checkin:set_center(center_x,center_y)
 	suspicion_bg:set_center(center_x,center_y)
 	suspicion_icon:set_center(center_x,center_y)
 	for i=1,NUM_SUSPICION_EFFECT_GHOSTS,1 do 

--- a/lua/sc/loc/loc.lua
+++ b/lua/sc/loc/loc.lua
@@ -5189,6 +5189,10 @@ Hooks:Add("LocalizationManagerPostInit", "SC_Localization_Skills_Eng", function(
 		["hud_repair_sentry"] = "$AMMO_LEFT",
 		["hud_action_repair_sentry"] = "Repairing sentry...",
 
+		-- Intimidated guards checking in in stealth
+		["intimidated_guard_checkin_active"] = "Guard will check in in $CHECKIN_TIME seconds. (+$SUSP_INC suspicion)",
+		["intimidated_guard_checkin_inactive"] = "No effect on guard checking in.",
+
 		--More fitting descriptions of difficulties--
 		["menu_risk_elite"] = "DEATH WISH. FOR YOU, ACTION IS THE JUICE.",
 		["menu_risk_sm_wish"] = "DEATH SENTENCE. NOW SHOW THEM THAT YOU CAN'T BE STOPPED.",
@@ -5285,6 +5289,8 @@ Hooks:Add("LocalizationManagerPostInit", "SC_Localization_Skills_Eng", function(
 		["loading_stealth_res_19"] = "Pager operators are less lenient on higher difficulties. Your last pager is indicated by the use of a special voice line.",
 		["loading_stealth_res_20"] = "Answering pagers beyond your allowed limit massively increases suspicion, but not as much as dropping or not answering.",
 		["loading_stealth_res_21"] = "Pagers take longer to answer and expire faster on the ground on higher difficulties.",
+		["loading_stealth_res_22"] = "Intimidated guards check in with the operators every so often, raising your suspicion over time. However, the heist cannot ever go loud because of a check-in.",
+		["loading_stealth_res_23"] = "You can see when an intimidated guard will next check in with the pager operators (and how much your suspicion will increase when that happens) by hovering over them.",
 		--Equipment/Skill Hints
 		["loading_equip_skills_res_title"] = "Restoration Equipment/Skill Tips",
 		["loading_equip_skills_res_1"] = "Shotguns lose effectiveness at long range as their accuracy gets lower while higher accuracy hurts their ability to hit multiple targets; experiment and see what works best!",

--- a/lua/sc/managers/enemymanager.lua
+++ b/lua/sc/managers/enemymanager.lua
@@ -35,3 +35,42 @@ Hooks:PostHook(EnemyManager, "on_enemy_died", "ResOnEnemyDied", function(self, d
 	end
 	
 end)
+
+-- For intimidated guards checking in with the pager operators.
+
+Hooks:PostHook(EnemyManager, "_init_enemy_data", "res_init_enemy_data", function(self)
+	--- Contains the actual data about intimidated guards.
+	self._intimidated_guards = {}
+end)
+
+function EnemyManager:all_intimidated_guards()
+	return self._intimidated_guards
+end
+
+function EnemyManager:register_intimidated_guard(guard_unit, t)
+	self._intimidated_guards[guard_unit:key()] = {
+		unit = guard_unit, -- Unit data.
+		t = t, -- The time when the unit was intimidated.
+		hints = { -- Used exclusively for the interaction text.
+			time_left = 0, -- Time left before next check-in.
+			sus_increase = 0 -- By how much will the next check-in increase suspicion.
+		}
+	}
+end
+
+function EnemyManager:unregister_intimidated_guard(guard_unit)
+	self._intimidated_guards[guard_unit:key()] = nil
+end
+
+--- Updates only the hints of the intimidated guard (hints being what are used to fill out the interaction text).
+--- @param key Key The unit's key, typically obtained with unit:key(). Used for index determination.
+--- @param time_left number Seconds left before the next check-in.
+--- @param sus_increase number Number between 0-1, the amount the suspicion meter will be increased by. Percentage of the suspicion meter, not related to the internal values -- so 0.5 will *always* mean 50% suspicion increase, no matter what difficulty.
+function EnemyManager:update_intimidated_guard_hints(key, time_left, sus_increase)
+	if self._intimidated_guards[key] then
+		self._intimidated_guards[key].hints = {
+			time_left = time_left,
+			sus_increase = sus_increase
+		}
+	end
+end

--- a/lua/sc/managers/groupaistatebase.lua
+++ b/lua/sc/managers/groupaistatebase.lua
@@ -1056,6 +1056,11 @@ function GroupAIStateBase:update(t, dt)
 					self:_delay_whisper_suspicion_mul_decay()
 				end
 
+				if data.unit:sound() then
+					data.unit:sound():stop()
+					data.unit:sound():play(data.unit:brain():_get_radio_id("dsp_radio_fooled_1"), nil, true)
+				end
+
 				data.t = data.t + time_since_intimidation
 			end
 

--- a/lua/sc/managers/groupaistatebase.lua
+++ b/lua/sc/managers/groupaistatebase.lua
@@ -1069,7 +1069,8 @@ function GroupAIStateBase:update(t, dt)
 			-- value of the overall suspicion meter visually, not as a percentage value of the internal numbers.
 			-- So this way, we get that back.
 
-			if potential_sus_increase == 0 and data.unit:interaction() and data.unit:interaction().tweak_data == "intimidated_guard_checkin" then
+			if potential_sus_increase == 0 and data.unit and alive(data.unit) and data.unit:base() and data.unit:interaction() and data.unit:interaction().tweak_data == "intimidated_guard_checkin" then
+				--  This is a comical amount of checks, but this goddamn if crashed the game with access violations so fucking much.
 				data.unit:interaction():set_tweak_data("intimidated_guard_checkin_pointless")
 			end
 

--- a/lua/sc/managers/groupaistatebase.lua
+++ b/lua/sc/managers/groupaistatebase.lua
@@ -1030,7 +1030,7 @@ function GroupAIStateBase:update(t, dt)
 	end
 	
 	-- Update intimidated guards in stealth to check in with the pager operators
-	if is_whisper_mode and Network:is_server() then
+	if is_whisper_mode then
 		-- You cannot use # to check the length of a table with non-sequential keys, but still, I only wanna dirty
 		-- the interaction text once per run through the intimidated guards.
 		local _has_dirtied_text_once_per_check = false
@@ -1041,16 +1041,18 @@ function GroupAIStateBase:update(t, dt)
 			local time_since_intimidation = t - data.t
 
 			if not vanilla_behaviour and potential_sus_increase > 0 and time_since_intimidation > tweak_data.stealth_intimidiated_checkin.time then
-				self._old_guard_detection_mul_raw = self._old_guard_detection_mul_raw + potential_sus_increase
-				self._guard_detection_mul_raw = self._old_guard_detection_mul_raw
-				self._decay_target = self._old_guard_detection_mul_raw * 0.75
-				self._guard_delay_deduction = self._guard_delay_deduction + potential_sus_increase
-				self:_delay_whisper_suspicion_mul_decay()
+				if Network:is_server() then
+					self._old_guard_detection_mul_raw = self._old_guard_detection_mul_raw + potential_sus_increase
+					self._guard_detection_mul_raw = self._old_guard_detection_mul_raw
+					self._decay_target = self._old_guard_detection_mul_raw * 0.75
+					self._guard_delay_deduction = self._guard_delay_deduction + potential_sus_increase
+					self:_delay_whisper_suspicion_mul_decay()
+				end
 
 				data.t = data.t + time_since_intimidation
 			end
 
-			managers.enemy:update_intimidated_guard_hints(index, tweak_data.stealth_intimidiated_checkin.time - time_since_intimidation, potential_sus_increase)
+			managers.enemy:update_intimidated_guard_hints(index, tweak_data.stealth_intimidiated_checkin.time - time_since_intimidation, potential_sus_increase / alarm_threshold)
 
 			if potential_sus_increase == 0 and data.unit:interaction() and data.unit:interaction().tweak_data == "intimidated_guard_checkin" then
 				data.unit:interaction():set_tweak_data("intimidated_guard_checkin_pointless")

--- a/lua/sc/managers/groupaistatebase.lua
+++ b/lua/sc/managers/groupaistatebase.lua
@@ -1037,10 +1037,17 @@ function GroupAIStateBase:update(t, dt)
 
 		for index, data in pairs(managers.enemy:all_intimidated_guards()) do
 			local vanilla_behaviour = managers.mutators:modify_value("CopMovement:VanillaPoliceCall", false)
-			local potential_sus_increase = math.max(math.min((tweak_data.stealth_intimidiated_checkin.limit * alarm_threshold) - level_suspicion, tweak_data.stealth_intimidiated_checkin.penalty * alarm_threshold), 0)
+			local potential_sus_increase = math.max(math.min((tweak_data.stealth_intimidiated_checkin.limit * alarm_threshold) - level_suspicion, tweak_data.stealth_intimidiated_checkin.penalty * alarm_threshold), 0) -- Effectively clamps the value between 0 and as many as needed to reach the limit. Couldn't actually use math.clamp because limit-current can be negative.
 			local time_since_intimidation = t - data.t
 
-			if not vanilla_behaviour and potential_sus_increase > 0 and time_since_intimidation > tweak_data.stealth_intimidiated_checkin.time then
+			local player_count = 1
+			if managers.network:session() then
+				player_count = table.size(managers.network:session():all_peers())
+			end
+			-- Theoretically supports big lobby mods if someone gets their jollies from 12 player stealth.
+			local time_til_checkin = tweak_data.stealth_intimidiated_checkin.time[math.clamp(player_count,1,#tweak_data.stealth_intimidiated_checkin.time)]
+
+			if not vanilla_behaviour and potential_sus_increase > 0 and time_since_intimidation > time_til_checkin then
 				if Network:is_server() then
 					self._old_guard_detection_mul_raw = self._old_guard_detection_mul_raw + potential_sus_increase
 					self._guard_detection_mul_raw = self._old_guard_detection_mul_raw
@@ -1052,7 +1059,10 @@ function GroupAIStateBase:update(t, dt)
 				data.t = data.t + time_since_intimidation
 			end
 
-			managers.enemy:update_intimidated_guard_hints(index, tweak_data.stealth_intimidiated_checkin.time - time_since_intimidation, potential_sus_increase / alarm_threshold)
+			managers.enemy:update_intimidated_guard_hints(index, time_til_checkin - time_since_intimidation, potential_sus_increase / alarm_threshold)
+			-- potential_sus_increase needs to be divided by alarm_threshold, as the suspicion increase is stored as an actual percentage
+			-- value of the overall suspicion meter visually, not as a percentage value of the internal numbers.
+			-- So this way, we get that back.
 
 			if potential_sus_increase == 0 and data.unit:interaction() and data.unit:interaction().tweak_data == "intimidated_guard_checkin" then
 				data.unit:interaction():set_tweak_data("intimidated_guard_checkin_pointless")

--- a/lua/sc/managers/groupaistatebase.lua
+++ b/lua/sc/managers/groupaistatebase.lua
@@ -1028,9 +1028,41 @@ function GroupAIStateBase:update(t, dt)
 	if self._last_detection_mul and self._last_detection_mul ~= self._old_guard_detection_mul_raw and Network:is_server() then 
 		LuaNetworking:SendToPeers("restoration_sync_level_suspicion",tostring(self._old_guard_detection_mul_raw) .. ":" .. tostring(self._weapons_hot_threshold))
 	end
-			
 	
-	
+	-- Update intimidated guards in stealth to check in with the pager operators
+	if is_whisper_mode and Network:is_server() then
+		-- You cannot use # to check the length of a table with non-sequential keys, but still, I only wanna dirty
+		-- the interaction text once per run through the intimidated guards.
+		local _has_dirtied_text_once_per_check = false
+
+		for index, data in pairs(managers.enemy:all_intimidated_guards()) do
+			local vanilla_behaviour = managers.mutators:modify_value("CopMovement:VanillaPoliceCall", false)
+			local potential_sus_increase = math.max(math.min((tweak_data.stealth_intimidiated_checkin.limit * alarm_threshold) - level_suspicion, tweak_data.stealth_intimidiated_checkin.penalty * alarm_threshold), 0)
+			local time_since_intimidation = t - data.t
+
+			if not vanilla_behaviour and potential_sus_increase > 0 and time_since_intimidation > tweak_data.stealth_intimidiated_checkin.time then
+				self._old_guard_detection_mul_raw = self._old_guard_detection_mul_raw + potential_sus_increase
+				self._guard_detection_mul_raw = self._old_guard_detection_mul_raw
+				self._decay_target = self._old_guard_detection_mul_raw * 0.75
+				self._guard_delay_deduction = self._guard_delay_deduction + potential_sus_increase
+				self:_delay_whisper_suspicion_mul_decay()
+
+				data.t = data.t + time_since_intimidation
+			end
+
+			managers.enemy:update_intimidated_guard_hints(index, tweak_data.stealth_intimidiated_checkin.time - time_since_intimidation, potential_sus_increase)
+
+			if potential_sus_increase == 0 and data.unit:interaction() and data.unit:interaction().tweak_data == "intimidated_guard_checkin" then
+				data.unit:interaction():set_tweak_data("intimidated_guard_checkin_pointless")
+			end
+
+			if alive(managers.interaction:active_unit()) and not _has_dirtied_text_once_per_check then
+				managers.interaction:active_unit():interaction():set_text_dirty(true)
+				_has_dirtied_text_once_per_check = true
+			end
+		end
+	end
+
 	if is_whisper_mode then
 		local warning_1_threshold = self._weapons_hot_threshold * 0.25
 		local warning_2_threshold = self._weapons_hot_threshold * 0.5

--- a/lua/sc/tweak_data/interactiontweakdata.lua
+++ b/lua/sc/tweak_data/interactiontweakdata.lua
@@ -64,6 +64,18 @@ Hooks:PostHook( InteractionTweakData, "init", "SC_interact", function(self)
 	self.res_lvl_assault_shatter.action_text_id = "res_lvl_assault_shatter_action"
 	self.res_lvl_assault_shatter.timer = 3
 	
+
+	-- Intimidated guards in stealth display when they next check in.
+	self.intimidated_guard_checkin = {
+		icon = "develop",
+		text_id = "intimidated_guard_checkin_active",
+		no_contour = true
+	}
+	self.intimidated_guard_checkin_pointless = {
+		icon = "develop",
+		text_id = "intimidated_guard_checkin_inactive",
+		no_contour = true
+	}
 	
 	self.start_sentrygun_repairmode = {
 		icon = "icon_repair",

--- a/lua/sc/tweak_data/tipstweakdata.lua
+++ b/lua/sc/tweak_data/tipstweakdata.lua
@@ -500,6 +500,18 @@ function TipsTweakData:init()
 			category = "stealth_res"
 		},
 		{
+			cat_index = 22,
+			image = "enemy_guards",
+			consoles = true,
+			category = "stealth_res"
+		},
+		{
+			cat_index = 23,
+			image = "enemy_guards",
+			consoles = true,
+			category = "stealth_res"
+		},
+		{
 			cat_index = 1,
 			image = "general_enforcer",
 			consoles = true,

--- a/lua/sc/tweak_data/tweakdata.lua
+++ b/lua/sc/tweak_data/tweakdata.lua
@@ -1099,13 +1099,13 @@ end
 --- When a guard is intimidated during stealth, every X seconds, they'll do a check-in with control.
 --- This simply means that every X seconds, every intimidated guard will increase the suspicion meter by a given amount.   
 --- @class StealthIntimidationCheckin
---- @field time number Defines how many seconds should there been between check-ins.
+--- @field time number[] Defines how many seconds should there been between check-ins based on player count, with the index representing the current amount of players.
 --- @field penalty number A number between 0 and 1 that increases the suspicion meter by this much during a check-in. Do note that this is in relation to what you visually see -- in code, the "maximum" isn't 1 / 100% for the suspicion meter, but you can treat this number as if it was (it'll get adjusted to to the suspicion meter maximum).
 --- @field limit number A number between 0 and 1 that defines a point past which check-ins cannot increase the suspicion meter. Same as with the `penalty` field -- treat this as if it *actually* meant a percentage of the suspicion meter, so 0.5 will *always* mean 50% of the suspicion meter, regardless of difficulty.
 
 --- @type StealthIntimidationCheckin
 tweak_data.stealth_intimidiated_checkin = {}
-tweak_data.stealth_intimidiated_checkin.time = 60
+tweak_data.stealth_intimidiated_checkin.time = {80, 70, 60, 50}
 
 if difficulty_index <= 4 then
 	-- This gameplay mechanic is turned off for difficulties below Overkill.

--- a/lua/sc/tweak_data/tweakdata.lua
+++ b/lua/sc/tweak_data/tweakdata.lua
@@ -1094,6 +1094,41 @@ else
 	tweak_data.asu_damage_buff = 20
 end	
 
+-- Stealth-related tweaks
+
+--- When a guard is intimidated during stealth, every X seconds, they'll do a check-in with control.
+--- This simply means that every X seconds, every intimidated guard will increase the suspicion meter by a given amount.   
+--- @class StealthIntimidationCheckin
+--- @field time number Defines how many seconds should there been between check-ins.
+--- @field penalty number A number between 0 and 1 that increases the suspicion meter by this much during a check-in. Do note that this is in relation to what you visually see -- in code, the "maximum" isn't 1 / 100% for the suspicion meter, but you can treat this number as if it was (it'll get adjusted to to the suspicion meter maximum).
+--- @field limit number A number between 0 and 1 that defines a point past which check-ins cannot increase the suspicion meter. Same as with the `penalty` field -- treat this as if it *actually* meant a percentage of the suspicion meter, so 0.5 will *always* mean 50% of the suspicion meter, regardless of difficulty.
+
+--- @type StealthIntimidationCheckin
+tweak_data.stealth_intimidiated_checkin = {}
+tweak_data.stealth_intimidiated_checkin.time = 60
+
+if difficulty_index <= 4 then
+	-- This gameplay mechanic is turned off for difficulties below Overkill.
+	tweak_data.stealth_intimidiated_checkin.penalty = 0
+	tweak_data.stealth_intimidiated_checkin.limit = 0
+elseif difficulty_index == 5 then
+	-- 0.016 = 0.5 / 30 -> If you have a single guard intimidated, you'll reach the 50% limit in 30 minutes.
+	tweak_data.stealth_intimidiated_checkin.penalty = 0.016
+	tweak_data.stealth_intimidiated_checkin.limit = 0.5
+elseif difficulty_index == 6 then
+	-- 0.025 = 0.5 / 20 -> If you have a single guard intimidated, you'll reach the 50% limit in 20 minutes.
+	tweak_data.stealth_intimidiated_checkin.penalty = 0.025
+	tweak_data.stealth_intimidiated_checkin.limit = 0.5
+elseif difficulty_index == 7 then
+	-- 0.0375 = 0.75 / 20
+	tweak_data.stealth_intimidiated_checkin.penalty = 0.0375
+	tweak_data.stealth_intimidiated_checkin.limit = 0.75
+else
+	-- 0.05 = 1 / 20 (just rounding the 0.99 up)
+	tweak_data.stealth_intimidiated_checkin.penalty = 0.05
+	tweak_data.stealth_intimidiated_checkin.limit = 0.99
+end
+
 tweak_data.achievement.complete_heist_achievements.pain_train.num_players = nil
 tweak_data.achievement.complete_heist_achievements.anticimex.num_players = nil
 tweak_data.achievement.complete_heist_achievements.ovk_8.num_players = nil

--- a/lua/sc/units/enemies/copbrain.lua
+++ b/lua/sc/units/enemies/copbrain.lua
@@ -281,6 +281,10 @@ logic_variants.hector_boss = logic_variants.triad_boss
 logic_variants.drug_lord_boss = logic_variants.triad_boss
 logic_variants.biker_boss = logic_variants.triad_boss
 
+Hooks:PostHook(CopBrain, "init", "res_init", function(self, unit)
+	self._intimidation_t = 0 -- In Stealth, when the cop was intimidated
+end)
+
 -- Update immediately once we have our pathing results instead of waiting for the next update
 -- Not posthooking _add_pathing_result instead of these two just in case the path gets modified before navlink delays are applied in clbk_pathing_results
 Hooks:PostHook(CopBrain, "clbk_pathing_results", "res_clbk_pathing_results", function(self, search_id, path)

--- a/lua/sc/units/enemies/copdamage.lua
+++ b/lua/sc/units/enemies/copdamage.lua
@@ -2126,6 +2126,11 @@ function CopDamage:die(attack_data)
 		self._unit:interaction():set_active(false, true, false)
 	end
 
+	if self._unit:interaction().tweak_data == "intimidated_guard_checkin" or self._unit:interaction().tweak_data == "intimidated_guard_checkin_pointless" then
+		self._unit:interaction():set_active(false, true, false)
+	end
+	managers.enemy:unregister_intimidated_guard(self._unit)
+
 	if self._char_tweak.ends_assault_on_death then
 		if job == "crojob3" or job == "crojob3_night" then
 			--No assault end, as they're not the assaulting force

--- a/lua/sc/units/enemies/logics/coplogicintimidated.lua
+++ b/lua/sc/units/enemies/logics/coplogicintimidated.lua
@@ -70,6 +70,10 @@ function CopLogicIntimidated._do_tied(data, aggressor_unit)
 	managers.groupai:state():on_criminal_suspicion_progress(nil, data.unit, nil)
 end
 
+Hooks.PostHook(CopLogicIntimidated, "on_enemy_weapons_hot", "res_on_enemy_weapons_hot", function(data)
+	managers.enemy:unregister_intimidated_guard(data.unit)
+end)
+
 -- Tweak hostage rescue conditions
 function CopLogicIntimidated.rescue_SO_verification(ignore_this, data, unit, ...)
 	if unit:movement():cool() then

--- a/lua/sc/units/enemies/logics/coplogicintimidated.lua
+++ b/lua/sc/units/enemies/logics/coplogicintimidated.lua
@@ -40,6 +40,13 @@ function CopLogicIntimidated._do_tied(data, aggressor_unit)
 		data.unit:interaction():set_active(true, true, false)
 	end
 
+	-- Show when intimidated guards will increase suspicion.
+	if not data.brain:is_pager_started() and managers.groupai:state():whisper_mode() and not managers.mutators:modify_value("CopMovement:VanillaPoliceCall", false) then
+		managers.enemy:register_intimidated_guard(data.unit, data.t)
+		data.unit:interaction():set_tweak_data("intimidated_guard_checkin")
+		data.unit:interaction():set_active(true, true, false)
+	end
+
 	if data.unit:unit_data().mission_element then
 		data.unit:unit_data().mission_element:event("tied", data.unit)
 	end	

--- a/lua/sc/units/enemies/logics/coplogicintimidated.lua
+++ b/lua/sc/units/enemies/logics/coplogicintimidated.lua
@@ -41,7 +41,7 @@ function CopLogicIntimidated._do_tied(data, aggressor_unit)
 	end
 
 	-- Show when intimidated guards will increase suspicion.
-	if not data.brain:is_pager_started() and managers.groupai:state():whisper_mode() and not managers.mutators:modify_value("CopMovement:VanillaPoliceCall", false) then
+	if not data.brain:is_pager_started() and managers.groupai:state():whisper_mode() and not managers.mutators:modify_value("CopMovement:VanillaPoliceCall", false) and data.unit:unit_data().has_alarm_pager then
 		managers.enemy:register_intimidated_guard(data.unit, data.t)
 		data.unit:interaction():set_tweak_data("intimidated_guard_checkin")
 		data.unit:interaction():set_active(true, true, false)

--- a/lua/sc/units/interactions/interactionext.lua
+++ b/lua/sc/units/interactions/interactionext.lua
@@ -499,7 +499,7 @@ function IntimitateInteractionExt:_add_string_macros(macros)
 		macros.SUSP_IN = "0.0%"
 
 		if data and data.hints then 
-			macros.CHECKIN_TIME = tostring(math.ceil(data.hints.time_left))
+			macros.CHECKIN_TIME = tostring(math.ceil(math.max(0, data.hints.time_left)))
 			macros.SUSP_INC = tostring(math.floor(data.hints.sus_increase * 1000) / 10).."%" -- Multiplying by 100 gets a percentage value, doing it this way just lets us show one fractional.
 		end
 	end

--- a/lua/sc/units/interactions/interactionext.lua
+++ b/lua/sc/units/interactions/interactionext.lua
@@ -491,6 +491,20 @@ if PickUpWeaponInteractionExt then
 	end)
 end
 
+--- Intimidated guards will display how long until they next check in, and how much they'll increase the suspicion meter.
+function IntimitateInteractionExt:_add_string_macros(macros)
+	if self.tweak_data == "intimidated_guard_checkin" then
+		local data = managers.enemy:all_intimidated_guards()[self._unit:key()]
+		macros.CHECKIN_TIME = "0"
+		macros.SUSP_IN = "0.0%"
+
+		if data and data.hints then 
+			macros.CHECKIN_TIME = tostring(math.ceil(data.hints.time_left))
+			macros.SUSP_INC = tostring(math.floor(data.hints.sus_increase * 1000) / 10).."%" -- Multiplying by 100 gets a percentage value, doing it this way just lets us show one fractional.
+		end
+	end
+end
+
 -- Carry Stacker below
 local master_IntimitateInteractionExt_interact_blocked = IntimitateInteractionExt._interact_blocked
 local master_CarryInteractionExt_interact_blocked = CarryInteractionExt._interact_blocked
@@ -503,6 +517,12 @@ function IntimitateInteractionExt:_interact_blocked(player)
 		end
 		local result = not managers.player:can_carry("person")
 		return result
+	elseif self.tweak_data == "intimidated_guard_checkin" then
+		-- The intimidated guard check-in "interactions" never actually have you interact.
+		return true, nil, "intimidated_guard_checkin_active"
+	elseif self.tweak_data == "intimidated_guard_checkin_pointless" then
+		-- The intimidated guard check-in "interactions" never actually have you interact.
+		return true, nil, "intimidated_guard_checkin_inactive"
 	end
 	local result = master_IntimitateInteractionExt_interact_blocked(self, player)
 	return result


### PR DESCRIPTION
This PR adds a feature wherein intimidated guards will slowly raise suspicion during Stealth.

Firstly, the Suspicion Meter now has a blue-tinted part to it -- this shows the how much suspicion can you gain from purely guard check-ins. When you intimidate a guard, hovering over them will show you when they next check in, and how much it'll raise the suspicion by. When a guard checks in, the "pager operator fooled" voice line will play, allowing you to time which intimidated guard checked in if nearby.

The check in timers, limits, and the "penalty" on a check in vary by player number and difficulty. The current numbers are:

## Check-in Times

| Player Count | Check In Time |
|--------------|---------------|
| 1            | 80 seconds    |
| 2            | 70 seconds    |
| 3            | 60 seconds    |
| 4            | 50 seconds    |

## Limits and Penalties

| Difficulty            | Limit    | Penalty    |
|-----------------------|----------|------------|
| Very Hard (and below) | No limit | No penalty |
| Overkill              | 50%      | +1.6%      |
| Mayhem                | 50%      | +2.5%      |
| Death Wish            | 75%      | +3.75%     |
| Death Sentence        | 99%      | +5%        |

The limits are intentionally set so that the heist cannot go loud purely from guard check-ins.   
Additionally, for every difficulty except Overkill, the penalties are calculated so that with 1 guard intimidated and 3 players, it takes 20 minutes to reach the limit, with additional guards cutting it to 10 minutes (for 2 guards), 6.7 minutes (for 3), and 5 minutes (for 4), assuming they all somehow got intimidated at the same time.   
In case of Overkill, the numbers are 30 minutes for one guard, 15 for two, 10 for three, and 7.5 for four.  
_(The default assumption is 3 players simply because the check-in times were originally static at 60 seconds.)_

**Known issues:** If a player joins mid-game while there's at least one guard intimidated in Stealth, they I think would either not see the hint that shows how much time is left til next check in, or they might see it, but without the values filled in. I gotta look into synchronising that over later.