### PR TITLE
Fix incorrect button prompts on guard interactions and ziplines keeping your speed after attaching a bag

### DIFF
--- a/lua/sc/managers/playermanager.lua
+++ b/lua/sc/managers/playermanager.lua
@@ -2334,3 +2334,8 @@ Hooks:PreHook(PlayerManager, "clear_carry", "ResCarryStackerPreClearCarry", func
 
 	self:update_removed_synced_carry_stacker_to_peers()
 end)
+
+Hooks:PostHook(PlayerManager, "sync_carry_data", "ResSyncCarryData", function(self, _, _, _, _, _, _, _, _, _, _, peer_id)
+	self:recalculate_carried_weights()
+	self:update_carrystacker_hud(peer_id)
+end)

--- a/lua/sc/units/interactions/interactionext.lua
+++ b/lua/sc/units/interactions/interactionext.lua
@@ -493,6 +493,7 @@ end
 
 --- Intimidated guards will display how long until they next check in, and how much they'll increase the suspicion meter.
 function IntimitateInteractionExt:_add_string_macros(macros)
+	IntimitateInteractionExt.super._add_string_macros(self, macros)
 	if self.tweak_data == "intimidated_guard_checkin" then
 		local data = managers.enemy:all_intimidated_guards()[self._unit:key()]
 		macros.CHECKIN_TIME = "0"


### PR DESCRIPTION
This PR ponders why zipline interactions are that deep in the carry code.

It also fixes an issue where even after attaching a bag to a zipline, your speed would still be slowed down, and another where the prompts to answer guard pagers / bag corpses would call for the wrong button.