### PR TITLE
Synchronise guard check-in data over net to clients

### DIFF
--- a/lua/sc/managers/enemymanager.lua
+++ b/lua/sc/managers/enemymanager.lua
@@ -48,7 +48,7 @@ function EnemyManager:all_intimidated_guards()
 end
 
 function EnemyManager:register_intimidated_guard(guard_unit, t)
-	self._intimidated_guards[guard_unit:key()] = {
+	self._intimidated_guards[guard_unit:id()] = {
 		unit = guard_unit, -- Unit data.
 		t = t, -- The time when the unit was intimidated.
 		hints = { -- Used exclusively for the interaction text.
@@ -58,19 +58,40 @@ function EnemyManager:register_intimidated_guard(guard_unit, t)
 	}
 end
 
-function EnemyManager:unregister_intimidated_guard(guard_unit)
-	self._intimidated_guards[guard_unit:key()] = nil
+function EnemyManager:unregister_intimidated_guard(guard_id)
+	self._intimidated_guards[guard_id] = nil
 end
 
 --- Updates only the hints of the intimidated guard (hints being what are used to fill out the interaction text).
---- @param key Key The unit's key, typically obtained with unit:key(). Used for index determination.
+--- @param id UnitID The unit's ID, typically obtained with unit:id(). Used for index determination.
 --- @param time_left number Seconds left before the next check-in.
 --- @param sus_increase number Number between 0-1, the amount the suspicion meter will be increased by. Percentage of the suspicion meter, not related to the internal values -- so 0.5 will *always* mean 50% suspicion increase, no matter what difficulty.
-function EnemyManager:update_intimidated_guard_hints(key, time_left, sus_increase)
-	if self._intimidated_guards[key] then
-		self._intimidated_guards[key].hints = {
+function EnemyManager:update_intimidated_guard_hints(id, time_left, sus_increase)
+	if self._intimidated_guards[id] then
+		self._intimidated_guards[id].hints = {
 			time_left = time_left,
 			sus_increase = sus_increase
 		}
+	end
+end
+
+function EnemyManager:decode_intimidated_guard_units(unit_id, time)
+
+	local units = World:find_units_quick("all", managers.slot:get_mask("hostages"))
+	for _, unit in pairs(units) do
+		if tonumber(unit:id()) == tonumber(unit_id) then
+			self:register_intimidated_guard(unit, tonumber(time))
+			return
+		end
+	end
+end
+
+function EnemyManager:update_intimidated_guard_data_to_peer(peer)
+	if peer:ip_verified() then
+		for unit_id, data in pairs(self._intimidated_guards) do
+			if data.t and data.unit then
+				LuaNetworking:SendToPeers("sync_intimidated_guard_data",data.unit:id(), tostring(data.t))
+			end
+		end
 	end
 end

--- a/lua/sc/managers/groupaistatebase.lua
+++ b/lua/sc/managers/groupaistatebase.lua
@@ -1036,7 +1036,12 @@ function GroupAIStateBase:update(t, dt)
 		local _has_dirtied_text_once_per_check = false
 
 		for index, data in pairs(managers.enemy:all_intimidated_guards()) do
-			local temp_alarm_threshold = (alarm_threshold ~= 0) and alarm_threshold or self._weapons_hot_threshold or 1 -- While the alarm threshold is 0, the server won't sync it over. Until then, we'll just pretend we got the most amount of suspicion possible to fill.
+			-- While the alarm threshold is 0, the server won't sync it over. Until then, we'll just pretend we got the most amount
+			-- of suspicion possible to fill. _weapons_hot_threshold shouldn't ever be 0, but I'm starting to not trust PAYDAY code.
+			local temp_alarm_threshold =
+				(alarm_threshold ~= 0 and alarm_threshold)
+				or (self._weapons_hot_threshold ~= 0 and self._weapons_hot_threshold)
+				or 1
 
 			local vanilla_behaviour = managers.mutators:modify_value("CopMovement:VanillaPoliceCall", false)
 			local potential_sus_increase = math.max(math.min((tweak_data.stealth_intimidiated_checkin.limit * temp_alarm_threshold) - level_suspicion, tweak_data.stealth_intimidiated_checkin.penalty * temp_alarm_threshold), 0) -- Effectively clamps the value between 0 and as many as needed to reach the limit. Couldn't actually use math.clamp because limit-current can be negative.

--- a/lua/sc/managers/groupaistatebase.lua
+++ b/lua/sc/managers/groupaistatebase.lua
@@ -1036,8 +1036,10 @@ function GroupAIStateBase:update(t, dt)
 		local _has_dirtied_text_once_per_check = false
 
 		for index, data in pairs(managers.enemy:all_intimidated_guards()) do
+			local temp_alarm_threshold = (alarm_threshold ~= 0) and alarm_threshold or self._weapons_hot_threshold or 1 -- While the alarm threshold is 0, the server won't sync it over. Until then, we'll just pretend we got the most amount of suspicion possible to fill.
+
 			local vanilla_behaviour = managers.mutators:modify_value("CopMovement:VanillaPoliceCall", false)
-			local potential_sus_increase = math.max(math.min((tweak_data.stealth_intimidiated_checkin.limit * alarm_threshold) - level_suspicion, tweak_data.stealth_intimidiated_checkin.penalty * alarm_threshold), 0) -- Effectively clamps the value between 0 and as many as needed to reach the limit. Couldn't actually use math.clamp because limit-current can be negative.
+			local potential_sus_increase = math.max(math.min((tweak_data.stealth_intimidiated_checkin.limit * temp_alarm_threshold) - level_suspicion, tweak_data.stealth_intimidiated_checkin.penalty * temp_alarm_threshold), 0) -- Effectively clamps the value between 0 and as many as needed to reach the limit. Couldn't actually use math.clamp because limit-current can be negative.
 			local time_since_intimidation = t - data.t
 
 			local player_count = 1
@@ -1064,7 +1066,7 @@ function GroupAIStateBase:update(t, dt)
 				data.t = data.t + time_since_intimidation
 			end
 
-			managers.enemy:update_intimidated_guard_hints(index, time_til_checkin - time_since_intimidation, potential_sus_increase / alarm_threshold)
+			managers.enemy:update_intimidated_guard_hints(index, time_til_checkin - time_since_intimidation, potential_sus_increase / temp_alarm_threshold)
 			-- potential_sus_increase needs to be divided by alarm_threshold, as the suspicion increase is stored as an actual percentage
 			-- value of the overall suspicion meter visually, not as a percentage value of the internal numbers.
 			-- So this way, we get that back.

--- a/lua/sc/network/base/networkpeer.lua
+++ b/lua/sc/network/base/networkpeer.lua
@@ -49,6 +49,12 @@ function NetworkPeer:mark_cheater(reason, auto_kick)
 	return
 end
 
+Hooks:PostHook(NetworkPeer, "sync_data", "res_sync_data", function(self, peer)
+	if Network:is_server() then
+		managers.enemy:update_intimidated_guard_data_to_peer(peer)
+	end
+end)
+
 -- Hooks:PostHook( NetworkPeer, "send", "SC_Network", function(self, func_name, ...)
 -- 	-- In SC mode if the func is matched, call the prefixed version instead
 -- 	if restoration.network_handler_funcs[func_name] then

--- a/lua/sc/network/handlers/unitnetworkhandler.lua
+++ b/lua/sc/network/handlers/unitnetworkhandler.lua
@@ -370,3 +370,11 @@ function UnitNetworkHandler:camera_set_attention_pos(cam_unit, pos)
 
 	cam_unit:base():set_target_attention({ pos = pos })
 end
+
+LuaNetworking:AddReceiveHook("sync_intimidated_guard_data", "SyncIntimidatedGuardDataHook", function(unit_id, time, sender)
+	managers.enemy:decode_intimidated_guard_units(unit_id, time)
+end)
+
+LuaNetworking:AddReceiveHook("sync_intimidated_guard_data_delete", "SyncIntimidatedGuardDataDeleteHook", function(unit_id, sender)
+	managers.enemy:unregister_intimidated_guard(unit_id)
+end)

--- a/lua/sc/units/enemies/copdamage.lua
+++ b/lua/sc/units/enemies/copdamage.lua
@@ -2129,7 +2129,10 @@ function CopDamage:die(attack_data)
 	if self._unit:interaction().tweak_data == "intimidated_guard_checkin" or self._unit:interaction().tweak_data == "intimidated_guard_checkin_pointless" then
 		self._unit:interaction():set_active(false, true, false)
 	end
-	managers.enemy:unregister_intimidated_guard(self._unit)
+	managers.enemy:unregister_intimidated_guard(self._unit:id())
+	if Network:is_server() then
+		LuaNetworking:SendToPeers("sync_intimidated_guard_data_delete", self._unit:id())
+	end
 
 	if self._char_tweak.ends_assault_on_death then
 		if job == "crojob3" or job == "crojob3_night" then

--- a/lua/sc/units/enemies/logics/coplogicintimidated.lua
+++ b/lua/sc/units/enemies/logics/coplogicintimidated.lua
@@ -43,6 +43,7 @@ function CopLogicIntimidated._do_tied(data, aggressor_unit)
 	-- Show when intimidated guards will increase suspicion.
 	if not data.brain:is_pager_started() and managers.groupai:state():whisper_mode() and not managers.mutators:modify_value("CopMovement:VanillaPoliceCall", false) and data.unit:unit_data().has_alarm_pager then
 		managers.enemy:register_intimidated_guard(data.unit, data.t)
+		LuaNetworking:SendToPeers("sync_intimidated_guard_data",data.unit:id(), tostring(data.t))
 		data.unit:interaction():set_tweak_data("intimidated_guard_checkin")
 		data.unit:interaction():set_active(true, true, false)
 	end
@@ -70,8 +71,9 @@ function CopLogicIntimidated._do_tied(data, aggressor_unit)
 	managers.groupai:state():on_criminal_suspicion_progress(nil, data.unit, nil)
 end
 
-Hooks.PostHook(CopLogicIntimidated, "on_enemy_weapons_hot", "res_on_enemy_weapons_hot", function(data)
-	managers.enemy:unregister_intimidated_guard(data.unit)
+Hooks:PostHook(CopLogicIntimidated, "on_enemy_weapons_hot", "res_on_enemy_weapons_hot", function(data)
+	managers.enemy:unregister_intimidated_guard(data.unit:id())
+	LuaNetworking:SendToPeers("sync_intimidated_guard_data_delete",data.unit:id())
 end)
 
 -- Tweak hostage rescue conditions

--- a/lua/sc/units/interactions/interactionext.lua
+++ b/lua/sc/units/interactions/interactionext.lua
@@ -495,7 +495,7 @@ end
 function IntimitateInteractionExt:_add_string_macros(macros)
 	IntimitateInteractionExt.super._add_string_macros(self, macros)
 	if self.tweak_data == "intimidated_guard_checkin" then
-		local data = managers.enemy:all_intimidated_guards()[self._unit:key()]
+		local data = managers.enemy:all_intimidated_guards()[self._unit:id()]
 		macros.CHECKIN_TIME = "0"
 		macros.SUSP_IN = "0.0%"
 

--- a/restorationmod_network_tweak.xml
+++ b/restorationmod_network_tweak.xml
@@ -94,16 +94,6 @@
 		<search>
 			<network/>
 			<rpc/>
-			<message name="sync_remove_carry_stacker"/>
-		</search>
-		<target mode="attributes">
-			<attr name="delivery" value="ordered"/>
-		</target>
-	</tweak>
-	<tweak name="settings/network" extension="network_settings">
-		<search>
-			<network/>
-			<rpc/>
 			<message name="damage_tase"/>
 					<param type="int" min="0" max="1" />
 		</search>
@@ -119,6 +109,15 @@
 		</search>
 		<target mode="attach">
 			<param type="float" min="0" max="63" step="0.1" exact="false"/>
+		</target>
+	</tweak>
+	<tweak version="2" name="settings/network" extension="network_settings">
+		<search>
+			<network/>
+			<rpc/>
+		</search>
+		<target mode="attach">
+			<message name="sync_remove_carry_stacker"/>
 		</target>
 	</tweak>
 	<tweak version="2" name="settings/network" extension="network_settings">


### PR DESCRIPTION
This PR actually finishes what I started with the [guard check-in PR](https://github.com/payday-restoration/restoration-mod/pull/708), by synchronising the check-in data to the other peers.

That's about it.