### PR TITLE
Fix Leech's HP regen

### DIFF
--- a/lua/sc/managers/playermanager.lua
+++ b/lua/sc/managers/playermanager.lua
@@ -465,7 +465,7 @@ function PlayerManager:on_killshot(killed_unit, variant, headshot, weapon_id)
 				local health_regen = wanted_health - current_health
 
 				if health_regen > 0 then
-					damage_ext:restore_health(health_regen)
+					damage_ext:restore_health(health_regen, true)
 					damage_ext:on_copr_killshot()
 				end
 			end


### PR DESCRIPTION
`PlayerDamage:restore_health()`'s second parameter defines if a HP regen should be static or not.

We'll figure the graphical problem out later.