### PR TITLE
Make Dig In Your Heels respect Berserker heal block

### DIFF
--- a/lua/sc/managers/playermanager.lua
+++ b/lua/sc/managers/playermanager.lua
@@ -2429,7 +2429,7 @@ function PlayerManager:update_cohesion_stacks(t, dt)
 	local affected_players = {}
 
 	-- biker users get to update their "suggested" tendency.
-	if self:upgrade_value("player", "biker_emit_aura", 0) ~= 0 then
+	if self:has_category_upgrade("player","biker_emit_aura") then
 		local heisters_affected = 0
 		local converts_affected = 0
 		affected_players, heisters_affected, converts_affected = self:get_biker_aura_affected(player_unit:position())

--- a/lua/sc/tweak_data/skilltreetweakdata.lua
+++ b/lua/sc/tweak_data/skilltreetweakdata.lua
@@ -3453,7 +3453,8 @@ function SkillTreeTweakData:init(tweak_data)
 			icon_atlas = "icons_atlas",
 			upgrades = {
 				"team_biker_damage_to_lose_2",
-				"team_biker_regen_health"
+				"team_biker_regen_health",
+				"player_biker_causer_of_regen"
 			},
 			texture_bundle_folder = "wild",
 			icon_xy = {

--- a/lua/sc/tweak_data/upgradestweakdata.lua
+++ b/lua/sc/tweak_data/upgradestweakdata.lua
@@ -2843,6 +2843,11 @@ Hooks:PostHook(UpgradesTweakData, "_init_pd2_values", "ResSkillsInit", function(
 		}
 	}
 
+	-- Literally only exists to determine who should the Dig in Your Heels regeneration affect when someone has Berserker.
+	self.values.player.biker_causer_of_regen = {
+		true
+	}
+
 	-- How much faster should armour be regenerated based on stacks, in percentages.
 	self.values.team.player.biker_armour_regen_bonus = {
 		0.02
@@ -6322,6 +6327,17 @@ function UpgradesTweakData:_player_definitions()
 		upgrade = {
 			value = 1,
 			upgrade = "biker_personal_kill_stack_reward",
+			category = "player"
+		}
+	}
+
+    -- Signifies the current player as the one who is (one of) the source(s) of Dig In Your Heels regen.
+    self.definitions.player_biker_causer_of_regen = {
+		name_id = "menu_player_biker_causer_of_regen",
+		category = "feature",
+		upgrade = {
+			value = 1,
+			upgrade = "biker_causer_of_regen",
 			category = "player"
 		}
 	}

--- a/lua/sc/units/player/playerdamage.lua
+++ b/lua/sc/units/player/playerdamage.lua
@@ -1862,8 +1862,8 @@ function PlayerDamage:_upd_health_regen(t, dt)
 		if self._biker_regen_t <= t then
 			self._biker_regen_t = t + biker_diyh_timer
 			local cohesion_steps = managers.player:get_cohesion_stacks_as_treated()
-			local heal =(managers.player:team_upgrade_value("player", "biker_regen_health").amount or 0) * cohesion_steps
-			self:restore_health(heal, true)
+			local heal = (managers.player:team_upgrade_value("player", "biker_regen_health").amount or 0) * cohesion_steps
+			self:restore_health(heal, true, not managers.player:has_category_upgrade("player","biker_causer_of_regen"))
 			managers.hud:start_cooldown("dig_in_your_heels", biker_diyh_timer)
 		end
 	end


### PR DESCRIPTION
Is there a way to check from whom a team upgrade came from?   
I don't quite like this solution. It works, I just don't like it.