### PR TITLE
JoaT now grants more ordnance bags, boosts them too

### DIFF
--- a/lua/sc/loc/loc.lua
+++ b/lua/sc/loc/loc.lua
@@ -5921,7 +5921,7 @@ Hooks:Add("LocalizationManagerPostInit", "SC_Localization_Skills_Eng", function(
 
 				--Jack of all Trades
 				["menu_jack_of_all_trades_beta_sc"] = "Jack of All Trades",
-				["menu_jack_of_all_trades_beta_desc_sc"] = "BASIC: #{owned}#$basic##\nTEMP-SPACE\n\nACE: #{owned}#$pro##\n#{skill_color}#You can now equip a second deployable to bring with you.## Pressing #{skill_color}#$BTN_CHANGE_EQ## will allow you to toggle between deployables.\n\nYou carry #{important_1}#50%## the normal amount of your second deployable, to a minimum of #{skill_color}#1.##",
+				["menu_jack_of_all_trades_beta_desc_sc"] = "BASIC: #{owned}#$basic##\nEach ordnance bag now contains #{skill_color}#$skill_value_b1## ammunition for your weapons.\n\nACE: #{owned}#$pro##\nYou can now place #{skill_color}#$skill_value_p1## ordnance bags instead of just one.\n\n#{skill_color}#You can now equip a second deployable to bring with you.## Pressing #{skill_color}#$BTN_CHANGE_EQ## will allow you to toggle between deployables.\n\nYou carry #{important_1}#50%## the normal amount of your second deployable, to a minimum of #{skill_color}#1.##",
 
 				--Sentry Tower Defense--
 				["menu_tower_defense_beta_sc"] = "Tower Defense",

--- a/lua/sc/tweak_data/skilltreetweakdata.lua
+++ b/lua/sc/tweak_data/skilltreetweakdata.lua
@@ -916,13 +916,14 @@ function SkillTreeTweakData:init(tweak_data)
 					["icon_xy"] = {9, 4},
 					[1] = {
 						upgrades = {
-							--TEMP
+							"grenade_crate_ammo_increase1"
 						},
 						cost = self.costs.hightier
 					},
 					[2] = {
 						upgrades = {
-							"second_deployable_1"
+							"second_deployable_1",
+							"grenade_crate_quantity"
 						},
 						cost = self.costs.hightierpro
 					}

--- a/lua/sc/tweak_data/upgradestweakdata.lua
+++ b/lua/sc/tweak_data/upgradestweakdata.lua
@@ -368,6 +368,42 @@ Hooks:PostHook(UpgradesTweakData, "init", "ResLevelTableInit", function(self, tw
 	self:_money_weapon_definitions()
 end)
 
+-- Ordnance bag definitions
+function UpgradesTweakData:_grenade_crate_definitions()
+
+	self.definitions.grenade_crate = {
+		equipment_id = "grenade_crate",
+		slot = 1,
+		dlc = "mxm",
+		category = "equipment",
+		name_id = "menu_equipment_grenade_crate"
+	}
+
+	-- I've taken this from the ammo_bag_definitions, and I'm gonna be honest, I've no idea why that one
+	-- has so much shit in it. Definitions typically just have name_id and category.
+	for i, _ in ipairs(self.values.grenade_crate.ammo_increase) do
+		self.definitions["grenade_crate_ammo_increase" .. i] = {
+			name_id = "grenade_crate_ammo_increase" .. i,
+			category = "equipment_upgrade",
+			upgrade = {
+				upgrade = "ammo_increase",
+				category = "grenade_crate",
+				value = i
+			}
+		}
+	end
+
+	self.definitions.grenade_crate_quantity = {
+		name_id = "menu_grenade_crate_quantity",
+		category = "equipment_upgrade",
+		upgrade = {
+			value = 1,
+			upgrade = "quantity",
+			category = "grenade_crate"
+		}
+	}
+end
+
 --Money thrower definitions
 function UpgradesTweakData:_money_weapon_definitions()
 	self.definitions.money = {
@@ -632,6 +668,10 @@ Hooks:PostHook(UpgradesTweakData, "_init_pd2_values", "ResSkillsInit", function(
 		1.3,
 		1.2
 	}
+
+	-- Ordnance bag
+	self.ordnance_bag_ammo = 0.25
+	self.ordnance_bag_grenades = 4
 	
 	self.values.player.corpse_dispose_amount = {2, 3}
 	self.values.bodybags_bag.quantity = {1}
@@ -1210,12 +1250,15 @@ Hooks:PostHook(UpgradesTweakData, "_init_pd2_values", "ResSkillsInit", function(
 		
 			--Jack of All Trades
 				--Basic
-
+					self.values.grenade_crate = self.values.grenade_crate or {}
+					self.values.grenade_crate.ammo_increase = {2}
 				--Ace
+					self.values.grenade_crate.quantity = {1}
 					self.values.player.second_deployable = {true}
 					
 					self.skill_descs.engineering = {
-						skill_value_b1 = tostring(self.values.player.throwables_multiplier[1] % 1 * 100).."%" -- more throwables
+						skill_value_b1 = tostring(self.values.grenade_crate.ammo_increase[1] * self.ordnance_bag_ammo * 100).."%", -- More ammo for weapons
+						skill_value_p1 = tostring(self.values.grenade_crate.quantity[1] + 1) -- Quantity of ammo bags
 					}
 	
 			--Tower Defense

--- a/lua/sc/units/equipment/grenadecratebase.lua
+++ b/lua/sc/units/equipment/grenadecratebase.lua
@@ -28,7 +28,8 @@ end
 
 --Overkill Grenade Case
 function GrenadeCrateDeployableBase:setup()
-	self._max_grenade_amount = 4
+	self._max_grenade_amount = tweak_data.upgrades.ordnance_bag_grenades
+	self._ammo_amount = tweak_data.upgrades.ordnance_bag_ammo * managers.player:upgrade_value("grenade_crate", "ammo_increase", 1)
 	
 	GrenadeCrateDeployableBase.super.setup(self)
 end
@@ -49,7 +50,7 @@ function GrenadeCrateDeployableBase:take_grenade(unit)
 	--So you take some ammo back too
 	if inventory then
 		for id, weapon in pairs(inventory:available_selections()) do
-			local took = self:round_value(weapon.unit:base():add_ammo_from_bag(0.25))
+			local took = self:round_value(weapon.unit:base():add_ammo_from_bag(self._ammo_amount))
 			managers.hud:set_ammo_amount(id, weapon.unit:base():ammo_info())
 		end
 	end


### PR DESCRIPTION
This PR changes Jack of All Trades to match the typical skills that boost deployables, with Basic now making Ordnance Bags grant 50% ammo to weapons on use instead of 25%, and Aced allowing a second Ordnance Bag to be deployed.

JoaT Aced still keeps the feature where it allows a secondary deployable.