### PR TITLE
Tangerine's Guns Stuff

### DIFF
--- a/lua/sc/tweak_data/weaponfactorytweakdata.lua
+++ b/lua/sc/tweak_data/weaponfactorytweakdata.lua
@@ -42493,7 +42493,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 				self.parts.wpn_fps_ass_galil_body_intermediate.custom_stats = {
 					alt_desc = "bm_galil_556_sc_desc",
 					ads_speed_mult = 0.842105,
-					damage_min_mult = 0.625,
+					damage_min_mult = 0.75,
 					falloff_start_mult = 0.72,
 					armor_piercing_override = 0,
 					armor_piercing_add_override = 0,
@@ -42625,7 +42625,7 @@ Hooks:PostHook( WeaponFactoryTweakData, "create_bonuses", "SC_mods", function(se
 					trail_effect = "effects/particles/weapons/weapon_trail",
 					falloff_start_mult = 1.06667,
 					falloff_end_mult = 1.1206896,
-					damage_min_mult = 0.8,
+					damage_min_mult = 0.853333,
 					ammo_pickup_max_mul = 0.43243,
 					ammo_pickup_min_mul = 0.43243,
 					alt_ammo_pickup_max_mul = 0.43243,

--- a/lua/sc/tweak_data/weapontweakdata.lua
+++ b/lua/sc/tweak_data/weapontweakdata.lua
@@ -31152,6 +31152,46 @@ Hooks:PostHook( WeaponTweakData, "init", "SC_weapons", function(self)
 					self.x_polar9.panic_suppression_chance = 0.05
 					self.x_polar9.timers = deep_clone(self.x_b92fs.timers)
 
+				--Primary
+				self.polar9_primary.recategorize = { "light_pis" }
+				self.polar9_primary.damage_type = "pistol"
+				self.polar9_primary.fire_mode_data.fire_rate =  0.0882352
+				self.polar9_primary.AMMO_MAX = 150
+				self.polar9_primary.CLIP_AMMO_MAX = 17
+				self.polar9_primary.tactical_reload = 1
+				self.polar9_primary.lock_slide = true
+				self.polar9_primary.kick = self.stat_info.kick_tables.even_recoil
+				self.polar9_primary.kick_pattern = {
+					{0, self.stat_info.kick_tables.moderate_kick},
+					{3, self.stat_info.kick_tables.right_kick},
+					{8, self.stat_info.kick_tables.moderate_left_kick},
+					{14, self.stat_info.kick_tables.even_recoil}
+				}
+				self.polar9_primary.supported = true
+				self.polar9_primary.ads_speed = 0.140
+				self.polar9_primary.damage_falloff = {
+					start_dist = 1500,
+					end_dist = 2700,
+					min_mult = 0.25
+				}
+				self.polar9_primary.stats = {
+					damage = 24,
+					spread = 61,
+					recoil = 79,
+					spread_moving = 9,
+					zoom = 1,
+					concealment = 30,
+					suppression = 12,
+					alert_size = 2,
+					extra_ammo = 101,
+					total_ammo_mod = 400,
+					value = 1,
+					reload = 25
+				}
+				self.polar9_primary.stats_modifiers = nil
+				self.polar9_primary.panic_suppression_chance = 0.05
+				self.polar9_primary.timers = deep_clone(self.colt_1911.timers)
+
 				self.baller.desc_id = "bm_baller_sc_desc"
 				self.baller.recategorize = { "heavy_pis" }
 				self.baller.damage_type = "heavy_pistol"


### PR DESCRIPTION
- Corrected the minimum damage values for the 6.5 AK and 5.56 Galil kits.
- Added support for the primary version of the Polar 9mm (same stats as secondary except for ammo).